### PR TITLE
feat: add Trusted Publishing workflow for npm and GitHub Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,59 @@
+name: Publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-npm:
+    name: Publish to npm (Trusted Publishing)
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write  # Required for OIDC / Trusted Publishing
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm with provenance
+        run: npm publish --access public --provenance
+        # No NODE_AUTH_TOKEN needed — OIDC handles authentication
+
+  publish-gpr:
+    name: Publish to GitHub Packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write  # Required for GitHub Packages
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@ebmarquez'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to GitHub Packages
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -58,5 +58,9 @@
     "typescript-eslint": "^8.58.2",
     "vitest": "^4.1.4"
   },
-  "type": "module"
+  "type": "module",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
 }


### PR DESCRIPTION
## What this adds
Automated publishing to both registries on every GitHub Release:
- **npmjs.com** via OIDC Trusted Publishing (no token stored anywhere)
- **GitHub Packages** via built-in GITHUB_TOKEN

## How it works
```
git tag v0.1.0 && git push --tags
→ Create GitHub Release from tag
→ publish.yml triggers
→ npm: OIDC authenticates with Trusted Publisher config on npm.com
→ GitHub Packages: GITHUB_TOKEN authenticates automatically
```

## Required manual step (one-time)
Before publishing works, set up Trusted Publisher on npm:
1. Go to https://www.npmjs.com/settings/ebmarquez/packages
2. Find `ai-ssh-toolkit` → Publishing → Trusted Publishers  
3. Add GitHub publisher:
   - Repository: `ebmarquez/ai-ssh-toolkit`
   - Workflow: `publish.yml`

No secrets needed — no NPM_TOKEN required.

## Closes
Closes #13, Closes #8