### PR TITLE
feat: add version_check MCP tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "node-pty": "^1.1.0",
+        "semver": "^7.7.4",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -19,6 +20,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^25.6.0",
+        "@types/semver": "^7.7.1",
         "@typescript-eslint/eslint-plugin": "^8.58.2",
         "@typescript-eslint/parser": "^8.58.2",
         "eslint": "^10.2.0",
@@ -649,6 +651,13 @@
       "dependencies": {
         "undici-types": "~7.19.0"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.2",
@@ -2898,7 +2907,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -48,11 +48,13 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "node-pty": "^1.1.0",
+    "semver": "^7.7.4",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.6.0",
+    "@types/semver": "^7.7.1",
     "@typescript-eslint/eslint-plugin": "^8.58.2",
     "@typescript-eslint/parser": "^8.58.2",
     "eslint": "^10.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@
  *  - ssh_check_host            (SSH connectivity probe)
  *  - credential_get            (credential metadata, never returns passwords)
  *  - credential_list_backends  (list registered credential backends)
+ *  - version_check             (installed vs latest published package version)
  */
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -22,6 +23,7 @@ import { sshMultiExecute } from './tools/ssh-multi-execute.js';
 import { credentialGet } from './tools/credential-get.js';
 import { credentialListBackends } from './tools/credential-list.js';
 import { sshCheckHost } from './tools/ssh-check.js';
+import { versionCheck } from './tools/version-check.js';
 import { CredentialRegistry } from './credentials/registry.js';
 import { GoogleSecretManagerBackend } from './credentials/google-secret-manager.js';
 
@@ -145,6 +147,24 @@ server.tool(
   async (input) => {
     try {
       const result = await sshCheckHost(input);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── version_check ────────────────────────────────────────────────────────────
+server.tool(
+  'version_check',
+  'Check installed ai-ssh-toolkit version against latest published npm version.',
+  {},
+  async () => {
+    try {
+      const result = await versionCheck();
       return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
     } catch (err: unknown) {
       return {

--- a/src/tools/version-check.ts
+++ b/src/tools/version-check.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { readFile } from 'fs/promises';
+import semver from 'semver';
 
 const execFileAsync = promisify(execFile);
 const CACHE_TTL_MS = 60 * 60 * 1000;
@@ -44,6 +45,13 @@ async function fetchLatestPublishedVersion(): Promise<string> {
 }
 
 function compareVersions(current: string, latest: string): { up_to_date: boolean; update_available: boolean } {
+  if (semver.valid(current) && semver.valid(latest)) {
+    return {
+      up_to_date: semver.eq(current, latest),
+      update_available: semver.gt(latest, current),
+    };
+  }
+
   return {
     up_to_date: current === latest,
     update_available: current !== latest,
@@ -58,13 +66,19 @@ export function clearVersionCheckCache(): void {
 export async function versionCheck(
   fetchLatest: () => Promise<string> = fetchLatestPublishedVersion,
   nowMs: number = Date.now(),
+  currentVersionProvider: () => Promise<string> = getCurrentVersion,
 ): Promise<VersionCheckResult> {
-  const current = await getCurrentVersion();
+  const current = await currentVersionProvider();
   const checked_at = new Date(nowMs).toISOString();
 
   if (cachedResult && nowMs - cachedAt < CACHE_TTL_MS) {
+    const comparison = cachedResult.latest ? compareVersions(current, cachedResult.latest) : {
+      up_to_date: cachedResult.up_to_date,
+      update_available: cachedResult.update_available,
+    };
     return {
       ...cachedResult,
+      ...comparison,
       current,
       checked_at,
       source: 'cache',

--- a/src/tools/version-check.ts
+++ b/src/tools/version-check.ts
@@ -1,0 +1,103 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { readFile } from 'fs/promises';
+
+const execFileAsync = promisify(execFile);
+const CACHE_TTL_MS = 60 * 60 * 1000;
+const PACKAGE_NAME = 'ai-ssh-toolkit';
+
+export interface VersionCheckResult {
+  current: string;
+  latest: string | null;
+  up_to_date: boolean | null;
+  update_available: boolean | null;
+  upgrade_hint: string;
+  checked_at: string;
+  source: 'npm' | 'cache' | 'unavailable';
+  error?: string;
+}
+
+let cachedResult: VersionCheckResult | null = null;
+let cachedAt = 0;
+
+async function getCurrentVersion(): Promise<string> {
+  const packageJsonPath = new URL('../../package.json', import.meta.url);
+  const raw = await readFile(packageJsonPath, 'utf-8');
+  const pkg = JSON.parse(raw) as { version?: string };
+  if (!pkg.version) {
+    throw new Error('Unable to determine installed package version');
+  }
+  return pkg.version;
+}
+
+async function fetchLatestPublishedVersion(): Promise<string> {
+  const { stdout } = await execFileAsync('npm', ['view', PACKAGE_NAME, 'version', '--json'], {
+    timeout: 10000,
+    encoding: 'utf-8',
+  });
+
+  const parsed = JSON.parse(stdout.trim()) as string;
+  if (!parsed || typeof parsed !== 'string') {
+    throw new Error('Invalid npm version response');
+  }
+  return parsed;
+}
+
+function compareVersions(current: string, latest: string): { up_to_date: boolean; update_available: boolean } {
+  return {
+    up_to_date: current === latest,
+    update_available: current !== latest,
+  };
+}
+
+export function clearVersionCheckCache(): void {
+  cachedResult = null;
+  cachedAt = 0;
+}
+
+export async function versionCheck(
+  fetchLatest: () => Promise<string> = fetchLatestPublishedVersion,
+  nowMs: number = Date.now(),
+): Promise<VersionCheckResult> {
+  const current = await getCurrentVersion();
+  const checked_at = new Date(nowMs).toISOString();
+
+  if (cachedResult && nowMs - cachedAt < CACHE_TTL_MS) {
+    return {
+      ...cachedResult,
+      current,
+      checked_at,
+      source: 'cache',
+    };
+  }
+
+  try {
+    const latest = await fetchLatest();
+    const comparison = compareVersions(current, latest);
+    const result: VersionCheckResult = {
+      current,
+      latest,
+      ...comparison,
+      upgrade_hint: `npm install -g ${PACKAGE_NAME}@latest`,
+      checked_at,
+      source: 'npm',
+    };
+    cachedResult = result;
+    cachedAt = nowMs;
+    return result;
+  } catch (err: unknown) {
+    const result: VersionCheckResult = {
+      current,
+      latest: null,
+      up_to_date: null,
+      update_available: null,
+      upgrade_hint: `npm install -g ${PACKAGE_NAME}@latest`,
+      checked_at,
+      source: 'unavailable',
+      error: err instanceof Error ? err.message : String(err),
+    };
+    cachedResult = result;
+    cachedAt = nowMs;
+    return result;
+  }
+}

--- a/test/smoke/mcp-server.smoke.test.ts
+++ b/test/smoke/mcp-server.smoke.test.ts
@@ -1,6 +1,6 @@
 /**
  * Smoke test: verify the MCP server starts, responds to initialize,
- * and registers all 4 expected tools.
+ * and registers all expected tools.
  *
  * Sends JSON-RPC messages via stdin/stdout (no transport library needed).
  */
@@ -55,7 +55,7 @@ describe('MCP server smoke test', () => {
     expect(initResponse.result.capabilities.tools).toBeDefined();
   });
 
-  it('tools/list returns all 4 expected tools', () => {
+  it('tools/list returns all expected tools', () => {
     const responses = sendMessages([
       {
         jsonrpc: '2.0',

--- a/test/smoke/mcp-server.smoke.test.ts
+++ b/test/smoke/mcp-server.smoke.test.ts
@@ -12,7 +12,7 @@ import { fileURLToPath } from 'url';
 
 const DIST_INDEX = resolve(fileURLToPath(new URL('.', import.meta.url)), '../../dist/index.js');
 
-const EXPECTED_TOOLS = ['ssh_execute', 'ssh_multi_execute', 'credential_get', 'credential_list_backends', 'ssh_check_host'];
+const EXPECTED_TOOLS = ['ssh_execute', 'ssh_multi_execute', 'credential_get', 'credential_list_backends', 'ssh_check_host', 'version_check'];
 
 /**
  * Send one or more newline-delimited JSON-RPC messages to the server via stdin,

--- a/test/unit/version-check.test.ts
+++ b/test/unit/version-check.test.ts
@@ -7,28 +7,34 @@ describe('versionCheck', () => {
   });
 
   it('reports up to date when current matches latest', async () => {
-    const result = await versionCheck(async () => '0.1.0', 1_000);
-    expect(result.current).toBe('0.1.0');
-    expect(result.latest).toBe('0.1.0');
+    const result = await versionCheck(async () => '1.2.3', 1_000, async () => '1.2.3');
+    expect(result.current).toBe('1.2.3');
+    expect(result.latest).toBe('1.2.3');
     expect(result.up_to_date).toBe(true);
     expect(result.update_available).toBe(false);
     expect(result.source).toBe('npm');
   });
 
-  it('reports update available when latest differs', async () => {
-    const result = await versionCheck(async () => '0.1.9', 2_000);
-    expect(result.current).toBe('0.1.0');
-    expect(result.latest).toBe('0.1.9');
+  it('reports update available when latest is greater than current', async () => {
+    const result = await versionCheck(async () => '1.2.9', 2_000, async () => '1.2.3');
+    expect(result.current).toBe('1.2.3');
+    expect(result.latest).toBe('1.2.9');
     expect(result.up_to_date).toBe(false);
     expect(result.update_available).toBe(true);
     expect(result.upgrade_hint).toContain('npm install -g ai-ssh-toolkit@latest');
   });
 
+  it('does not report update available when current is newer than latest', async () => {
+    const result = await versionCheck(async () => '1.2.2', 2_500, async () => '1.2.3-beta.1');
+    expect(result.up_to_date).toBe(false);
+    expect(result.update_available).toBe(false);
+  });
+
   it('returns unavailable state when npm lookup fails', async () => {
     const result = await versionCheck(async () => {
       throw new Error('network down');
-    }, 3_000);
-    expect(result.current).toBe('0.1.0');
+    }, 3_000, async () => '1.2.3');
+    expect(result.current).toBe('1.2.3');
     expect(result.latest).toBeNull();
     expect(result.up_to_date).toBeNull();
     expect(result.update_available).toBeNull();
@@ -36,21 +42,24 @@ describe('versionCheck', () => {
     expect(result.error).toContain('network down');
   });
 
-  it('uses cache within ttl', async () => {
+  it('uses cache within ttl and recomputes flags against fresh current version', async () => {
     let calls = 0;
     const fetchLatest = async () => {
       calls += 1;
-      return '0.1.2';
+      return '1.2.2';
     };
 
-    const first = await versionCheck(fetchLatest, 10_000);
+    const first = await versionCheck(fetchLatest, 10_000, async () => '1.2.0');
     const second = await versionCheck(async () => {
       calls += 1;
       return '9.9.9';
-    }, 10_500);
+    }, 10_500, async () => '1.2.3');
 
-    expect(first.latest).toBe('0.1.2');
-    expect(second.latest).toBe('0.1.2');
+    expect(first.latest).toBe('1.2.2');
+    expect(second.latest).toBe('1.2.2');
+    expect(second.current).toBe('1.2.3');
+    expect(second.up_to_date).toBe(false);
+    expect(second.update_available).toBe(false);
     expect(second.source).toBe('cache');
     expect(calls).toBe(1);
   });

--- a/test/unit/version-check.test.ts
+++ b/test/unit/version-check.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { clearVersionCheckCache, versionCheck } from '../../src/tools/version-check.js';
+
+describe('versionCheck', () => {
+  beforeEach(() => {
+    clearVersionCheckCache();
+  });
+
+  it('reports up to date when current matches latest', async () => {
+    const result = await versionCheck(async () => '0.1.0', 1_000);
+    expect(result.current).toBe('0.1.0');
+    expect(result.latest).toBe('0.1.0');
+    expect(result.up_to_date).toBe(true);
+    expect(result.update_available).toBe(false);
+    expect(result.source).toBe('npm');
+  });
+
+  it('reports update available when latest differs', async () => {
+    const result = await versionCheck(async () => '0.1.9', 2_000);
+    expect(result.current).toBe('0.1.0');
+    expect(result.latest).toBe('0.1.9');
+    expect(result.up_to_date).toBe(false);
+    expect(result.update_available).toBe(true);
+    expect(result.upgrade_hint).toContain('npm install -g ai-ssh-toolkit@latest');
+  });
+
+  it('returns unavailable state when npm lookup fails', async () => {
+    const result = await versionCheck(async () => {
+      throw new Error('network down');
+    }, 3_000);
+    expect(result.current).toBe('0.1.0');
+    expect(result.latest).toBeNull();
+    expect(result.up_to_date).toBeNull();
+    expect(result.update_available).toBeNull();
+    expect(result.source).toBe('unavailable');
+    expect(result.error).toContain('network down');
+  });
+
+  it('uses cache within ttl', async () => {
+    let calls = 0;
+    const fetchLatest = async () => {
+      calls += 1;
+      return '0.1.2';
+    };
+
+    const first = await versionCheck(fetchLatest, 10_000);
+    const second = await versionCheck(async () => {
+      calls += 1;
+      return '9.9.9';
+    }, 10_500);
+
+    expect(first.latest).toBe('0.1.2');
+    expect(second.latest).toBe('0.1.2');
+    expect(second.source).toBe('cache');
+    expect(calls).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #33

## Summary
Add a new MCP tool, `version_check`, that reports the installed ai-ssh-toolkit version vs the latest published npm version.

## What it returns
- current version
- latest published version
- up_to_date / update_available flags
- upgrade hint
- checked_at timestamp
- source (`npm`, `cache`, or `unavailable`)
- error field when npm lookup is unavailable

## Details
- reads installed version from package metadata
- checks npm for latest version on demand
- caches lookup results for 1 hour
- does not fail startup or the server if npm is unreachable
- includes tests for:
  - up-to-date
  - update available
  - npm unreachable
  - cache hit behavior
