### PR TITLE
feat: add ssh_multi_execute for parallel multi-host SSH execution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,86 @@
 #!/usr/bin/env node
-// TODO: MCP server entry point — stdio transport
-// See: docs/plans/2026-04-14-ai-ssh-toolkit-design.md
+/**
+ * ai-ssh-toolkit MCP server — stdio transport
+ *
+ * Registered tools:
+ *  - ssh_multi_execute  (parallel multi-host SSH execution)
+ *  - credential_list    (list available credential backends)
+ *  - credential_get     (retrieve credential metadata)
+ *  - ssh_check          (verify SSH reachability)
+ */
 
-export {};
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+import { CredentialRegistry } from "./credentials/registry.js";
+import { EnvCredentialBackend } from "./credentials/env.js";
+import {
+  sshMultiExecute,
+  SSH_MULTI_EXECUTE_TOOL,
+  SshMultiExecuteInput,
+} from "./tools/ssh-multi-execute.js";
+
+// ---------------------------------------------------------------------------
+// Bootstrap credential registry
+// ---------------------------------------------------------------------------
+
+const registry = new CredentialRegistry();
+registry.register(new EnvCredentialBackend());
+// Additional backends (bitwarden, azure-keyvault) registered if available:
+try {
+  const { BitwardenBackend: BitwardenCredentialBackend } = await import(
+    "./credentials/bitwarden.js"
+  );
+  registry.register(new BitwardenCredentialBackend());
+} catch {
+  /* optional dep */
+}
+try {
+  const { AzureKeyVaultBackend } = await import(
+    "./credentials/azure-keyvault.js"
+  );
+  registry.register(new AzureKeyVaultBackend());
+} catch {
+  /* optional dep */
+}
+
+await registry.discoverAvailability();
+
+// ---------------------------------------------------------------------------
+// MCP Server
+// ---------------------------------------------------------------------------
+
+const server = new Server(
+  { name: "ai-ssh-toolkit", version: "0.1.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [SSH_MULTI_EXECUTE_TOOL],
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  if (name === "ssh_multi_execute") {
+    const input = args as unknown as SshMultiExecuteInput;
+    const result = await sshMultiExecute(input, registry);
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(result, null, 2),
+        },
+      ],
+    };
+  }
+
+  throw new Error(`Unknown tool: ${name}`);
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/src/tools/ssh-multi-execute.ts
+++ b/src/tools/ssh-multi-execute.ts
@@ -1,4 +1,5 @@
 import { PlatformHint, detectPrompt, detectPasswordPrompt } from "../ssh/prompt-detector.js";
+import { scrubOutput } from "../ssh/output-scrubber.js";
 import { CredentialRegistry } from "../credentials/registry.js";
 
 export interface SshMultiExecuteInput {
@@ -38,11 +39,30 @@ export async function executeSingleHost(
   input: SshMultiExecuteInput,
   registry?: CredentialRegistry,
 ): Promise<HostResult> {
+  // Validate credential params upfront
+  if ((input.credential_backend && !input.credential_ref) ||
+      (!input.credential_backend && input.credential_ref)) {
+    return {
+      host,
+      success: false,
+      error: 'credential_backend and credential_ref must both be provided together',
+      duration_ms: 0,
+    };
+  }
+  if (input.credential_backend && !registry) {
+    return {
+      host,
+      success: false,
+      error: 'credential_backend requested but no registry available',
+      duration_ms: 0,
+    };
+  }
+
   const start = Date.now();
 
+  let password: Buffer | undefined;
   try {
     // Resolve credentials if a backend is configured
-    let password: Buffer | undefined;
     let username = input.username;
 
     if (input.credential_backend && input.credential_ref && registry) {
@@ -54,7 +74,7 @@ export async function executeSingleHost(
       password = cred.password;
     }
 
-    const output = await runSshCommands({
+    const rawOutput = await runSshCommands({
       host,
       port: input.port ?? 22,
       username,
@@ -64,8 +84,7 @@ export async function executeSingleHost(
       timeoutMs: (input.timeout_per_host ?? 30) * 1000,
     });
 
-    // Zero-fill password buffer after use
-    if (password) password.fill(0);
+    const output = scrubOutput(rawOutput);
 
     return {
       host,
@@ -80,6 +99,9 @@ export async function executeSingleHost(
       error: err instanceof Error ? err.message : String(err),
       duration_ms: Date.now() - start,
     };
+  } finally {
+    // Always zero-fill password buffer — success or failure
+    if (password) password.fill(0);
   }
 }
 
@@ -92,7 +114,10 @@ export async function sshMultiExecute(
   executor: typeof executeSingleHost = executeSingleHost,
 ): Promise<SshMultiExecuteOutput> {
   const wallStart = Date.now();
-  const maxParallel = input.max_parallel ?? 10;
+  const maxParallel = Math.max(1, Math.floor(input.max_parallel ?? 10));
+  if (!Number.isFinite(maxParallel)) {
+    throw new Error('max_parallel must be a finite positive integer');
+  }
   const hosts = input.hosts;
 
   // True concurrency limiter: slots fill as hosts complete, not in fixed batches.
@@ -253,7 +278,7 @@ export const SSH_MULTI_EXECUTE_TOOL = {
         type: "array",
         items: { type: "string" },
         description: "List of hostnames or IP addresses",
-        minItems: 1,
+        minItems: 0,
       },
       username: {
         type: "string",

--- a/src/tools/ssh-multi-execute.ts
+++ b/src/tools/ssh-multi-execute.ts
@@ -223,7 +223,7 @@ async function runSshCommands(opts: RunSshOptions): Promise<string> {
     const allCommands = [...commands, "exit"];
 
     const timer = setTimeout(() => {
-      reject(new Error(`Timeout after ${timeoutMs}ms connecting to ${host}`));
+      reject(new Error(`Timeout after ${timeoutMs}ms during SSH session execution on ${host}`));
       proc.kill();
     }, timeoutMs);
 

--- a/src/tools/ssh-multi-execute.ts
+++ b/src/tools/ssh-multi-execute.ts
@@ -95,31 +95,49 @@ export async function sshMultiExecute(
   const maxParallel = input.max_parallel ?? 10;
   const hosts = input.hosts;
 
-  const results: HostResult[] = [];
+  // True concurrency limiter: slots fill as hosts complete, not in fixed batches.
+  // This prevents slow hosts from blocking idle slots.
+  let activeSlots = 0;
+  const results: HostResult[] = new Array(hosts.length);
+  const queue = hosts.map((host, idx) => ({ host, idx }));
+  let queuePos = 0;
 
-  // Process in batches of max_parallel
-  for (let i = 0; i < hosts.length; i += maxParallel) {
-    const batch = hosts.slice(i, i + maxParallel);
-    const settled = await Promise.allSettled(
-      batch.map((host) => executor(host, input, registry)),
-    );
-
-    for (const outcome of settled) {
-      if (outcome.status === "fulfilled") {
-        results.push(outcome.value);
-      } else {
-        // Unexpected — executeSingleHost catches internally, but handle defensively
-        results.push({
-          host: "unknown",
-          success: false,
-          error: outcome.reason instanceof Error
-            ? outcome.reason.message
-            : String(outcome.reason),
-          duration_ms: 0,
-        });
-      }
+  await new Promise<void>((resolveAll) => {
+    if (hosts.length === 0) {
+      resolveAll();
+      return;
     }
-  }
+
+    let completed = 0;
+
+    const runNext = () => {
+      while (activeSlots < maxParallel && queuePos < queue.length) {
+        const { host, idx } = queue[queuePos++];
+        activeSlots++;
+
+        executor(host, input, registry)
+          .catch((err): HostResult => ({
+            // Capture host in closure so rejection fallback has the right name
+            host,
+            success: false,
+            error: err instanceof Error ? err.message : String(err),
+            duration_ms: 0,
+          }))
+          .then((result) => {
+            results[idx] = result;
+            activeSlots--;
+            completed++;
+            if (completed === hosts.length) {
+              resolveAll();
+            } else {
+              runNext();
+            }
+          });
+      }
+    };
+
+    runNext();
+  });
 
   const successful = results.filter((r) => r.success).length;
 
@@ -158,7 +176,9 @@ async function runSshCommands(opts: RunSshOptions): Promise<string> {
 
   return new Promise<string>((resolve, reject) => {
     const sshArgs = [
-      "-o", "StrictHostKeyChecking=no",
+      // NOTE: StrictHostKeyChecking is intentionally NOT disabled here.
+      // Hosts must be in the user's ~/.ssh/known_hosts.
+      // For lab/testing: run `ssh-keyscan <host> >> ~/.ssh/known_hosts` first.
       "-o", "BatchMode=no",
       "-o", `ConnectTimeout=${Math.ceil(timeoutMs / 1000)}`,
       "-p", String(port),

--- a/src/tools/ssh-multi-execute.ts
+++ b/src/tools/ssh-multi-execute.ts
@@ -1,0 +1,281 @@
+import { PlatformHint, detectPrompt, detectPasswordPrompt } from "../ssh/prompt-detector.js";
+import { CredentialRegistry } from "../credentials/registry.js";
+
+export interface SshMultiExecuteInput {
+  hosts: string[];
+  username: string;
+  commands: string[];
+  credential_backend?: string;
+  credential_ref?: string;
+  platform_hint?: PlatformHint;
+  port?: number;
+  max_parallel?: number;
+  timeout_per_host?: number;
+}
+
+export interface HostResult {
+  host: string;
+  success: boolean;
+  output?: string;
+  error?: string;
+  duration_ms: number;
+}
+
+export interface SshMultiExecuteOutput {
+  results: HostResult[];
+  total_hosts: number;
+  successful: number;
+  failed: number;
+  duration_ms: number;
+}
+
+/**
+ * Execute SSH commands on a single host, returning a HostResult.
+ * Exported for testing / reuse.
+ */
+export async function executeSingleHost(
+  host: string,
+  input: SshMultiExecuteInput,
+  registry?: CredentialRegistry,
+): Promise<HostResult> {
+  const start = Date.now();
+
+  try {
+    // Resolve credentials if a backend is configured
+    let password: Buffer | undefined;
+    let username = input.username;
+
+    if (input.credential_backend && input.credential_ref && registry) {
+      const cred = await registry.getCredential(
+        input.credential_backend,
+        input.credential_ref,
+      );
+      username = cred.username;
+      password = cred.password;
+    }
+
+    const output = await runSshCommands({
+      host,
+      port: input.port ?? 22,
+      username,
+      password,
+      commands: input.commands,
+      platformHint: input.platform_hint ?? "auto",
+      timeoutMs: (input.timeout_per_host ?? 30) * 1000,
+    });
+
+    // Zero-fill password buffer after use
+    if (password) password.fill(0);
+
+    return {
+      host,
+      success: true,
+      output,
+      duration_ms: Date.now() - start,
+    };
+  } catch (err) {
+    return {
+      host,
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+      duration_ms: Date.now() - start,
+    };
+  }
+}
+
+/**
+ * Run commands on multiple hosts in parallel, respecting max_parallel.
+ */
+export async function sshMultiExecute(
+  input: SshMultiExecuteInput,
+  registry?: CredentialRegistry,
+  executor: typeof executeSingleHost = executeSingleHost,
+): Promise<SshMultiExecuteOutput> {
+  const wallStart = Date.now();
+  const maxParallel = input.max_parallel ?? 10;
+  const hosts = input.hosts;
+
+  const results: HostResult[] = [];
+
+  // Process in batches of max_parallel
+  for (let i = 0; i < hosts.length; i += maxParallel) {
+    const batch = hosts.slice(i, i + maxParallel);
+    const settled = await Promise.allSettled(
+      batch.map((host) => executor(host, input, registry)),
+    );
+
+    for (const outcome of settled) {
+      if (outcome.status === "fulfilled") {
+        results.push(outcome.value);
+      } else {
+        // Unexpected — executeSingleHost catches internally, but handle defensively
+        results.push({
+          host: "unknown",
+          success: false,
+          error: outcome.reason instanceof Error
+            ? outcome.reason.message
+            : String(outcome.reason),
+          duration_ms: 0,
+        });
+      }
+    }
+  }
+
+  const successful = results.filter((r) => r.success).length;
+
+  return {
+    results,
+    total_hosts: hosts.length,
+    successful,
+    failed: hosts.length - successful,
+    duration_ms: Date.now() - wallStart,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal SSH execution using node-pty
+// ---------------------------------------------------------------------------
+
+interface RunSshOptions {
+  host: string;
+  port: number;
+  username: string;
+  password?: Buffer;
+  commands: string[];
+  platformHint: PlatformHint;
+  timeoutMs: number;
+}
+
+/**
+ * Low-level SSH runner using node-pty.
+ * Throws on connection failure or timeout.
+ */
+async function runSshCommands(opts: RunSshOptions): Promise<string> {
+  // Dynamic import to allow mocking in tests
+  const { default: pty } = await import("node-pty");
+
+  const { host, port, username, password, commands, platformHint, timeoutMs } = opts;
+
+  return new Promise<string>((resolve, reject) => {
+    const sshArgs = [
+      "-o", "StrictHostKeyChecking=no",
+      "-o", "BatchMode=no",
+      "-o", `ConnectTimeout=${Math.ceil(timeoutMs / 1000)}`,
+      "-p", String(port),
+      `${username}@${host}`,
+    ];
+
+    const proc = pty.spawn("ssh", sshArgs, {
+      name: "xterm-color",
+      cols: 220,
+      rows: 40,
+      env: process.env as Record<string, string>,
+    });
+
+    let outputBuf = "";
+    let authenticated = false;
+    let cmdIndex = 0;
+    const allCommands = [...commands, "exit"];
+
+    const timer = setTimeout(() => {
+      reject(new Error(`Timeout after ${timeoutMs}ms connecting to ${host}`));
+      proc.kill();
+    }, timeoutMs);
+
+    proc.onData((data: string) => {
+      outputBuf += data;
+
+      if (!authenticated && detectPasswordPrompt(outputBuf)) {
+        if (password) {
+          proc.write(password.toString("utf-8") + "\r");
+          authenticated = true;
+          outputBuf = "";
+        } else {
+          clearTimeout(timer);
+          proc.kill();
+          reject(new Error(`Password required for ${host} but none provided`));
+        }
+        return;
+      }
+
+      if (detectPrompt(outputBuf, platformHint)) {
+        if (cmdIndex < allCommands.length) {
+          proc.write(allCommands[cmdIndex++] + "\r");
+        }
+      }
+    });
+
+    proc.onExit(({ exitCode }) => {
+      clearTimeout(timer);
+      if (exitCode === 0 || exitCode === null) {
+        resolve(outputBuf.trim());
+      } else {
+        reject(new Error(`SSH exited with code ${exitCode} for ${host}`));
+      }
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// MCP tool definition (JSON Schema + handler)
+// ---------------------------------------------------------------------------
+
+export const SSH_MULTI_EXECUTE_TOOL = {
+  name: "ssh_multi_execute",
+  description:
+    "Execute SSH commands on multiple hosts in parallel. " +
+    "Returns per-host results; failed hosts do not stop others.",
+  inputSchema: {
+    type: "object",
+    required: ["hosts", "username", "commands"],
+    properties: {
+      hosts: {
+        type: "array",
+        items: { type: "string" },
+        description: "List of hostnames or IP addresses",
+        minItems: 1,
+      },
+      username: {
+        type: "string",
+        description: "SSH username",
+      },
+      commands: {
+        type: "array",
+        items: { type: "string" },
+        description: "Commands to run on each host",
+        minItems: 1,
+      },
+      credential_backend: {
+        type: "string",
+        enum: ["bitwarden", "azure-keyvault", "env"],
+        description: "Credential backend to use for authentication",
+      },
+      credential_ref: {
+        type: "string",
+        description: "Backend-specific credential reference",
+      },
+      platform_hint: {
+        type: "string",
+        enum: ["nxos", "os10", "sonic", "linux", "auto"],
+        description: "Target platform for prompt detection (default: auto)",
+      },
+      port: {
+        type: "number",
+        description: "SSH port (default: 22)",
+        default: 22,
+      },
+      max_parallel: {
+        type: "number",
+        description: "Maximum concurrent SSH connections (default: 10)",
+        default: 10,
+        minimum: 1,
+      },
+      timeout_per_host: {
+        type: "number",
+        description: "Per-host timeout in seconds (default: 30)",
+        default: 30,
+        minimum: 1,
+      },
+    },
+  },
+} as const;

--- a/test/unit/ssh-multi-execute.test.ts
+++ b/test/unit/ssh-multi-execute.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Unit tests for ssh-multi-execute.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { SshMultiExecuteInput } from "../../src/tools/ssh-multi-execute.js";
+
+vi.mock("node-pty", () => ({
+  default: { spawn: vi.fn() },
+}));
+
+import { sshMultiExecute, executeSingleHost } from "../../src/tools/ssh-multi-execute.js";
+
+function buildPtyMock(opts: {
+  outputLines?: string[];
+  exitCode?: number;
+  passwordPrompt?: boolean;
+}) {
+  const {
+    outputLines = ["user@host:~$ "],
+    exitCode = 0,
+    passwordPrompt = false,
+  } = opts;
+
+  let onExitCb: ((a: { exitCode: number | null }) => void) | null = null;
+  const written: string[] = [];
+
+  return {
+    written,
+    onData(cb: (d: string) => void) {
+      Promise.resolve().then(() => {
+        if (passwordPrompt) cb("Password: ");
+        for (const line of outputLines) cb(line);
+        onExitCb?.({ exitCode });
+      });
+    },
+    onExit(cb: (a: { exitCode: number | null }) => void) {
+      onExitCb = cb;
+    },
+    write(data: string) {
+      written.push(data);
+    },
+    kill: vi.fn(),
+  };
+}
+
+describe("executeSingleHost", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.resetAllMocks();
+  });
+
+  const baseInput: SshMultiExecuteInput = {
+    hosts: ["192.168.1.1"],
+    username: "admin",
+    commands: ["show version"],
+    platform_hint: "linux",
+    timeout_per_host: 10,
+  };
+
+  it("returns success when SSH exits cleanly", async () => {
+    const { default: pty } = await import("node-pty");
+    vi.mocked(pty.spawn).mockReturnValue(
+      buildPtyMock({ outputLines: ["NX-OS 10.0\r\nuser@host:~$ "] }) as unknown as ReturnType<typeof pty.spawn>,
+    );
+
+    const promise = executeSingleHost("192.168.1.1", baseInput);
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.host).toBe("192.168.1.1");
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("NX-OS 10.0");
+    expect(result.error).toBeUndefined();
+  });
+
+  it("returns failure when SSH exits with non-zero code", async () => {
+    const { default: pty } = await import("node-pty");
+    vi.mocked(pty.spawn).mockReturnValue(
+      buildPtyMock({ exitCode: 255, outputLines: [] }) as unknown as ReturnType<typeof pty.spawn>,
+    );
+
+    const promise = executeSingleHost("10.0.0.99", baseInput);
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.host).toBe("10.0.0.99");
+    expect(result.success).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  it("returns timeout failure when host does not respond", async () => {
+    const { default: pty } = await import("node-pty");
+    const mock = {
+      onData: vi.fn(),
+      onExit: vi.fn(),
+      write: vi.fn(),
+      kill: vi.fn(),
+    };
+    vi.mocked(pty.spawn).mockReturnValue(mock as unknown as ReturnType<typeof pty.spawn>);
+
+    const promise = executeSingleHost("10.0.0.1", {
+      ...baseInput,
+      timeout_per_host: 2,
+    });
+
+    await vi.advanceTimersByTimeAsync(2001);
+    const result = await promise;
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/[Tt]imeout/);
+    expect(mock.kill).toHaveBeenCalled();
+  });
+});
+
+describe("sshMultiExecute", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("returns results for all hosts", async () => {
+    const executor = vi.fn(async (host: string) => ({
+      host,
+      success: host !== "10.0.0.2",
+      output: host !== "10.0.0.2" ? `ok-${host}` : undefined,
+      error: host === "10.0.0.2" ? "connection refused" : undefined,
+      duration_ms: 1,
+    }));
+
+    const input: SshMultiExecuteInput = {
+      hosts: ["10.0.0.1", "10.0.0.2", "10.0.0.3"],
+      username: "admin",
+      commands: ["show version"],
+    };
+
+    const result = await sshMultiExecute(input, undefined, executor as typeof executeSingleHost);
+
+    expect(result.total_hosts).toBe(3);
+    expect(result.results).toHaveLength(3);
+    const hostMap = Object.fromEntries(result.results.map((r) => [r.host, r]));
+    expect(hostMap["10.0.0.1"].success).toBe(true);
+    expect(hostMap["10.0.0.2"].success).toBe(false);
+    expect(hostMap["10.0.0.3"].success).toBe(true);
+    expect(result.successful).toBe(2);
+    expect(result.failed).toBe(1);
+  });
+
+  it("one failing host does not prevent others from running", async () => {
+    const attempted: string[] = [];
+    const executor = vi.fn(async (host: string) => {
+      attempted.push(host);
+      if (host === "10.0.0.1") {
+        return { host, success: false, error: "boom", duration_ms: 1 };
+      }
+      return { host, success: true, output: "ok", duration_ms: 1 };
+    });
+
+    const result = await sshMultiExecute(
+      {
+        hosts: ["10.0.0.1", "10.0.0.2", "10.0.0.3"],
+        username: "admin",
+        commands: ["hostname"],
+      },
+      undefined,
+      executor as typeof executeSingleHost,
+    );
+
+    expect(attempted).toEqual(["10.0.0.1", "10.0.0.2", "10.0.0.3"]);
+    expect(result.results).toHaveLength(3);
+    expect(result.failed).toBe(1);
+    expect(result.successful).toBe(2);
+  });
+
+  it("respects max_parallel by batching hosts", async () => {
+    let activeConcurrent = 0;
+    let peakConcurrent = 0;
+
+    const executor = async (host: string) => {
+      activeConcurrent++;
+      peakConcurrent = Math.max(peakConcurrent, activeConcurrent);
+      await new Promise((r) => setTimeout(r, 5));
+      activeConcurrent--;
+      return { host, success: true, output: "ok", duration_ms: 5 };
+    };
+
+    const hosts = Array.from({ length: 15 }, (_, i) => `10.0.0.${i + 1}`);
+    await sshMultiExecute(
+      {
+        hosts,
+        username: "admin",
+        commands: ["uptime"],
+        max_parallel: 5,
+      },
+      undefined,
+      executor as typeof executeSingleHost,
+    );
+
+    expect(peakConcurrent).toBeLessThanOrEqual(5);
+  }, 10000);
+
+  it("returns empty results for empty host list", async () => {
+    const result = await sshMultiExecute({
+      hosts: [],
+      username: "admin",
+      commands: ["hostname"],
+    });
+
+    expect(result.total_hosts).toBe(0);
+    expect(result.results).toHaveLength(0);
+    expect(result.successful).toBe(0);
+    expect(result.failed).toBe(0);
+  });
+
+  it("tracks wall-clock duration_ms", async () => {
+    const executor = vi.fn(async (host: string) => ({
+      host,
+      success: true,
+      output: "ok",
+      duration_ms: 3,
+    }));
+
+    const result = await sshMultiExecute(
+      {
+        hosts: ["10.0.0.1"],
+        username: "admin",
+        commands: ["hostname"],
+      },
+      undefined,
+      executor as typeof executeSingleHost,
+    );
+
+    expect(result.duration_ms).toBeGreaterThanOrEqual(0);
+    expect(result.results[0].duration_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it("defaults max_parallel to 10 when not specified", async () => {
+    let peakConcurrent = 0;
+    let activeConcurrent = 0;
+
+    const executor = async (host: string) => {
+      activeConcurrent++;
+      peakConcurrent = Math.max(peakConcurrent, activeConcurrent);
+      await new Promise((r) => setTimeout(r, 5));
+      activeConcurrent--;
+      return { host, success: true, output: "ok", duration_ms: 5 };
+    };
+
+    const hosts = Array.from({ length: 25 }, (_, i) => `10.0.${Math.floor(i / 255)}.${(i % 255) + 1}`);
+    await sshMultiExecute(
+      { hosts, username: "admin", commands: ["uptime"] },
+      undefined,
+      executor as typeof executeSingleHost,
+    );
+
+    expect(peakConcurrent).toBeLessThanOrEqual(10);
+  }, 10000);
+
+  it("sets successful/failed counts correctly", async () => {
+    const outcomes: Record<string, boolean> = {
+      a: true,
+      b: false,
+      c: true,
+      d: false,
+      e: false,
+    };
+
+    const executor = vi.fn(async (host: string) => ({
+      host,
+      success: outcomes[host],
+      output: outcomes[host] ? "ok" : undefined,
+      error: outcomes[host] ? undefined : "failed",
+      duration_ms: 1,
+    }));
+
+    const result = await sshMultiExecute(
+      {
+        hosts: Object.keys(outcomes),
+        username: "admin",
+        commands: ["test"],
+      },
+      undefined,
+      executor as typeof executeSingleHost,
+    );
+
+    expect(result.successful).toBe(2);
+    expect(result.failed).toBe(3);
+    expect(result.successful + result.failed).toBe(result.total_hosts);
+  });
+});


### PR DESCRIPTION
Adds `ssh_multi_execute` MCP tool for running commands across multiple hosts in parallel.

## Features
- **Configurable concurrency** — `max_parallel` (default: 10) limits simultaneous SSH connections
- **Per-host timeout** — `timeout_per_host` in seconds (default: 30)
- **Partial failure handling** — failed hosts never stop other hosts; all results always returned
- **Per-host results** — success/failure status, output, error message, duration_ms
- **Summary stats** — total, successful, failed counts + total wall-clock duration
- **Reuses existing credential backends** — Bitwarden, Azure Key Vault, env vars

## Usage example
```json
{
  "hosts": ["spine-01", "spine-02", "leaf-01", "leaf-02"],
  "username": "admin",
  "commands": ["show ip bgp summary"],
  "credential_backend": "bitwarden",
  "credential_ref": "lab-switch-password",
  "max_parallel": 10,
  "timeout_per_host": 30
}
```

## Test coverage
10 new unit tests covering: parallel execution, partial failures, timeout handling, max_parallel batching.

All 95 tests pass.

Closes #9