### PR TITLE
fix: restore packaged MCP server backend wiring

### DIFF
--- a/src/credentials/bitwarden.ts
+++ b/src/credentials/bitwarden.ts
@@ -40,7 +40,9 @@ export class BitwardenBackend implements CredentialBackend {
   async isAvailable(): Promise<boolean> {
     try {
       this.cliPath = resolveCliPath("bw");
-      const { stdout } = await execFileAsync(this.cliPath, ["status"], {
+      this.hydrateSessionKeyFromEnv();
+      const args = this.sessionKey ? ["status", "--session", this.sessionKey] : ["status"];
+      const { stdout } = await execFileAsync(this.cliPath, args, {
         timeout: 10000,
       });
       const status = JSON.parse(stdout);
@@ -103,7 +105,14 @@ export class BitwardenBackend implements CredentialBackend {
     if (!this.cliPath) {
       this.cliPath = resolveCliPath("bw");
     }
+    this.hydrateSessionKeyFromEnv();
     return this.cliPath;
+  }
+
+  private hydrateSessionKeyFromEnv(): void {
+    if (!this.sessionKey && process.env.BW_SESSION) {
+      this.sessionKey = process.env.BW_SESSION;
+    }
   }
 
   private buildArgs(baseArgs: string[]): string[] {

--- a/src/credentials/registry.ts
+++ b/src/credentials/registry.ts
@@ -25,18 +25,20 @@ export class CredentialRegistry {
 
   /** Probe all registered backends for availability */
   async discoverAvailability(): Promise<BackendStatus[]> {
-    const results: BackendStatus[] = [];
+    const entries = Array.from(this.backends.entries());
 
-    for (const [name, backend] of this.backends) {
-      try {
-        const available = await backend.isAvailable();
-        this.availability.set(name, available);
-        results.push({ name, available });
-      } catch {
-        this.availability.set(name, false);
-        results.push({ name, available: false });
-      }
-    }
+    const results = await Promise.all(
+      entries.map(async ([name, backend]): Promise<BackendStatus> => {
+        try {
+          const available = await backend.isAvailable();
+          this.availability.set(name, available);
+          return { name, available };
+        } catch {
+          this.availability.set(name, false);
+          return { name, available: false };
+        }
+      })
+    );
 
     return results;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,9 +33,18 @@ import { readFileSync } from 'fs';
 
 function getPackageVersion(): string {
   const packageJsonPath = new URL('../package.json', import.meta.url);
-  const raw = readFileSync(packageJsonPath, 'utf-8');
-  const pkg = JSON.parse(raw) as { version?: string };
-  return pkg.version ?? '0.0.0';
+  try {
+    const raw = readFileSync(packageJsonPath, 'utf-8');
+    const pkg = JSON.parse(raw) as { version?: string };
+    return pkg.version ?? '0.0.0';
+  } catch (err: unknown) {
+    process.stderr.write(
+      `Warning: failed to read package version from ${packageJsonPath.toString()}: ${
+        err instanceof Error ? err.message : String(err)
+      }\n`
+    );
+    return '0.0.0';
+  }
 }
 
 const server = new McpServer(

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,14 +25,28 @@ import { credentialListBackends } from './tools/credential-list.js';
 import { sshCheckHost } from './tools/ssh-check.js';
 import { versionCheck } from './tools/version-check.js';
 import { CredentialRegistry } from './credentials/registry.js';
+import { BitwardenBackend } from './credentials/bitwarden.js';
+import { AzureKeyVaultBackend } from './credentials/azure-keyvault.js';
+import { EnvCredentialBackend } from './credentials/env.js';
 import { GoogleSecretManagerBackend } from './credentials/google-secret-manager.js';
+import { readFileSync } from 'fs';
+
+function getPackageVersion(): string {
+  const packageJsonPath = new URL('../package.json', import.meta.url);
+  const raw = readFileSync(packageJsonPath, 'utf-8');
+  const pkg = JSON.parse(raw) as { version?: string };
+  return pkg.version ?? '0.0.0';
+}
 
 const server = new McpServer(
-  { name: 'ai-ssh-toolkit', version: '0.1.0' },
+  { name: 'ai-ssh-toolkit', version: getPackageVersion() },
   { capabilities: { tools: {} } }
 );
 
 const registry = new CredentialRegistry();
+registry.register(new BitwardenBackend());
+registry.register(new AzureKeyVaultBackend());
+registry.register(new EnvCredentialBackend());
 registry.register(new GoogleSecretManagerBackend());
 
 // ── ssh_execute ──────────────────────────────────────────────────────────────

--- a/src/tools/credential-get.ts
+++ b/src/tools/credential-get.ts
@@ -12,17 +12,11 @@ export interface CredentialGetInput {
   backend?: string;
 }
 
-const VALID_REF = /^[a-zA-Z0-9/_\-.@:]+$/;
-
 export async function credentialGet(
   registry: CredentialRegistry,
   input: CredentialGetInput
 ): Promise<CredentialMetadata> {
   const { ref, backend: backendName = 'google-secret-manager' } = input;
-
-  if (!VALID_REF.test(ref)) {
-    throw new Error('Invalid credential_ref format');
-  }
 
   const backend = registry.getBackend(backendName);
 

--- a/src/tools/ssh-execute.ts
+++ b/src/tools/ssh-execute.ts
@@ -8,8 +8,6 @@
 import type { PlatformHint } from '../ssh/prompt-detector.js';
 import type { CredentialRegistry } from '../credentials/registry.js';
 
-const VALID_REF = /^[a-zA-Z0-9/_\-.@:]+$/;
-
 export interface SshExecuteInput {
   host: string;
   command: string;
@@ -42,9 +40,6 @@ export async function sshExecute(
   // wired into PtyManager when src/ssh/pty-manager.ts is implemented.
   let resolvedUsername = username ?? '';
   if (credential_ref) {
-    if (!VALID_REF.test(credential_ref)) {
-      throw new Error('Invalid credential_ref format');
-    }
     const backendName = credential_backend ?? 'google-secret-manager';
     const backend = registry.getBackend(backendName);
     try {

--- a/src/tools/ssh-execute.ts
+++ b/src/tools/ssh-execute.ts
@@ -39,7 +39,10 @@ export async function sshExecute(
   // TODO(pty): input.platform, input.timeout_ms, and resolvedUsername will be
   // wired into PtyManager when src/ssh/pty-manager.ts is implemented.
   let resolvedUsername = username ?? '';
-  if (credential_ref) {
+  if (credential_ref !== undefined) {
+    if (!credential_ref.trim()) {
+      throw new Error('credential_ref cannot be empty');
+    }
     const backendName = credential_backend ?? 'google-secret-manager';
     const backend = registry.getBackend(backendName);
     try {

--- a/src/tools/ssh-multi-execute.ts
+++ b/src/tools/ssh-multi-execute.ts
@@ -66,12 +66,17 @@ export async function executeSingleHost(
     let username = input.username;
 
     if (input.credential_backend && input.credential_ref && registry) {
-      const cred = await registry.getCredential(
-        input.credential_backend,
-        input.credential_ref,
-      );
-      username = cred.username;
-      password = cred.password;
+      const backend = registry.getBackend(input.credential_backend);
+      try {
+        const cred = await registry.getCredential(
+          input.credential_backend,
+          input.credential_ref,
+        );
+        username = cred.username;
+        password = cred.password;
+      } finally {
+        await backend.cleanup();
+      }
     }
 
     const rawOutput = await runSshCommands({

--- a/src/tools/ssh-multi-execute.ts
+++ b/src/tools/ssh-multi-execute.ts
@@ -2,8 +2,6 @@ import { PlatformHint, detectPrompt, detectPasswordPrompt } from "../ssh/prompt-
 import { scrubOutput } from "../ssh/output-scrubber.js";
 import { CredentialRegistry } from "../credentials/registry.js";
 
-const VALID_REF = /^[a-zA-Z0-9/_\-.@:]+$/;
-
 export interface SshMultiExecuteInput {
   hosts: string[];
   username: string;
@@ -68,14 +66,6 @@ export async function executeSingleHost(
     let username = input.username;
 
     if (input.credential_backend && input.credential_ref && registry) {
-      if (!VALID_REF.test(input.credential_ref)) {
-        return {
-          host,
-          success: false,
-          error: 'Invalid credential_ref format',
-          duration_ms: 0,
-        };
-      }
       const cred = await registry.getCredential(
         input.credential_backend,
         input.credential_ref,

--- a/test/smoke/mcp-server.smoke.test.ts
+++ b/test/smoke/mcp-server.smoke.test.ts
@@ -59,7 +59,7 @@ describe('MCP server smoke test', () => {
     expect(initResponse.result.capabilities.tools).toBeDefined();
   });
 
-  it('credential_list_backends includes the expected registered backends', () => {
+  it('credential_list_backends includes the expected registered backends', { timeout: 15000 }, () => {
     const responses = sendMessages([
       {
         jsonrpc: '2.0',

--- a/test/smoke/mcp-server.smoke.test.ts
+++ b/test/smoke/mcp-server.smoke.test.ts
@@ -9,8 +9,11 @@ import { describe, it, expect } from 'vitest';
 import { execFileSync } from 'child_process';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
+import { readFileSync } from 'fs';
 
 const DIST_INDEX = resolve(fileURLToPath(new URL('.', import.meta.url)), '../../dist/index.js');
+const PACKAGE_JSON = resolve(fileURLToPath(new URL('.', import.meta.url)), '../../package.json');
+const PACKAGE_VERSION = JSON.parse(readFileSync(PACKAGE_JSON, 'utf-8')).version;
 
 const EXPECTED_TOOLS = ['ssh_execute', 'ssh_multi_execute', 'credential_get', 'credential_list_backends', 'ssh_check_host', 'version_check'];
 
@@ -52,7 +55,48 @@ describe('MCP server smoke test', () => {
     const initResponse = responses.find((r: any) => r.id === 1) as any;
     expect(initResponse).toBeDefined();
     expect(initResponse.result.serverInfo.name).toBe('ai-ssh-toolkit');
+    expect(initResponse.result.serverInfo.version).toBe(PACKAGE_VERSION);
     expect(initResponse.result.capabilities.tools).toBeDefined();
+  });
+
+  it('credential_list_backends includes the expected registered backends', () => {
+    const responses = sendMessages([
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'smoke-test', version: '1.0' },
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'notifications/initialized',
+      },
+      {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'credential_list_backends',
+          arguments: {},
+        },
+      },
+    ]);
+
+    const backendsResponse = responses.find((r: any) => r.id === 3) as any;
+    expect(backendsResponse).toBeDefined();
+    const text = backendsResponse.result.content[0].text;
+    const backends = JSON.parse(text) as Array<{ name: string; available: boolean }>;
+    const names = backends.map((b) => b.name);
+
+    expect(names).toContain('bitwarden');
+    expect(names).toContain('azure-keyvault');
+    expect(names).toContain('env');
+    expect(names).toContain('google-secret-manager');
   });
 
   it('tools/list returns all expected tools', () => {

--- a/test/smoke/mcp-server.smoke.test.ts
+++ b/test/smoke/mcp-server.smoke.test.ts
@@ -21,13 +21,13 @@ const EXPECTED_TOOLS = ['ssh_execute', 'ssh_multi_execute', 'credential_get', 'c
  * Send one or more newline-delimited JSON-RPC messages to the server via stdin,
  * and collect all newline-delimited JSON responses from stdout.
  */
-function sendMessages(messages: object[]): object[] {
+function sendMessages(messages: object[], timeout = 20_000): object[] {
   const input = messages.map(m => JSON.stringify(m)).join('\n') + '\n';
 
   const stdout = execFileSync('node', [DIST_INDEX], {
     input,
     encoding: 'utf-8',
-    timeout: 10_000,
+    timeout,
   });
 
   return stdout
@@ -59,7 +59,7 @@ describe('MCP server smoke test', () => {
     expect(initResponse.result.capabilities.tools).toBeDefined();
   });
 
-  it('credential_list_backends includes the expected registered backends', { timeout: 15000 }, () => {
+  it('credential_list_backends includes the expected registered backends', { timeout: 25000 }, () => {
     const responses = sendMessages([
       {
         jsonrpc: '2.0',
@@ -85,7 +85,7 @@ describe('MCP server smoke test', () => {
           arguments: {},
         },
       },
-    ]);
+    ], 20_000);
 
     const backendsResponse = responses.find((r: any) => r.id === 3) as any;
     expect(backendsResponse).toBeDefined();

--- a/test/unit/bitwarden-backend.test.ts
+++ b/test/unit/bitwarden-backend.test.ts
@@ -50,6 +50,7 @@ describe("BitwardenBackend", () => {
   beforeEach(() => {
     backend = new BitwardenBackend();
     vi.clearAllMocks();
+    delete process.env.BW_SESSION;
     // Restore default mock — resolveCliPath returns a valid path
     vi.mocked(resolveCliPath).mockReturnValue("/usr/bin/bw");
   });
@@ -90,6 +91,19 @@ describe("BitwardenBackend", () => {
     it("should return false when bw status command fails", async () => {
       mockExecFileError("Command failed");
       expect(await backend.isAvailable()).toBe(false);
+    });
+
+    it("should use BW_SESSION from environment when present", async () => {
+      process.env.BW_SESSION = "env-session-key-123";
+      mockExecFile(JSON.stringify({ status: "unlocked" }));
+
+      expect(await backend.isAvailable()).toBe(true);
+
+      const mock = vi.mocked(execFile);
+      const callArgs = mock.mock.calls[0];
+      const args = callArgs[1] as string[];
+      expect(args).toContain("--session");
+      expect(args).toContain("env-session-key-123");
     });
   });
 


### PR DESCRIPTION
Closes #48

## Summary
Fix the actual shipped product defect behind the broken npm package behavior.

## What changed
- register all intended credential backends in the MCP server entrypoint:
  - `bitwarden`
  - `azure-keyvault`
  - `env`
  - `google-secret-manager`
- stop hardcoding stale MCP server version metadata (`0.1.0`)
- derive runtime server version from `package.json`
- remove the generic credential ref validator that incorrectly rejected Bitwarden item names with spaces
- hydrate Bitwarden session support from `BW_SESSION` so server-side MCP usage can work in non-interactive contexts
- strengthen the smoke test to verify:
  - `serverInfo.version === package.json.version`
  - expected backend registration is present

## Validation performed
### Repo validation
- `npm run build` ✅
- `npm test` ✅

### Clean packaged-artifact validation
- `npm pack` ✅
- clean temp install ✅
- packaged MCP server now reports `0.2.2` ✅
- `credential_list_backends` includes `bitwarden`, `azure-keyvault`, `env`, `google-secret-manager` ✅
- `credential_get` using Bitwarden ref `surface-aac-1 (Ubuntu login)` succeeds with `BW_SESSION` provided ✅

### Real target check
Against `surface-aac-1.local` from the packaged artifact:
- packaged server version is correct ✅
- Bitwarden credential metadata lookup works ✅
- `ssh_execute` still returns the existing explicit not-implemented PTY manager error

## Note
This PR fixes the release-integrity / stale-product-surface failure chain in #48.
It does **not** implement `ssh_execute` PTY functionality; that tool already reports a clear not-yet-implemented error and is a separate product gap.
