### PR TITLE
fix: scope package name for GitHub Packages publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,15 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Add scoped name for GitHub Packages
+        run: |
+          # GitHub Packages requires a scoped name (@owner/package)
+          node -e "
+            const pkg = require('./package.json');
+            pkg.name = '@ebmarquez/ai-ssh-toolkit';
+            require('fs').writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
       - name: Publish to GitHub Packages
         run: npm publish --access public
         env:


### PR DESCRIPTION
GitHub Packages requires a scoped name (`@owner/package`). The GPR publish job was attempting to publish the unscoped name to the GitHub registry, which failed with ENEEDAUTH.

## Fix
- Dynamically rename to `@ebmarquez/ai-ssh-toolkit` in the GPR job only
- npm publish remains unscoped (`ai-ssh-toolkit`)
- Users can install from either:
  - `npm install ai-ssh-toolkit` (npmjs.com)
  - `npm install @ebmarquez/ai-ssh-toolkit --registry https://npm.pkg.github.com` (GitHub Packages)