### PR TITLE
chore: release 0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-ssh-toolkit",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-ssh-toolkit",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-ssh-toolkit",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "MCP server for AI-driven SSH sessions with pluggable credential backends",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release PR for v0.2.2 after merging the trusted publishing workflow/toolchain fix.