### PR TITLE
fix: harden ssh_multi_execute credential handling and PTY env

### DIFF
--- a/src/ssh/output-scrubber.ts
+++ b/src/ssh/output-scrubber.ts
@@ -1,15 +1,29 @@
 /**
  * Scrub sensitive patterns from PTY output before returning to MCP client.
+ *
+ * Covers common credential prompt variants across platforms:
+ * - Linux/Unix: Password:, password:
+ * - Cisco IOS/NX-OS: Password:, Secret:
+ * - SSH keys: Enter passphrase:
+ * - Generic: PIN:, Token:, Authentication token:
  */
 export function scrubOutput(raw: string): string {
   let scrubbed = raw;
 
-  // Remove password prompt lines that might echo
-  scrubbed = scrubbed.replace(/[Pp]assword:\s*.*\r?\n?/g, "");
+  // Remove credential prompt lines (case-insensitive, multiple variants)
+  scrubbed = scrubbed.replace(/(?:password|secret|passphrase|pass phrase|pin|token|auth(?:entication)?(?:\s+token)?)[^:]*:\s*.*\r?\n?/gi, "");
 
-  // Remove ANSI escape sequences
+  // Remove ANSI escape sequences (CSI sequences: ESC [ ... final-byte)
   // eslint-disable-next-line no-control-regex
   scrubbed = scrubbed.replace(/\x1B\[[0-9;]*[A-Za-z]/g, "");
+
+  // Remove OSC sequences (ESC ] ... ST or BEL)
+  // eslint-disable-next-line no-control-regex
+  scrubbed = scrubbed.replace(/\x1B\][^\x07\x1B]*(?:\x07|\x1B\\)/g, "");
+
+  // Remove DCS sequences (ESC P ... ST)
+  // eslint-disable-next-line no-control-regex
+  scrubbed = scrubbed.replace(/\x1BP[^\x1B]*\x1B\\/g, "");
 
   return scrubbed;
 }

--- a/src/ssh/output-scrubber.ts
+++ b/src/ssh/output-scrubber.ts
@@ -10,8 +10,12 @@
 export function scrubOutput(raw: string): string {
   let scrubbed = raw;
 
-  // Remove credential prompt lines (case-insensitive, multiple variants)
-  scrubbed = scrubbed.replace(/(?:password|secret|passphrase|pass phrase|pin|token|auth(?:entication)?(?:\s+token)?)[^:]*:\s*.*\r?\n?/gi, "");
+  // Remove credential prompt lines (anchored to prompt-like line starts to avoid
+  // stripping normal command output that happens to contain words like "token:".)
+  scrubbed = scrubbed.replace(
+    /^\s*(?:enter\s+)?(?:password|secret|passphrase|pass phrase|pin|authentication\s+token)\s*:\s*.*(?:\r?\n|$)/gim,
+    "",
+  );
 
   // Remove ANSI escape sequences (CSI sequences: ESC [ ... final-byte)
   // eslint-disable-next-line no-control-regex
@@ -23,7 +27,7 @@ export function scrubOutput(raw: string): string {
 
   // Remove DCS sequences (ESC P ... ST)
   // eslint-disable-next-line no-control-regex
-  scrubbed = scrubbed.replace(/\x1BP[^\x1B]*\x1B\\/g, "");
+  scrubbed = scrubbed.replace(/\x1BP[\s\S]*?\x1B\\/g, "");
 
   return scrubbed;
 }

--- a/src/ssh/output-scrubber.ts
+++ b/src/ssh/output-scrubber.ts
@@ -11,9 +11,9 @@ export function scrubOutput(raw: string): string {
   let scrubbed = raw;
 
   // Remove credential prompt lines (anchored to prompt-like line starts to avoid
-  // stripping normal command output that happens to contain words like "token:".)
+  // stripping normal command output that happens to contain words like "Token Ring:".)
   scrubbed = scrubbed.replace(
-    /^\s*(?:enter\s+)?(?:password|secret|passphrase|pass phrase|pin|authentication\s+token)\s*:\s*.*(?:\r?\n|$)/gim,
+    /^\s*(?:enter\s+)?(?:password|secret|passphrase|pass phrase|pin|token|authentication\s+token)\s*:\s*.*(?:\r?\n|$)/gim,
     "",
   );
 

--- a/src/tools/ssh-multi-execute.ts
+++ b/src/tools/ssh-multi-execute.ts
@@ -227,7 +227,13 @@ async function runSshCommands(opts: RunSshOptions): Promise<string> {
       "TERM",
       "LANG",
       "LC_ALL",
+      // SSH config / agent vars
+      "SSH_AUTH_SOCK",
+      "SSH_AGENT_PID",
       // Windows/platform-critical vars
+      "USERPROFILE",
+      "HOMEDRIVE",
+      "HOMEPATH",
       "SystemRoot",
       "WINDIR",
       "ComSpec",

--- a/src/tools/ssh-multi-execute.ts
+++ b/src/tools/ssh-multi-execute.ts
@@ -2,6 +2,8 @@ import { PlatformHint, detectPrompt, detectPasswordPrompt } from "../ssh/prompt-
 import { scrubOutput } from "../ssh/output-scrubber.js";
 import { CredentialRegistry } from "../credentials/registry.js";
 
+const VALID_REF = /^[a-zA-Z0-9/_\-.@:]+$/;
+
 export interface SshMultiExecuteInput {
   hosts: string[];
   username: string;
@@ -66,6 +68,14 @@ export async function executeSingleHost(
     let username = input.username;
 
     if (input.credential_backend && input.credential_ref && registry) {
+      if (!VALID_REF.test(input.credential_ref)) {
+        return {
+          host,
+          success: false,
+          error: 'Invalid credential_ref format',
+          duration_ms: 0,
+        };
+      }
       const cred = await registry.getCredential(
         input.credential_backend,
         input.credential_ref,
@@ -201,9 +211,9 @@ async function runSshCommands(opts: RunSshOptions): Promise<string> {
 
   return new Promise<string>((resolve, reject) => {
     const sshArgs = [
-      // NOTE: StrictHostKeyChecking is intentionally NOT disabled here.
-      // Hosts must be in the user's ~/.ssh/known_hosts.
-      // For lab/testing: run `ssh-keyscan <host> >> ~/.ssh/known_hosts` first.
+      // Honor ~/.ssh/config for StrictHostKeyChecking — user's config wins.
+      // Default behavior without this flag: whatever ssh_config specifies.
+      "-o", "ForwardAgent=no",
       "-o", "BatchMode=no",
       "-o", `ConnectTimeout=${Math.ceil(timeoutMs / 1000)}`,
       "-p", String(port),
@@ -214,7 +224,16 @@ async function runSshCommands(opts: RunSshOptions): Promise<string> {
       name: "xterm-color",
       cols: 220,
       rows: 40,
-      env: process.env as Record<string, string>,
+      // Pass minimal env — never expose full process.env to SSH children.
+      // Full env inheritance risks leaking Vault tokens, cloud credentials,
+      // SSH_AUTH_SOCK, etc. to SSH servers with AcceptEnv *.
+      env: {
+        HOME: process.env.HOME ?? "",
+        PATH: process.env.PATH ?? "/usr/bin:/bin",
+        TERM: "xterm-color",
+        LANG: process.env.LANG ?? "en_US.UTF-8",
+        LC_ALL: process.env.LC_ALL ?? "",
+      },
     });
 
     let outputBuf = "";
@@ -232,7 +251,9 @@ async function runSshCommands(opts: RunSshOptions): Promise<string> {
 
       if (!authenticated && detectPasswordPrompt(outputBuf)) {
         if (password) {
-          proc.write(password.toString("utf-8") + "\r");
+          // Write password bytes directly — never materialize as a JS string
+          // (strings are immutable on V8 heap and cannot be zeroed)
+          proc.write(Buffer.from(password).toString('binary') + "\r");
           authenticated = true;
           outputBuf = "";
         } else {

--- a/src/tools/ssh-multi-execute.ts
+++ b/src/tools/ssh-multi-execute.ts
@@ -220,20 +220,33 @@ async function runSshCommands(opts: RunSshOptions): Promise<string> {
       `${username}@${host}`,
     ];
 
+    const childEnv: Record<string, string> = {};
+    const allowlist = [
+      "HOME",
+      "PATH",
+      "TERM",
+      "LANG",
+      "LC_ALL",
+      // Windows/platform-critical vars
+      "SystemRoot",
+      "WINDIR",
+      "ComSpec",
+      "PATHEXT",
+      "TEMP",
+      "TMP",
+    ];
+    for (const key of allowlist) {
+      const value = process.env[key];
+      if (value) childEnv[key] = value;
+    }
+    childEnv.TERM ??= "xterm-color";
+
     const proc = pty.spawn("ssh", sshArgs, {
       name: "xterm-color",
       cols: 220,
       rows: 40,
-      // Pass minimal env — never expose full process.env to SSH children.
-      // Full env inheritance risks leaking Vault tokens, cloud credentials,
-      // SSH_AUTH_SOCK, etc. to SSH servers with AcceptEnv *.
-      env: {
-        HOME: process.env.HOME ?? "",
-        PATH: process.env.PATH ?? "/usr/bin:/bin",
-        TERM: "xterm-color",
-        LANG: process.env.LANG ?? "en_US.UTF-8",
-        LC_ALL: process.env.LC_ALL ?? "",
-      },
+      // Pass filtered env only — never expose full process.env to SSH children.
+      env: childEnv,
     });
 
     let outputBuf = "";
@@ -251,9 +264,10 @@ async function runSshCommands(opts: RunSshOptions): Promise<string> {
 
       if (!authenticated && detectPasswordPrompt(outputBuf)) {
         if (password) {
-          // Write password bytes directly — never materialize as a JS string
-          // (strings are immutable on V8 heap and cannot be zeroed)
-          proc.write(Buffer.from(password).toString('binary') + "\r");
+          // node-pty write() is string-based, so preserve the intended UTF-8
+          // characters for non-ASCII passwords. The Buffer is still zeroed in
+          // the caller's finally block after session completion.
+          proc.write(password.toString("utf-8") + "\r");
           authenticated = true;
           outputBuf = "";
         } else {

--- a/test/unit/output-scrubber.test.ts
+++ b/test/unit/output-scrubber.test.ts
@@ -9,6 +9,15 @@ describe("scrubOutput", () => {
     expect(result).toContain("show version");
   });
 
+  it("removes secret/passphrase/token style prompt lines", () => {
+    const input = "Secret: topsecret\nEnter passphrase: abc123\nAuthentication token: 999999\nswitch01# show run";
+    const result = scrubOutput(input);
+    expect(result).not.toContain("Secret:");
+    expect(result).not.toContain("passphrase");
+    expect(result).not.toContain("Authentication token:");
+    expect(result).toContain("show run");
+  });
+
   it("removes ANSI escape sequences", () => {
     const input = "\x1B[32mswitch01#\x1B[0m show version";
     const result = scrubOutput(input);
@@ -16,9 +25,22 @@ describe("scrubOutput", () => {
     expect(result).toContain("switch01#");
   });
 
+  it("removes OSC and DCS escape sequences", () => {
+    const input = "hello\x1B]0;window title\x07world\x1BP1$r0m\x1B\\done";
+    const result = scrubOutput(input);
+    expect(result).toBe("helloworlddone");
+  });
+
   it("preserves normal command output", () => {
     const input = "Cisco Nexus Operating System\nVersion 10.3(4a)";
     expect(scrubOutput(input)).toBe(input);
+  });
+
+  it("does not strip normal output containing token/secret words mid-line", () => {
+    const input = "Token Ring: enabled\nsecret sauce recipe: unavailable\nshow version";
+    const result = scrubOutput(input);
+    expect(result).toContain("Token Ring: enabled");
+    expect(result).toContain("secret sauce recipe: unavailable");
   });
 
   it("handles empty input", () => {

--- a/test/unit/output-scrubber.test.ts
+++ b/test/unit/output-scrubber.test.ts
@@ -10,11 +10,12 @@ describe("scrubOutput", () => {
   });
 
   it("removes secret/passphrase/token style prompt lines", () => {
-    const input = "Secret: topsecret\nEnter passphrase: abc123\nAuthentication token: 999999\nswitch01# show run";
+    const input = "Secret: topsecret\nEnter passphrase: abc123\nAuthentication token: 999999\nToken: 123456\nswitch01# show run";
     const result = scrubOutput(input);
     expect(result).not.toContain("Secret:");
     expect(result).not.toContain("passphrase");
     expect(result).not.toContain("Authentication token:");
+    expect(result).not.toContain("Token: 123456");
     expect(result).toContain("show run");
   });
 


### PR DESCRIPTION
Follow-up hardening for the merged ssh_multi_execute work.

## What this fixes
- use minimal allowlisted env for SSH PTY child processes instead of full process.env
- disable agent forwarding explicitly with -o ForwardAgent=no
- broaden output scrubbing beyond Password: to include Secret:, Passphrase:, token/PIN-style prompts, and additional terminal escape sequences
- validate credential_ref format before handing it to credential backends
- honor user ~/.ssh/config for StrictHostKeyChecking behavior (no forced override in ssh_multi_execute)

## Context
This is a follow-up to the Ghost security review after PR #20 merged.

## Notes
- local build passes
- local tests pass (97 tests)
