### PR TITLE
feat: add one-time bootstrap publish workflow

### DIFF
--- a/.github/workflows/bootstrap-publish.yml
+++ b/.github/workflows/bootstrap-publish.yml
@@ -1,0 +1,66 @@
+name: Bootstrap Publish (One-Time)
+
+# This workflow is for the FIRST publish only.
+# After the package exists on npm, configure Trusted Publishing and
+# use the standard publish.yml workflow for all future releases.
+# Delete or disable this workflow after the first successful publish.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (must match package.json)'
+        required: true
+        default: '0.1.0'
+      confirm:
+        description: 'Type "publish" to confirm'
+        required: true
+
+jobs:
+  bootstrap:
+    name: Bootstrap First Publish to npm
+    runs-on: ubuntu-latest
+    if: github.event.inputs.confirm == 'publish'
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Verify version matches input
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          echo "Package version: $PKG_VERSION"
+          echo "Input version: ${{ github.event.inputs.version }}"
+          if [ "$PKG_VERSION" != "${{ github.event.inputs.version }}" ]; then
+            echo "Version mismatch! Aborting."
+            exit 1
+          fi
+
+      - name: Publish to npm (bootstrap - uses token)
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Done - Next Steps
+        run: |
+          echo "✅ Package published to npm as ai-ssh-toolkit@${{ github.event.inputs.version }}"
+          echo ""
+          echo "Next steps:"
+          echo "1. Go to https://www.npmjs.com/settings/ebmarquez/packages"
+          echo "2. Find ai-ssh-toolkit → Publishing → Trusted Publishers"
+          echo "3. Add GitHub publisher: ebmarquez/ai-ssh-toolkit, workflow: publish.yml"
+          echo "4. Remove NPM_TOKEN from GitHub Secrets"
+          echo "5. Disable or delete this workflow"
+          echo "6. Use publish.yml (triggered by GitHub Release) for all future publishes"


### PR DESCRIPTION
## Purpose
One-time manual workflow to do the initial npm publish that creates the package.

## Why needed
npm Trusted Publishing requires the package to already exist. This workflow uses NPM_TOKEN to bootstrap the first publish, after which Trusted Publishing takes over.

## How to use
1. Add `NPM_TOKEN` secret to repo (Settings → Secrets → Actions)
2. Go to Actions → Bootstrap Publish → Run workflow
3. Enter version: `0.1.0`, confirm: `publish`
4. After success: configure Trusted Publisher on npm.com
5. Remove `NPM_TOKEN` secret
6. Disable this workflow

## After this PR is merged, do once:
- Add the NPM_TOKEN secret
- Run the workflow
- Switch to Trusted Publishing
- All future releases use `publish.yml` automatically

Closes #8