### PR TITLE
fix: use current Node/npm for trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,12 +14,17 @@ jobs:
       id-token: write  # Required for OIDC / Trusted Publishing
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Show Node and npm versions
+        run: |
+          node --version
+          npm --version
 
       - name: Install dependencies
         run: npm ci
@@ -40,13 +45,18 @@ jobs:
       id-token: write  # Required for provenance (publishConfig.provenance=true in package.json)
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: 'https://npm.pkg.github.com'
           scope: '@ebmarquez'
+
+      - name: Show Node and npm versions
+        run: |
+          node --version
+          npm --version
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Closes #42

## Summary
Update the publish workflow to use current GitHub Actions and a current Node/npm toolchain for npm Trusted Publishing.

## Why
The npm trusted publishing docs require:
- Node 22.14.0+ or newer
- npm CLI 11.5.1+

The existing workflow used:
- `actions/checkout@v4`
- `actions/setup-node@v4`
- `node-version: 22`

That likely left the publish job on an older bundled npm, which matches the observed failure mode:
- provenance/OIDC path appears to start
- final `npm publish` PUT fails with misleading `E404`

This PR moves publish jobs to current actions and Node 24, and logs Node/npm versions so future failures are easier to diagnose.

## Changes
- `actions/checkout@v6`
- `actions/setup-node@v6`
- `node-version: 24`
- add `node --version` and `npm --version` logging to both publish jobs

## Expected result
- npm Trusted Publishing uses a compatible npm CLI
- the `v0.2.x` publish path succeeds on npm
- GitHub Packages continues to publish successfully
