### PR TITLE
fix: add id-token write permission to publish-gpr job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,7 @@ jobs:
     permissions:
       contents: read
       packages: write  # Required for GitHub Packages
+      id-token: write  # Required for provenance (publishConfig.provenance=true in package.json)
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The `publish-gpr` (GitHub Packages) job in the Publish workflow was failing with:

```
npm error Provenance generation in GitHub Actions requires "write" access to the "id-token" permission
```

## Root Cause

`package.json` has `"provenance": true` in `publishConfig`. npm enforces this flag on **every** publish, requiring `id-token: write` permission in the GitHub Actions job.

The `publish-npm` job already had `id-token: write` (needed for OIDC trusted publishing). The `publish-gpr` job only had `packages: write`, missing the `id-token: write` permission.

## Fix

Added `id-token: write` to the `publish-gpr` job's permissions block.

## Testing

This fix allows CI to retry the publish. The next release trigger (or a manual workflow dispatch) will confirm both registries publish successfully.

Closes #40