### PR TITLE
fix: replace Function type with explicit callback signature

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,6 @@
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.2",
     "vitest": "^4.1.4"
-  }
+  },
+  "type": "module"
 }

--- a/test/unit/azure-keyvault-backend.test.ts
+++ b/test/unit/azure-keyvault-backend.test.ts
@@ -17,7 +17,7 @@ function mockExecFileSequence(responses: Array<{ stdout?: string; error?: Error 
   const mock = vi.mocked(execFile);
   let callIndex = 0;
   mock.mockImplementation(
-    (_cmd: unknown, _args: unknown, _opts: unknown, callback?: Function) => {
+    (_cmd: unknown, _args: unknown, _opts: unknown, callback?: (err: Error | null, stdout: string, stderr: string) => void) => {
       const response = responses[callIndex] ?? responses[responses.length - 1];
       callIndex++;
       const cb = typeof _opts === "function" ? _opts : callback;

--- a/test/unit/bitwarden-backend.test.ts
+++ b/test/unit/bitwarden-backend.test.ts
@@ -17,7 +17,7 @@ import { resolveCliPath } from "../../src/utils/cli-resolver.js";
 function mockExecFile(stdout: string) {
   const mock = vi.mocked(execFile);
   mock.mockImplementation(
-    (_cmd: unknown, _args: unknown, _opts: unknown, callback?: Function) => {
+    (_cmd: unknown, _args: unknown, _opts: unknown, callback?: (err: Error | null, stdout: string, stderr: string) => void) => {
       if (typeof _opts === "function") {
         // callback in 3rd position (no opts)
         _opts(null, stdout, "");
@@ -32,7 +32,7 @@ function mockExecFile(stdout: string) {
 function mockExecFileError(message: string) {
   const mock = vi.mocked(execFile);
   mock.mockImplementation(
-    (_cmd: unknown, _args: unknown, _opts: unknown, callback?: Function) => {
+    (_cmd: unknown, _args: unknown, _opts: unknown, callback?: (err: Error | null, stdout: string, stderr: string) => void) => {
       const err = new Error(message);
       if (typeof _opts === "function") {
         _opts(err, "", "");


### PR DESCRIPTION
## Problem
CI failing with 3 ESLint errors:
```
error: The 'Function' type accepts any function-like value.
Prefer explicitly defining any function parameters and return type
@typescript-eslint/no-unsafe-function-type
```

**Files:**
- `test/unit/bitwarden-backend.test.ts` (lines 20, 35)
- `test/unit/azure-keyvault-backend.test.ts` (line 20)

## Fix
Replace `callback?: Function` with explicit type:
```ts
callback?: (err: Error | null, stdout: string, stderr: string) => void
```

Also adds `"type": "module"` to `package.json` to eliminate the eslint.config.js module type warning:
> Module type of file is not specified and it doesn't parse as CommonJS.

## Closes
Resolves CI failure on dependabot PR #7