### PR TITLE
feat: add persistent SSH session tools (ssh_session_open/execute/close) (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,14 @@ Connect to a host via SSH, run a single command, return output, and close. Best 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `host` | string | ✅ | Hostname or IP |
-| `username` | string | ✅ | SSH username |
+| `username` | string | ❌* | SSH username |
 | `command` | string | ✅ | Command to execute |
 | `credential_backend` | string | ❌ | Backend name (bitwarden, azure-keyvault, env) |
 | `credential_ref` | string | ❌ | Backend-specific reference (BW item name, AKV secret name) |
 | `platform` | string | ❌ | Target OS hint: nxos, os10, sonic, linux, auto (default: auto) |
 | `timeout_ms` | number | ❌ | Command timeout in ms (default: 30000) |
+
+\*Optional when `credential_ref` provides a username.
 
 ### `credential_get`
 
@@ -121,7 +123,7 @@ Expired sessions are cleaned up automatically — you don't need to explicitly c
 ### Security
 
 - Session IDs are **ephemeral `crypto.randomUUID()` values** — never logged, never included in error messages.
-- Credentials are resolved once at open time and the password `Buffer` is zero-filled immediately after the PTY handshake.
+- Credentials are resolved once at open time and the password `Buffer` is zero-filled immediately after the PTY write.
 - The env allowlist prevents full `process.env` leakage to SSH child processes.
 
 ### Tool reference
@@ -133,12 +135,14 @@ Open a persistent interactive SSH shell. Returns a `session_id` for subsequent c
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `host` | string | ✅ | Hostname or IP address |
-| `username` | string | ❌ | SSH username (overrides credential ref username) |
+| `username` | string | ❌* | SSH username (overrides credential ref username) |
 | `credential_ref` | string | ❌ | Credential reference (BW item name, AKV secret, etc.) |
 | `credential_backend` | string | ❌ | Backend name: bitwarden, azure-keyvault, env (default: google-secret-manager) |
 | `platform` | string | ❌ | Prompt detection hint: nxos, os10, sonic, linux, auto (default: auto) |
 | `timeout_ms` | number | ❌ | Connect + initial prompt timeout in ms (default: 30000) |
 | `idle_timeout_ms` | number | ❌ | Inactivity auto-close timeout in ms (default: 300000) |
+
+\*Optional when `credential_ref` provides a username.
 
 **Returns:**
 ```json

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ MCP server for AI-driven SSH session management and secure credential retrieval.
 ## Features
 
 - **SSH Command Execution** — Connect, authenticate, run commands on remote hosts via PTY
+- **Persistent SSH Sessions** — Open an interactive shell once, run multiple commands, close when done
 - **Pluggable Credentials** — Bitwarden CLI, Azure Key Vault, environment variables (extensible)
 - **Network Device Support** — NX-OS, Dell OS10, SONiC, Linux with auto-prompt detection
-- **Hardened Security** — No temp files, Buffer-only passwords, PTY output scrubbing
+- **Hardened Security** — No temp files, Buffer-only passwords, PTY output scrubbing, ephemeral session IDs
 - **Cross-Platform** — Windows (ConPTY) + Linux/macOS (Unix PTY) from day one
 
 ## Quick Start
@@ -46,17 +47,17 @@ Add to `claude_desktop_config.json`:
 
 ### `ssh_execute`
 
-Connect to a host via SSH, run commands, return output.
+Connect to a host via SSH, run a single command, return output, and close. Best for one-shot commands where you don't need to maintain state between invocations.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `host` | string | ✅ | Hostname or IP |
 | `username` | string | ✅ | SSH username |
-| `commands` | string[] | ✅ | Commands to execute |
+| `command` | string | ✅ | Command to execute |
 | `credential_backend` | string | ❌ | Backend name (bitwarden, azure-keyvault, env) |
 | `credential_ref` | string | ❌ | Backend-specific reference (BW item name, AKV secret name) |
-| `platform_hint` | string | ❌ | Target OS hint: nxos, os10, sonic, linux, auto (default: auto) |
-| `port` | number | ❌ | SSH port (default: 22) |
+| `platform` | string | ❌ | Target OS hint: nxos, os10, sonic, linux, auto (default: auto) |
+| `timeout_ms` | number | ❌ | Command timeout in ms (default: 30000) |
 
 ### `credential_get`
 
@@ -81,6 +82,162 @@ Check TCP reachability of a host with latency measurement.
 |-----------|------|----------|-------------|
 | `host` | string | ✅ | Hostname or IP |
 | `port` | number | ❌ | Port to check (default: 22) |
+
+---
+
+## Persistent SSH Sessions
+
+For multi-step workflows — entering config mode, making changes, verifying state — use the persistent session tools instead of calling `ssh_execute` repeatedly. A persistent session keeps one SSH connection open so each command runs in the same shell context.
+
+### When to use persistent sessions vs `ssh_execute`
+
+| Use case | Tool |
+|----------|------|
+| Run one command and you're done | `ssh_execute` |
+| Need shell state across commands (env vars, `cd`, `configure`) | `ssh_session_open` + `ssh_session_execute` |
+| Multi-step workflows on network devices (configure → commit) | Persistent sessions |
+| Parallel commands across many hosts | `ssh_multi_execute` |
+
+### Session lifecycle
+
+```
+ssh_session_open  →  ssh_session_execute (×N)  →  ssh_session_close
+```
+
+1. **`ssh_session_open`** — Opens an interactive shell. Returns a `session_id`.
+2. **`ssh_session_execute`** — Sends a command and waits for the next shell prompt. Repeat as needed.
+3. **`ssh_session_close`** — Sends `exit`, kills the PTY, and removes the session.
+
+### Auto-expiry
+
+Sessions auto-expire after **5 minutes of inactivity** (default). Each `ssh_session_execute` call resets the idle timer. You can override the timeout per session:
+
+```json
+{ "idle_timeout_ms": 600000 }  // 10-minute idle timeout
+```
+
+Expired sessions are cleaned up automatically — you don't need to explicitly close them, though it's good practice.
+
+### Security
+
+- Session IDs are **ephemeral `crypto.randomUUID()` values** — never logged, never included in error messages.
+- Credentials are resolved once at open time and the password `Buffer` is zero-filled immediately after the PTY handshake.
+- The env allowlist prevents full `process.env` leakage to SSH child processes.
+
+### Tool reference
+
+#### `ssh_session_open`
+
+Open a persistent interactive SSH shell. Returns a `session_id` for subsequent calls.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `host` | string | ✅ | Hostname or IP address |
+| `username` | string | ❌ | SSH username (overrides credential ref username) |
+| `credential_ref` | string | ❌ | Credential reference (BW item name, AKV secret, etc.) |
+| `credential_backend` | string | ❌ | Backend name: bitwarden, azure-keyvault, env (default: google-secret-manager) |
+| `platform` | string | ❌ | Prompt detection hint: nxos, os10, sonic, linux, auto (default: auto) |
+| `timeout_ms` | number | ❌ | Connect + initial prompt timeout in ms (default: 30000) |
+| `idle_timeout_ms` | number | ❌ | Inactivity auto-close timeout in ms (default: 300000) |
+
+**Returns:**
+```json
+{
+  "session_id": "550e8400-e29b-41d4-a716-446655440000",
+  "host": "myswitch.local",
+  "username": "admin",
+  "message": "Session opened successfully"
+}
+```
+
+#### `ssh_session_execute`
+
+Run a command inside an open session. Waits for the shell prompt to return before resolving.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `session_id` | string | ✅ | Session ID from `ssh_session_open` |
+| `command` | string | ✅ | Command to run |
+| `timeout_ms` | number | ❌ | Command timeout in ms (default: 30000) |
+
+**Returns:**
+```json
+{
+  "output": "Linux myhost 5.15.0-91-generic ...",
+  "exit_code": null,
+  "session_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+> `exit_code` is `null` for interactive sessions — the shell doesn't produce an exit code until it closes.
+
+#### `ssh_session_close`
+
+Gracefully close a session. Sends `exit`, kills the PTY, and removes the session from the store.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `session_id` | string | ✅ | Session ID from `ssh_session_open` |
+
+**Returns:**
+```json
+{ "message": "Session closed" }
+```
+
+### Example: multi-step workflow on a Linux server
+
+This example opens a session, runs a few commands in sequence (each inheriting the previous shell state), then closes.
+
+```
+1. ssh_session_open
+   host: "myserver.local"
+   username: "admin"
+   credential_ref: "myserver-login"
+   credential_backend: "bitwarden"
+   platform: "linux"
+
+   → session_id: "abc123..."
+
+2. ssh_session_execute  (session_id: "abc123...")
+   command: "cd /etc && pwd"
+   → output: "/etc"
+
+3. ssh_session_execute  (session_id: "abc123...")
+   command: "ls *.conf | head -5"
+   → output: "hosts  hostname  nsswitch.conf  ..."
+
+4. ssh_session_execute  (session_id: "abc123...")
+   command: "cat hostname"
+   → output: "myserver"
+
+5. ssh_session_close   (session_id: "abc123...")
+   → message: "Session closed"
+```
+
+### Example: network device config workflow (NX-OS)
+
+```
+1. ssh_session_open
+   host: "core-switch-01"
+   username: "netadmin"
+   credential_ref: "core-switch-01"
+   credential_backend: "bitwarden"
+   platform: "nxos"
+
+2. ssh_session_execute  command: "configure terminal"
+   → enters config mode, prompt changes to (config)#
+
+3. ssh_session_execute  command: "interface Ethernet1/1"
+   → prompt: (config-if)#
+
+4. ssh_session_execute  command: "description Uplink to spine"
+
+5. ssh_session_execute  command: "end"
+
+6. ssh_session_execute  command: "copy running-config startup-config"
+
+7. ssh_session_close
+```
 
 ## Credential Backends
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Connect to a host via SSH, run a single command, return output, and close. Best 
 | `host` | string | ✅ | Hostname or IP |
 | `username` | string | ❌* | SSH username |
 | `command` | string | ✅ | Command to execute |
-| `credential_backend` | string | ❌ | Backend name (bitwarden, azure-keyvault, env) |
+| `credential_backend` | string | ❌ | Backend name: bitwarden, azure-keyvault, env, google-secret-manager (default: google-secret-manager) |
 | `credential_ref` | string | ❌ | Backend-specific reference (BW item name, AKV secret name) |
 | `platform` | string | ❌ | Target OS hint: nxos, os10, sonic, linux, auto (default: auto) |
 | `timeout_ms` | number | ❌ | Command timeout in ms (default: 30000) |
@@ -137,7 +137,7 @@ Open a persistent interactive SSH shell. Returns a `session_id` for subsequent c
 | `host` | string | ✅ | Hostname or IP address |
 | `username` | string | ❌* | SSH username (overrides credential ref username) |
 | `credential_ref` | string | ❌ | Credential reference (BW item name, AKV secret, etc.) |
-| `credential_backend` | string | ❌ | Backend name: bitwarden, azure-keyvault, env (default: google-secret-manager) |
+| `credential_backend` | string | ❌ | Backend name: bitwarden, azure-keyvault, env, google-secret-manager (default: google-secret-manager) |
 | `platform` | string | ❌ | Prompt detection hint: nxos, os10, sonic, linux, auto (default: auto) |
 | `timeout_ms` | number | ❌ | Connect + initial prompt timeout in ms (default: 30000) |
 | `idle_timeout_ms` | number | ❌ | Inactivity auto-close timeout in ms (default: 300000) |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ai-ssh-toolkit
 
-MCP server for AI-driven SSH session management and secure credential retrieval. Enables AI assistants (GitHub Copilot CLI, Claude, ChatGPT) to execute commands on remote hosts via SSH with pluggable credential backends.
+MCP server for AI-driven SSH session management and secure credential retrieval. Enables GitHub Copilot to execute commands on remote hosts via SSH with pluggable credential backends.
 
 ## Features
 
@@ -28,9 +28,9 @@ Add to your MCP config:
 }
 ```
 
-### Claude Desktop
+### VS Code / GitHub Copilot Chat
 
-Add to `claude_desktop_config.json`:
+Add to your `.vscode/mcp.json` (workspace) or user `settings.json`:
 
 ```json
 {

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,12 @@ registry.register(new GoogleSecretManagerBackend());
 
 const sessionStore = new SessionStore();
 
+// Graceful shutdown: destroy all sessions before exiting
+const shutdown = () => { sessionStore.destroy(); process.exit(0); };
+process.once('SIGINT', shutdown);
+process.once('SIGTERM', shutdown);
+process.on('exit', () => sessionStore.destroy());
+
 // ── ssh_execute ──────────────────────────────────────────────────────────────
 server.tool(
   'ssh_execute',

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,10 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import * as z from 'zod/v3';
 
 import { sshExecute } from './tools/ssh-execute.js';
+import { sshSessionOpen } from './tools/ssh-session-open.js';
+import { sshSessionExecute } from './tools/ssh-session-execute.js';
+import { sshSessionClose } from './tools/ssh-session-close.js';
+import { SessionStore } from './ssh/session-store.js';
 import { sshMultiExecute } from './tools/ssh-multi-execute.js';
 import { credentialGet } from './tools/credential-get.js';
 import { credentialListBackends } from './tools/credential-list.js';
@@ -57,6 +61,8 @@ registry.register(new BitwardenBackend());
 registry.register(new AzureKeyVaultBackend());
 registry.register(new EnvCredentialBackend());
 registry.register(new GoogleSecretManagerBackend());
+
+const sessionStore = new SessionStore();
 
 // ── ssh_execute ──────────────────────────────────────────────────────────────
 server.tool(
@@ -170,6 +176,77 @@ server.tool(
   async (input) => {
     try {
       const result = await sshCheckHost(input);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── ssh_session_open ─────────────────────────────────────────────────────────
+server.tool(
+  'ssh_session_open',
+  'Open a persistent interactive SSH shell session. Returns a session_id for use with ssh_session_execute and ssh_session_close.',
+  {
+    host: z.string().describe('Hostname or IP address of the remote target'),
+    username: z.string().optional().describe('SSH username (overrides credential ref username)'),
+    credential_ref: z.string().optional().describe('Credential reference string understood by the selected backend'),
+    credential_backend: z.string().optional().describe('Name of the credential backend (default: google-secret-manager)'),
+    platform: z
+      .enum(['nxos', 'os10', 'sonic', 'linux', 'auto'])
+      .optional()
+      .describe('Platform hint for prompt detection (default: auto)'),
+    timeout_ms: z.number().int().positive().optional().describe('Connect + initial prompt timeout in milliseconds (default: 30000)'),
+    idle_timeout_ms: z.number().int().positive().optional().describe('Inactivity auto-close timeout in milliseconds (default: 300000)'),
+  },
+  async (input) => {
+    try {
+      const result = await sshSessionOpen(registry, sessionStore, input);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── ssh_session_execute ───────────────────────────────────────────────────────
+server.tool(
+  'ssh_session_execute',
+  'Execute a command inside an open persistent SSH session.',
+  {
+    session_id: z.string().describe('Session ID returned by ssh_session_open'),
+    command: z.string().describe('Command to execute in the session'),
+    timeout_ms: z.number().int().positive().optional().describe('Command timeout in milliseconds (default: 30000)'),
+  },
+  async (input) => {
+    try {
+      const result = await sshSessionExecute(sessionStore, input);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── ssh_session_close ─────────────────────────────────────────────────────────
+server.tool(
+  'ssh_session_close',
+  'Close a persistent SSH session opened with ssh_session_open.',
+  {
+    session_id: z.string().describe('Session ID returned by ssh_session_open'),
+  },
+  async (input) => {
+    try {
+      const result = await sshSessionClose(sessionStore, input);
       return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
     } catch (err: unknown) {
       return {

--- a/src/ssh/output-scrubber.ts
+++ b/src/ssh/output-scrubber.ts
@@ -18,10 +18,10 @@ export function scrubOutput(raw: string): string {
   );
 
   // Remove ANSI/CSI escape sequences including DEC private mode sequences
-  // (e.g. bracketed-paste ESC[?2004h/l, function keys ESC[1~, etc.)
-  // Final-byte range covers 0x40–0x7E per ECMA-48 §5.4 plus ~ for VT sequences.
+  // (e.g. bracketed-paste ESC[?2004h/l, function keys ESC[1~, cursor moves, etc.)
+  // Final-byte range [@-~] covers 0x40-0x7E per ECMA-48 §5.4, including ~.
   // eslint-disable-next-line no-control-regex
-  scrubbed = scrubbed.replace(/\x1B\[[?!>]?[0-9;]*[A-Za-z~]/g, "");
+  scrubbed = scrubbed.replace(/\x1B\[[?!>]?[0-9;]*[@-~]/g, "");
 
   // Remove OSC sequences (ESC ] ... ST or BEL)
   // eslint-disable-next-line no-control-regex

--- a/src/ssh/output-scrubber.ts
+++ b/src/ssh/output-scrubber.ts
@@ -17,10 +17,11 @@ export function scrubOutput(raw: string): string {
     "",
   );
 
-  // Remove ANSI escape sequences (CSI sequences: ESC [ ... final-byte),
-  // including DEC private mode sequences (e.g. bracketed-paste ESC[?2004h/l)
+  // Remove ANSI/CSI escape sequences including DEC private mode sequences
+  // (e.g. bracketed-paste ESC[?2004h/l, function keys ESC[1~, etc.)
+  // Final-byte range covers 0x40–0x7E per ECMA-48 §5.4 plus ~ for VT sequences.
   // eslint-disable-next-line no-control-regex
-  scrubbed = scrubbed.replace(/\x1B\[[?!>]?[0-9;]*[A-Za-z]/g, "");
+  scrubbed = scrubbed.replace(/\x1B\[[?!>]?[0-9;]*[A-Za-z~]/g, "");
 
   // Remove OSC sequences (ESC ] ... ST or BEL)
   // eslint-disable-next-line no-control-regex

--- a/src/ssh/output-scrubber.ts
+++ b/src/ssh/output-scrubber.ts
@@ -17,9 +17,10 @@ export function scrubOutput(raw: string): string {
     "",
   );
 
-  // Remove ANSI escape sequences (CSI sequences: ESC [ ... final-byte)
+  // Remove ANSI escape sequences (CSI sequences: ESC [ ... final-byte),
+  // including DEC private mode sequences (e.g. bracketed-paste ESC[?2004h/l)
   // eslint-disable-next-line no-control-regex
-  scrubbed = scrubbed.replace(/\x1B\[[0-9;]*[A-Za-z]/g, "");
+  scrubbed = scrubbed.replace(/\x1B\[[?!>]?[0-9;]*[A-Za-z]/g, "");
 
   // Remove OSC sequences (ESC ] ... ST or BEL)
   // eslint-disable-next-line no-control-regex

--- a/src/ssh/session-store.ts
+++ b/src/ssh/session-store.ts
@@ -48,16 +48,20 @@ export class SessionStore {
 
   /** Remove a session from the store (disposes listeners). Returns true if it existed.
    * If the session is inFlight, listeners are NOT disposed (the in-flight execute
-   * owns them and will clean up via cleanup()). The PTY is still killed.
+   * owns them and will clean up via cleanup()). The PTY is always killed.
    */
   delete(id: string): boolean {
     const session = this.sessions.get(id);
-    if (session && !session.inFlight) {
-      // Only dispose listeners when no command is executing
-      for (const d of session.disposables) {
-        try { d.dispose(); } catch { /* ignore */ }
+    if (session) {
+      if (!session.inFlight) {
+        // Only dispose listeners when no command is executing
+        for (const d of session.disposables) {
+          try { d.dispose(); } catch { /* ignore */ }
+        }
+        session.disposables.length = 0;
       }
-      session.disposables.length = 0;
+      // Always kill the PTY process
+      try { session.ptyProcess.kill(); } catch { /* ignore */ }
     }
     return this.sessions.delete(id);
   }

--- a/src/ssh/session-store.ts
+++ b/src/ssh/session-store.ts
@@ -1,0 +1,76 @@
+/**
+ * SessionStore — in-memory registry for persistent interactive SSH sessions.
+ *
+ * Each session holds a live node-pty process. Sessions are evicted
+ * automatically after `idleTimeoutMs` milliseconds of inactivity.
+ *
+ * Security: session IDs are crypto.randomUUID() values and are NEVER
+ * logged or included in error messages.
+ */
+
+import type { IPty } from 'node-pty';
+import type { PlatformHint } from './prompt-detector.js';
+
+export interface ManagedSession {
+  id: string;           // crypto.randomUUID()
+  ptyProcess: IPty;     // node-pty instance
+  lastActivity: number; // Date.now()
+  host: string;
+  username: string;
+  platform: PlatformHint;
+  outputBuffer: string; // accumulates PTY output since last command
+}
+
+export class SessionStore {
+  private sessions = new Map<string, ManagedSession>();
+  private cleanupInterval: NodeJS.Timeout;
+
+  constructor(private idleTimeoutMs = 5 * 60 * 1000) {
+    // Run cleanup every 60 s to evict idle sessions.
+    // .unref() prevents this timer from keeping the process alive.
+    this.cleanupInterval = setInterval(() => this.evictIdle(), 60_000).unref();
+  }
+
+  /** Add a new session to the store. */
+  add(session: ManagedSession): void {
+    this.sessions.set(session.id, session);
+  }
+
+  /** Retrieve a session by ID. Returns undefined if not found. */
+  get(id: string): ManagedSession | undefined {
+    return this.sessions.get(id);
+  }
+
+  /** Remove a session from the store. Returns true if it existed. */
+  delete(id: string): boolean {
+    return this.sessions.delete(id);
+  }
+
+  /** Kill and remove sessions that have been idle longer than idleTimeoutMs. */
+  private evictIdle(): void {
+    const now = Date.now();
+    for (const [id, session] of this.sessions) {
+      if (now - session.lastActivity > this.idleTimeoutMs) {
+        try {
+          session.ptyProcess.kill();
+        } catch {
+          // PTY may already be dead — ignore
+        }
+        this.sessions.delete(id);
+      }
+    }
+  }
+
+  /** Kill all sessions and stop the cleanup interval. */
+  destroy(): void {
+    clearInterval(this.cleanupInterval);
+    for (const session of this.sessions.values()) {
+      try {
+        session.ptyProcess.kill();
+      } catch {
+        // ignore
+      }
+    }
+    this.sessions.clear();
+  }
+}

--- a/src/ssh/session-store.ts
+++ b/src/ssh/session-store.ts
@@ -46,10 +46,14 @@ export class SessionStore {
     return this.sessions.get(id);
   }
 
-  /** Remove a session from the store (disposes listeners). Returns true if it existed. */
+  /** Remove a session from the store (disposes listeners). Returns true if it existed.
+   * If the session is inFlight, listeners are NOT disposed (the in-flight execute
+   * owns them and will clean up via cleanup()). The PTY is still killed.
+   */
   delete(id: string): boolean {
     const session = this.sessions.get(id);
-    if (session) {
+    if (session && !session.inFlight) {
+      // Only dispose listeners when no command is executing
       for (const d of session.disposables) {
         try { d.dispose(); } catch { /* ignore */ }
       }

--- a/src/ssh/session-store.ts
+++ b/src/ssh/session-store.ts
@@ -9,6 +9,7 @@
  */
 
 import type { IPty } from 'node-pty';
+import type { IDisposable } from 'node-pty';
 import type { PlatformHint } from './prompt-detector.js';
 
 export interface ManagedSession {
@@ -19,11 +20,15 @@ export interface ManagedSession {
   username: string;
   platform: PlatformHint;
   outputBuffer: string; // accumulates PTY output since last command
+  idleTimeoutMs?: number; // per-session idle timeout override
+  inFlight: boolean;      // true while a command is executing
+  disposables: IDisposable[]; // active PTY listeners to dispose on cleanup
 }
 
 export class SessionStore {
   private sessions = new Map<string, ManagedSession>();
   private cleanupInterval: NodeJS.Timeout;
+  private destroyed = false;
 
   constructor(private idleTimeoutMs = 5 * 60 * 1000) {
     // Run cleanup every 60 s to evict idle sessions.
@@ -41,16 +46,30 @@ export class SessionStore {
     return this.sessions.get(id);
   }
 
-  /** Remove a session from the store. Returns true if it existed. */
+  /** Remove a session from the store (disposes listeners). Returns true if it existed. */
   delete(id: string): boolean {
+    const session = this.sessions.get(id);
+    if (session) {
+      for (const d of session.disposables) {
+        try { d.dispose(); } catch { /* ignore */ }
+      }
+      session.disposables.length = 0;
+    }
     return this.sessions.delete(id);
   }
 
-  /** Kill and remove sessions that have been idle longer than idleTimeoutMs. */
+  /** Kill and remove sessions that have been idle longer than their timeout. */
   private evictIdle(): void {
     const now = Date.now();
     for (const [id, session] of this.sessions) {
-      if (now - session.lastActivity > this.idleTimeoutMs) {
+      // Never evict a session with a command in flight
+      if (session.inFlight) continue;
+      const timeout = session.idleTimeoutMs ?? this.idleTimeoutMs;
+      if (now - session.lastActivity > timeout) {
+        for (const d of session.disposables) {
+          try { d.dispose(); } catch { /* ignore */ }
+        }
+        session.disposables.length = 0;
         try {
           session.ptyProcess.kill();
         } catch {
@@ -61,10 +80,16 @@ export class SessionStore {
     }
   }
 
-  /** Kill all sessions and stop the cleanup interval. */
+  /** Kill all sessions and stop the cleanup interval. Idempotent. */
   destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
     clearInterval(this.cleanupInterval);
     for (const session of this.sessions.values()) {
+      for (const d of session.disposables) {
+        try { d.dispose(); } catch { /* ignore */ }
+      }
+      session.disposables.length = 0;
       try {
         session.ptyProcess.kill();
       } catch {

--- a/src/tools/ssh-session-close.ts
+++ b/src/tools/ssh-session-close.ts
@@ -23,6 +23,10 @@ export async function sshSessionClose(
     throw new Error('Session not found or expired');
   }
 
+  if (session.inFlight) {
+    throw new Error('Cannot close session while a command is executing. Wait for the command to complete or time out.');
+  }
+
   // Gracefully exit the shell, then forcibly kill the PTY
   try {
     session.ptyProcess.write('exit\r');

--- a/src/tools/ssh-session-close.ts
+++ b/src/tools/ssh-session-close.ts
@@ -25,7 +25,7 @@ export async function sshSessionClose(
 
   // Gracefully exit the shell, then forcibly kill the PTY
   try {
-    session.ptyProcess.write('exit\n');
+    session.ptyProcess.write('exit\r');
   } catch {
     // PTY may already be dead — continue to kill
   }

--- a/src/tools/ssh-session-close.ts
+++ b/src/tools/ssh-session-close.ts
@@ -1,0 +1,42 @@
+/**
+ * ssh_session_close tool handler — gracefully closes a persistent SSH session.
+ */
+
+import type { SessionStore } from '../ssh/session-store.js';
+
+export interface SshSessionCloseInput {
+  session_id: string;
+}
+
+export interface SshSessionCloseResult {
+  message: string;
+}
+
+export async function sshSessionClose(
+  sessionStore: SessionStore,
+  input: SshSessionCloseInput,
+): Promise<SshSessionCloseResult> {
+  const { session_id } = input;
+
+  const session = sessionStore.get(session_id);
+  if (!session) {
+    throw new Error('Session not found or expired');
+  }
+
+  // Gracefully exit the shell, then forcibly kill the PTY
+  try {
+    session.ptyProcess.write('exit\n');
+  } catch {
+    // PTY may already be dead — continue to kill
+  }
+
+  try {
+    session.ptyProcess.kill();
+  } catch {
+    // ignore
+  }
+
+  sessionStore.delete(session_id);
+
+  return { message: 'Session closed' };
+}

--- a/src/tools/ssh-session-close.ts
+++ b/src/tools/ssh-session-close.ts
@@ -18,6 +18,10 @@ export async function sshSessionClose(
 ): Promise<SshSessionCloseResult> {
   const { session_id } = input;
 
+  if (!session_id?.trim()) {
+    throw new Error('session_id is required and cannot be empty');
+  }
+
   const session = sessionStore.get(session_id);
   if (!session) {
     throw new Error('Session not found or expired');
@@ -27,17 +31,11 @@ export async function sshSessionClose(
     throw new Error('Cannot close session while a command is executing. Wait for the command to complete or time out.');
   }
 
-  // Gracefully exit the shell, then forcibly kill the PTY
+  // Gracefully send exit, then let SessionStore.delete() own the kill + dispose
   try {
     session.ptyProcess.write('exit\r');
   } catch {
-    // PTY may already be dead — continue to kill
-  }
-
-  try {
-    session.ptyProcess.kill();
-  } catch {
-    // ignore
+    // PTY may already be dead — continue
   }
 
   sessionStore.delete(session_id);

--- a/src/tools/ssh-session-execute.ts
+++ b/src/tools/ssh-session-execute.ts
@@ -50,12 +50,18 @@ export async function sshSessionExecute(
     let settled = false;
     let dataDisposable: IDisposable | undefined;
 
+    let exitDisposable: IDisposable | undefined;
+
     function cleanup() {
       if (dataDisposable) {
         try { dataDisposable.dispose(); } catch { /* ignore */ }
         const idx = sess.disposables.indexOf(dataDisposable);
         if (idx !== -1) sess.disposables.splice(idx, 1);
         dataDisposable = undefined;
+      }
+      if (exitDisposable) {
+        try { exitDisposable.dispose(); } catch { /* ignore */ }
+        exitDisposable = undefined;
       }
       sess.inFlight = false;
     }
@@ -95,12 +101,16 @@ export async function sshSessionExecute(
     sess.disposables.push(dataDisposable);
 
     // Listen for PTY exit (fast-fail instead of waiting for timeout)
-    const exitDisposable = sess.ptyProcess.onExit(({ exitCode }) => {
-      exitDisposable.dispose();
+    exitDisposable = sess.ptyProcess.onExit(({ exitCode }) => {
       fail(new Error(`SSH PTY exited unexpectedly with code ${exitCode} during command execution`));
     });
 
-    // Write the command to the PTY
-    sess.ptyProcess.write(command + '\n');
+    // Write the command to the PTY — wrap in try/catch so a dead PTY
+    // doesn't leave inFlight=true and listeners dangling
+    try {
+      sess.ptyProcess.write(command + '\r');
+    } catch (err) {
+      fail(new Error(`Failed to write to PTY: ${String(err)}`));
+    }
   });
 }

--- a/src/tools/ssh-session-execute.ts
+++ b/src/tools/ssh-session-execute.ts
@@ -5,7 +5,8 @@
  * then returns the scrubbed output.
  */
 
-import type { SessionStore } from '../ssh/session-store.js';
+import type { SessionStore, ManagedSession } from '../ssh/session-store.js';
+import type { IDisposable } from 'node-pty';
 import { detectPrompt } from '../ssh/prompt-detector.js';
 import { scrubOutput } from '../ssh/output-scrubber.js';
 
@@ -27,25 +28,43 @@ export async function sshSessionExecute(
 ): Promise<SshSessionExecuteResult> {
   const { session_id, command, timeout_ms = 30_000 } = input;
 
-  const session = sessionStore.get(session_id);
-  if (!session) {
+  const sessionOrUndef = sessionStore.get(session_id);
+  if (!sessionOrUndef) {
     throw new Error('Session not found or expired');
+  }
+  const session: ManagedSession = sessionOrUndef;
+
+  if (session.inFlight) {
+    throw new Error('A command is already running on this session. Wait for it to complete.');
   }
 
   // Update activity timestamp
   session.lastActivity = Date.now();
   session.outputBuffer = ''; // reset capture buffer for this command
+  session.inFlight = true;
+
+  const sess = session; // capture for closure — TypeScript narrowing guard
 
   return new Promise<SshSessionExecuteResult>((resolve, reject) => {
     let captureBuffer = '';
     let settled = false;
+    let dataDisposable: IDisposable | undefined;
+
+    function cleanup() {
+      if (dataDisposable) {
+        try { dataDisposable.dispose(); } catch { /* ignore */ }
+        const idx = sess.disposables.indexOf(dataDisposable);
+        if (idx !== -1) sess.disposables.splice(idx, 1);
+        dataDisposable = undefined;
+      }
+      sess.inFlight = false;
+    }
 
     function finish(output: string) {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      // Remove data listener by resetting onData to a no-op — we can't
-      // unsubscribe in node-pty, so we gate on the `settled` flag instead.
+      cleanup();
       const cleaned = scrubOutput(output);
       resolve({ output: cleaned, exit_code: null, session_id });
     }
@@ -54,6 +73,7 @@ export async function sshSessionExecute(
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      cleanup();
       reject(err);
     }
 
@@ -62,18 +82,25 @@ export async function sshSessionExecute(
     }, timeout_ms);
 
     // Listen for PTY output
-    session.ptyProcess.onData((data: string) => {
+    dataDisposable = sess.ptyProcess.onData((data: string) => {
       if (settled) return;
       captureBuffer += data;
-      session.outputBuffer += data;
-      session.lastActivity = Date.now();
+      sess.outputBuffer += data;
+      sess.lastActivity = Date.now();
 
-      if (detectPrompt(captureBuffer, session.platform)) {
+      if (detectPrompt(captureBuffer, sess.platform)) {
         finish(captureBuffer);
       }
     });
+    sess.disposables.push(dataDisposable);
+
+    // Listen for PTY exit (fast-fail instead of waiting for timeout)
+    const exitDisposable = sess.ptyProcess.onExit(({ exitCode }) => {
+      exitDisposable.dispose();
+      fail(new Error(`SSH PTY exited unexpectedly with code ${exitCode} during command execution`));
+    });
 
     // Write the command to the PTY
-    session.ptyProcess.write(command + '\n');
+    sess.ptyProcess.write(command + '\n');
   });
 }

--- a/src/tools/ssh-session-execute.ts
+++ b/src/tools/ssh-session-execute.ts
@@ -105,6 +105,8 @@ export async function sshSessionExecute(
     // Listen for PTY exit (fast-fail instead of waiting for timeout)
     // Also pushed to sess.disposables so SessionStore.delete/destroy cleans it up
     exitDisposable = sess.ptyProcess.onExit(({ exitCode }) => {
+      // Remove the dead session from the store so subsequent calls get "Session not found"
+      sessionStore.delete(sess.id);
       fail(new Error(`SSH PTY exited unexpectedly with code ${exitCode} during command execution`));
     });
     sess.disposables.push(exitDisposable);
@@ -114,6 +116,8 @@ export async function sshSessionExecute(
     try {
       sess.ptyProcess.write(command + '\r');
     } catch (err) {
+      // PTY is dead — remove the session from the store and fail cleanly
+      sessionStore.delete(sess.id);
       fail(new Error(`Failed to write to PTY: ${String(err)}`));
     }
   });

--- a/src/tools/ssh-session-execute.ts
+++ b/src/tools/ssh-session-execute.ts
@@ -61,6 +61,8 @@ export async function sshSessionExecute(
       }
       if (exitDisposable) {
         try { exitDisposable.dispose(); } catch { /* ignore */ }
+        const eidx = sess.disposables.indexOf(exitDisposable);
+        if (eidx !== -1) sess.disposables.splice(eidx, 1);
         exitDisposable = undefined;
       }
       sess.inFlight = false;
@@ -101,9 +103,11 @@ export async function sshSessionExecute(
     sess.disposables.push(dataDisposable);
 
     // Listen for PTY exit (fast-fail instead of waiting for timeout)
+    // Also pushed to sess.disposables so SessionStore.delete/destroy cleans it up
     exitDisposable = sess.ptyProcess.onExit(({ exitCode }) => {
       fail(new Error(`SSH PTY exited unexpectedly with code ${exitCode} during command execution`));
     });
+    sess.disposables.push(exitDisposable);
 
     // Write the command to the PTY — wrap in try/catch so a dead PTY
     // doesn't leave inFlight=true and listeners dangling

--- a/src/tools/ssh-session-execute.ts
+++ b/src/tools/ssh-session-execute.ts
@@ -28,6 +28,13 @@ export async function sshSessionExecute(
 ): Promise<SshSessionExecuteResult> {
   const { session_id, command, timeout_ms = 30_000 } = input;
 
+  if (!session_id?.trim()) {
+    throw new Error('session_id is required and cannot be empty');
+  }
+  if (!command?.trim()) {
+    throw new Error('command is required and cannot be empty');
+  }
+
   const sessionOrUndef = sessionStore.get(session_id);
   if (!sessionOrUndef) {
     throw new Error('Session not found or expired');

--- a/src/tools/ssh-session-execute.ts
+++ b/src/tools/ssh-session-execute.ts
@@ -1,0 +1,79 @@
+/**
+ * ssh_session_execute tool handler — executes a command inside an open session.
+ *
+ * Writes the command to the PTY, waits for the shell prompt to return,
+ * then returns the scrubbed output.
+ */
+
+import type { SessionStore } from '../ssh/session-store.js';
+import { detectPrompt } from '../ssh/prompt-detector.js';
+import { scrubOutput } from '../ssh/output-scrubber.js';
+
+export interface SshSessionExecuteInput {
+  session_id: string;
+  command: string;
+  timeout_ms?: number; // default 30000
+}
+
+export interface SshSessionExecuteResult {
+  output: string;
+  exit_code: number | null; // null for interactive sessions
+  session_id: string;
+}
+
+export async function sshSessionExecute(
+  sessionStore: SessionStore,
+  input: SshSessionExecuteInput,
+): Promise<SshSessionExecuteResult> {
+  const { session_id, command, timeout_ms = 30_000 } = input;
+
+  const session = sessionStore.get(session_id);
+  if (!session) {
+    throw new Error('Session not found or expired');
+  }
+
+  // Update activity timestamp
+  session.lastActivity = Date.now();
+  session.outputBuffer = ''; // reset capture buffer for this command
+
+  return new Promise<SshSessionExecuteResult>((resolve, reject) => {
+    let captureBuffer = '';
+    let settled = false;
+
+    function finish(output: string) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      // Remove data listener by resetting onData to a no-op — we can't
+      // unsubscribe in node-pty, so we gate on the `settled` flag instead.
+      const cleaned = scrubOutput(output);
+      resolve({ output: cleaned, exit_code: null, session_id });
+    }
+
+    function fail(err: Error) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    }
+
+    const timer = setTimeout(() => {
+      fail(new Error(`ssh_session_execute timed out after ${timeout_ms}ms`));
+    }, timeout_ms);
+
+    // Listen for PTY output
+    session.ptyProcess.onData((data: string) => {
+      if (settled) return;
+      captureBuffer += data;
+      session.outputBuffer += data;
+      session.lastActivity = Date.now();
+
+      if (detectPrompt(captureBuffer, session.platform)) {
+        finish(captureBuffer);
+      }
+    });
+
+    // Write the command to the PTY
+    session.ptyProcess.write(command + '\n');
+  });
+}

--- a/src/tools/ssh-session-open.ts
+++ b/src/tools/ssh-session-open.ts
@@ -1,0 +1,187 @@
+/**
+ * ssh_session_open tool handler — opens a persistent interactive SSH shell session.
+ *
+ * Returns a session_id that callers can use with ssh_session_execute and
+ * ssh_session_close. The session remains open until explicitly closed or
+ * until it is evicted by the SessionStore idle-timeout.
+ */
+
+import type { PlatformHint } from '../ssh/prompt-detector.js';
+import type { CredentialRegistry } from '../credentials/registry.js';
+import type { SessionStore } from '../ssh/session-store.js';
+import { detectPasswordPrompt, detectPrompt } from '../ssh/prompt-detector.js';
+
+export interface SshSessionOpenInput {
+  host: string;
+  username?: string;
+  credential_ref?: string;
+  credential_backend?: string;
+  platform?: PlatformHint;
+  timeout_ms?: number;      // connect + initial prompt timeout (default: 30000)
+  idle_timeout_ms?: number; // inactivity auto-close passed to SessionStore (default: 300000)
+}
+
+export interface SshSessionOpenResult {
+  session_id: string;
+  host: string;
+  username: string;
+  message: string;
+}
+
+export async function sshSessionOpen(
+  registry: CredentialRegistry,
+  sessionStore: SessionStore,
+  input: SshSessionOpenInput,
+): Promise<SshSessionOpenResult> {
+  const {
+    host,
+    username,
+    credential_ref,
+    credential_backend,
+    platform = 'auto',
+    timeout_ms = 30_000,
+  } = input;
+
+  if (!host) throw new Error('host is required');
+
+  // ── Resolve credentials ──────────────────────────────────────────────────
+  let resolvedUsername = username ?? '';
+  let passwordBuffer: Buffer = Buffer.alloc(0);
+
+  if (credential_ref !== undefined) {
+    if (!credential_ref.trim()) throw new Error('credential_ref cannot be empty');
+
+    const backendName = credential_backend ?? 'google-secret-manager';
+    const backend = registry.getBackend(backendName);
+    try {
+      const available = await backend.isAvailable();
+      if (!available) {
+        process.stderr.write(`Credential backend "${backendName}" unavailable in ssh_session_open\n`);
+        throw new Error(`Credential backend "${backendName}" failed. Check server logs for details.`);
+      }
+      const cred = await backend.getCredential(credential_ref);
+      resolvedUsername = cred.username || resolvedUsername;
+      passwordBuffer = Buffer.from(cred.password);
+      cred.password.fill(0);
+    } finally {
+      await backend.cleanup();
+    }
+  }
+
+  if (!resolvedUsername) {
+    throw new Error(
+      'username is required (provide username or a credential_ref with a username)',
+    );
+  }
+
+  // ── Dynamic import (allows mocking in tests) ─────────────────────────────
+  const { default: pty } = await import('node-pty');
+
+  // ── Env allowlist (same pattern as pty-manager.ts) ───────────────────────
+  const childEnv: Record<string, string> = {};
+  const allowlist = [
+    'HOME', 'PATH', 'TERM', 'LANG', 'LC_ALL',
+    'SSH_AUTH_SOCK', 'SSH_AGENT_PID',
+    'USERPROFILE', 'HOMEDRIVE', 'HOMEPATH',
+    'SystemRoot', 'WINDIR', 'ComSpec', 'PATHEXT', 'TEMP', 'TMP',
+  ];
+  for (const key of allowlist) {
+    const value = process.env[key];
+    if (value) childEnv[key] = value;
+  }
+  childEnv.TERM ??= 'xterm-color';
+
+  // ── Spawn interactive shell (no command in argv → opens a shell) ──────────
+  const sshArgs = [
+    '-tt',
+    '-o', 'StrictHostKeyChecking=accept-new',
+    '-o', 'NumberOfPasswordPrompts=1',
+    '-o', 'ConnectTimeout=10',
+    `${resolvedUsername}@${host}`,
+    // Intentionally no command — we want an interactive shell
+  ];
+
+  return new Promise<SshSessionOpenResult>((resolve, reject) => {
+    let term: import('node-pty').IPty;
+    try {
+      term = pty.spawn('ssh', sshArgs, {
+        name: 'xterm-color',
+        cols: 220,
+        rows: 24,
+        env: childEnv,
+      });
+    } catch (err) {
+      passwordBuffer.fill(0);
+      return reject(new Error(`Failed to spawn SSH PTY: ${String(err)}`));
+    }
+
+    let outputBuffer = '';
+    let passwordSent = false;
+    let settled = false;
+
+    function succeed() {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      passwordBuffer.fill(0);
+
+      const sessionId = crypto.randomUUID();
+      sessionStore.add({
+        id: sessionId,
+        ptyProcess: term,
+        lastActivity: Date.now(),
+        host,
+        username: resolvedUsername,
+        platform,
+        outputBuffer: '',
+      });
+
+      resolve({
+        session_id: sessionId,
+        host,
+        username: resolvedUsername,
+        message: 'Session opened successfully',
+      });
+    }
+
+    function fail(err: Error) {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      passwordBuffer.fill(0);
+      try { term.kill(); } catch { /* ignore */ }
+      reject(err);
+    }
+
+    const timer = setTimeout(() => {
+      fail(new Error(`SSH session open timed out after ${timeout_ms}ms`));
+    }, timeout_ms);
+
+    term.onData((data: string) => {
+      outputBuffer += data;
+
+      // Handle password prompt
+      if (!passwordSent && detectPasswordPrompt(outputBuffer)) {
+        passwordSent = true;
+        if (!passwordBuffer || passwordBuffer.length === 0) {
+          fail(new Error(
+            'SSH password prompt received but no credential was provided. ' +
+            'Use credential_ref to supply credentials, or ensure key-based auth is configured.',
+          ));
+          return;
+        }
+        term.write(passwordBuffer.toString('utf-8') + '\r');
+        return;
+      }
+
+      // Wait for the initial shell prompt before declaring the session ready
+      if (detectPrompt(outputBuffer, platform)) {
+        succeed();
+      }
+    });
+
+    term.onExit(({ exitCode }: { exitCode: number }) => {
+      fail(new Error(`SSH process exited unexpectedly with code ${exitCode}`));
+    });
+  });
+}

--- a/src/tools/ssh-session-open.ts
+++ b/src/tools/ssh-session-open.ts
@@ -119,11 +119,21 @@ export async function sshSessionOpen(
     let outputBuffer = '';
     let passwordSent = false;
     let settled = false;
+    let openDataDisposable: import('node-pty').IDisposable | undefined;
+    let openExitDisposable: import('node-pty').IDisposable | undefined;
+
+    function disposeOpenListeners() {
+      try { openDataDisposable?.dispose(); } catch { /* ignore */ }
+      try { openExitDisposable?.dispose(); } catch { /* ignore */ }
+      openDataDisposable = undefined;
+      openExitDisposable = undefined;
+    }
 
     function succeed() {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      disposeOpenListeners();
       passwordBuffer.fill(0);
 
       const sessionId = crypto.randomUUID();
@@ -152,6 +162,7 @@ export async function sshSessionOpen(
       if (settled) return;
       settled = true;
       clearTimeout(timer);
+      disposeOpenListeners();
       passwordBuffer.fill(0);
       try { term.kill(); } catch { /* ignore */ }
       reject(err);
@@ -161,7 +172,7 @@ export async function sshSessionOpen(
       fail(new Error(`SSH session open timed out after ${timeout_ms}ms`));
     }, timeout_ms);
 
-    term.onData((data: string) => {
+    openDataDisposable = term.onData((data: string) => {
       if (settled) return;
       outputBuffer += data;
 
@@ -186,7 +197,7 @@ export async function sshSessionOpen(
       }
     });
 
-    term.onExit(({ exitCode }: { exitCode: number }) => {
+    openExitDisposable = term.onExit(({ exitCode }: { exitCode: number }) => {
       fail(new Error(`SSH process exited unexpectedly with code ${exitCode}`));
     });
   });

--- a/src/tools/ssh-session-open.ts
+++ b/src/tools/ssh-session-open.ts
@@ -40,6 +40,7 @@ export async function sshSessionOpen(
     credential_backend,
     platform = 'auto',
     timeout_ms = 30_000,
+    idle_timeout_ms,
   } = input;
 
   if (!host) throw new Error('host is required');
@@ -134,6 +135,9 @@ export async function sshSessionOpen(
         username: resolvedUsername,
         platform,
         outputBuffer: '',
+        idleTimeoutMs: idle_timeout_ms,
+        inFlight: false,
+        disposables: [],
       });
 
       resolve({
@@ -158,6 +162,7 @@ export async function sshSessionOpen(
     }, timeout_ms);
 
     term.onData((data: string) => {
+      if (settled) return;
       outputBuffer += data;
 
       // Handle password prompt
@@ -171,6 +176,7 @@ export async function sshSessionOpen(
           return;
         }
         term.write(passwordBuffer.toString('utf-8') + '\r');
+        passwordBuffer.fill(0);
         return;
       }
 

--- a/src/tools/ssh-session-open.ts
+++ b/src/tools/ssh-session-open.ts
@@ -150,6 +150,14 @@ export async function sshSessionOpen(
         disposables: [],
       });
 
+      // Register a persistent onExit handler so unexpected PTY death
+      // auto-removes the session from the store instead of leaving a zombie.
+      const persistentExitDisposable = term.onExit(() => {
+        sessionStore.delete(sessionId);
+      });
+      const stored = sessionStore.get(sessionId);
+      if (stored) stored.disposables.push(persistentExitDisposable);
+
       resolve({
         session_id: sessionId,
         host,

--- a/test/unit/output-scrubber.test.ts
+++ b/test/unit/output-scrubber.test.ts
@@ -52,6 +52,14 @@ describe("scrubOutput", () => {
     expect(result).toContain("show version");
   });
 
+  it("removes VT-style CSI sequences ending with tilde (e.g. ESC[1~)", () => {
+    const input = "\x1B[1~switch01# show run\x1B[4~";
+    const result = scrubOutput(input);
+    expect(result).not.toContain("\x1B[");
+    expect(result).toContain("switch01#");
+    expect(result).toContain("show run");
+  });
+
   it("handles empty input", () => {
     expect(scrubOutput("")).toBe("");
   });

--- a/test/unit/output-scrubber.test.ts
+++ b/test/unit/output-scrubber.test.ts
@@ -44,6 +44,14 @@ describe("scrubOutput", () => {
     expect(result).toContain("secret sauce recipe: unavailable");
   });
 
+  it("removes DEC private mode CSI sequences (e.g. bracketed-paste)", () => {
+    const input = "\x1B[?2004hswitch01# show version\x1B[?2004l";
+    const result = scrubOutput(input);
+    expect(result).not.toContain("\x1B[?");
+    expect(result).toContain("switch01#");
+    expect(result).toContain("show version");
+  });
+
   it("handles empty input", () => {
     expect(scrubOutput("")).toBe("");
   });

--- a/test/unit/session-store.test.ts
+++ b/test/unit/session-store.test.ts
@@ -33,6 +33,8 @@ function makeSession(overrides: Partial<ManagedSession> = {}): ManagedSession {
     username: 'testuser',
     platform: 'linux',
     outputBuffer: '',
+    inFlight: false,
+    disposables: [],
     ...overrides,
   };
 }
@@ -93,6 +95,29 @@ describe('SessionStore', () => {
       (store as unknown as { evictIdle: () => void }).evictIdle();
 
       expect(store.get(session.id)).toBe(session);
+    });
+
+    it('uses per-session idleTimeoutMs when set', () => {
+      const fastStore = new SessionStore(100); // 100ms default
+      // Session has a long per-session timeout — should NOT be evicted
+      const session = makeSession({ lastActivity: Date.now() - 200, idleTimeoutMs: 60_000 });
+      fastStore.add(session);
+
+      (fastStore as unknown as { evictIdle: () => void }).evictIdle();
+
+      expect(fastStore.get(session.id)).toBe(session);
+      fastStore.destroy();
+    });
+
+    it('does not evict a session with inFlight=true', () => {
+      const fastStore = new SessionStore(100);
+      const session = makeSession({ lastActivity: Date.now() - 200, inFlight: true });
+      fastStore.add(session);
+
+      (fastStore as unknown as { evictIdle: () => void }).evictIdle();
+
+      expect(fastStore.get(session.id)).toBe(session);
+      fastStore.destroy();
     });
   });
 

--- a/test/unit/session-store.test.ts
+++ b/test/unit/session-store.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for SessionStore
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { IPty } from 'node-pty';
+import type { ManagedSession } from '../../src/ssh/session-store.js';
+import { SessionStore } from '../../src/ssh/session-store.js';
+
+function makeFakePty(): IPty {
+  return {
+    kill: vi.fn(),
+    write: vi.fn(),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    pid: 1,
+    cols: 80,
+    rows: 24,
+    process: 'ssh',
+    handleFlowControl: false,
+    resize: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+  } as unknown as IPty;
+}
+
+function makeSession(overrides: Partial<ManagedSession> = {}): ManagedSession {
+  return {
+    id: crypto.randomUUID(),
+    ptyProcess: makeFakePty(),
+    lastActivity: Date.now(),
+    host: 'test-host',
+    username: 'testuser',
+    platform: 'linux',
+    outputBuffer: '',
+    ...overrides,
+  };
+}
+
+describe('SessionStore', () => {
+  let store: SessionStore;
+
+  beforeEach(() => {
+    store = new SessionStore(5 * 60 * 1000);
+  });
+
+  afterEach(() => {
+    store.destroy();
+  });
+
+  describe('add / get / delete', () => {
+    it('adds and retrieves a session', () => {
+      const session = makeSession();
+      store.add(session);
+      expect(store.get(session.id)).toBe(session);
+    });
+
+    it('returns undefined for unknown session id', () => {
+      expect(store.get(crypto.randomUUID())).toBeUndefined();
+    });
+
+    it('deletes a session and returns true', () => {
+      const session = makeSession();
+      store.add(session);
+      expect(store.delete(session.id)).toBe(true);
+      expect(store.get(session.id)).toBeUndefined();
+    });
+
+    it('returns false when deleting unknown session', () => {
+      expect(store.delete(crypto.randomUUID())).toBe(false);
+    });
+  });
+
+  describe('evictIdle', () => {
+    it('evicts sessions that have been idle past the timeout', async () => {
+      // Use a very short timeout store for eviction testing
+      const fastStore = new SessionStore(100); // 100ms idle timeout
+      const session = makeSession({ lastActivity: Date.now() - 200 }); // already stale
+      fastStore.add(session);
+
+      // Access private method via bracket notation for testing
+      (fastStore as unknown as { evictIdle: () => void }).evictIdle();
+
+      expect(fastStore.get(session.id)).toBeUndefined();
+      expect(session.ptyProcess.kill).toHaveBeenCalled();
+      fastStore.destroy();
+    });
+
+    it('keeps sessions that are still within the timeout window', () => {
+      const session = makeSession({ lastActivity: Date.now() }); // fresh
+      store.add(session);
+
+      (store as unknown as { evictIdle: () => void }).evictIdle();
+
+      expect(store.get(session.id)).toBe(session);
+    });
+  });
+
+  describe('destroy', () => {
+    it('kills all sessions and clears the store', () => {
+      const s1 = makeSession();
+      const s2 = makeSession();
+      store.add(s1);
+      store.add(s2);
+
+      store.destroy();
+
+      expect(s1.ptyProcess.kill).toHaveBeenCalled();
+      expect(s2.ptyProcess.kill).toHaveBeenCalled();
+      expect(store.get(s1.id)).toBeUndefined();
+      expect(store.get(s2.id)).toBeUndefined();
+    });
+  });
+});

--- a/test/unit/ssh-session-execute.test.ts
+++ b/test/unit/ssh-session-execute.test.ts
@@ -75,7 +75,7 @@ describe('sshSessionExecute', () => {
     expect(result.session_id).toBe(session.id);
     expect(result.output).toContain('Linux test-host');
     expect(result.exit_code).toBeNull();
-    expect(pty.write).toHaveBeenCalledWith('uname -a\n');
+    expect(pty.write).toHaveBeenCalledWith('uname -a\r');
     store.destroy();
   });
 

--- a/test/unit/ssh-session-execute.test.ts
+++ b/test/unit/ssh-session-execute.test.ts
@@ -205,7 +205,7 @@ describe('sshSessionClose', () => {
     const result = await sshSessionClose(store, { session_id: session.id });
 
     expect(result.message).toBe('Session closed');
-    expect(pty.write).toHaveBeenCalledWith('exit\n');
+    expect(pty.write).toHaveBeenCalledWith('exit\r');
     expect(pty.kill).toHaveBeenCalled();
     expect(store.get(session.id)).toBeUndefined();
     store.destroy();

--- a/test/unit/ssh-session-execute.test.ts
+++ b/test/unit/ssh-session-execute.test.ts
@@ -24,7 +24,10 @@ function makeFakePty(): IPty & { _triggerData: (d: string) => void; _triggerExit
       }) };
       return disposable;
     },
-    onExit(cb: (ev: { exitCode: number }) => void) { onExitCb = cb; },
+    onExit(cb: (ev: { exitCode: number }) => void) {
+      onExitCb = cb;
+      return { dispose: vi.fn(() => { onExitCb = null; }) };
+    },
     _triggerData(d: string) { for (const cb of [...onDataCbs]) cb(d); },
     _triggerExit(code: number) { onExitCb?.({ exitCode: code }); },
     pid: 1234,

--- a/test/unit/ssh-session-execute.test.ts
+++ b/test/unit/ssh-session-execute.test.ts
@@ -10,15 +10,22 @@ import { sshSessionExecute } from '../../src/tools/ssh-session-execute.js';
 import { sshSessionClose } from '../../src/tools/ssh-session-close.js';
 
 function makeFakePty(): IPty & { _triggerData: (d: string) => void; _triggerExit: (code: number) => void; write: ReturnType<typeof vi.fn>; kill: ReturnType<typeof vi.fn> } {
-  let onDataCb: ((d: string) => void) | null = null;
+  const onDataCbs: ((d: string) => void)[] = [];
   let onExitCb: ((ev: { exitCode: number }) => void) | null = null;
 
   const fakePty = {
     write: vi.fn(),
     kill: vi.fn(),
-    onData(cb: (d: string) => void) { onDataCb = cb; },
+    onData(cb: (d: string) => void) {
+      onDataCbs.push(cb);
+      const disposable = { dispose: vi.fn(() => {
+        const idx = onDataCbs.indexOf(cb);
+        if (idx !== -1) onDataCbs.splice(idx, 1);
+      }) };
+      return disposable;
+    },
     onExit(cb: (ev: { exitCode: number }) => void) { onExitCb = cb; },
-    _triggerData(d: string) { onDataCb?.(d); },
+    _triggerData(d: string) { for (const cb of [...onDataCbs]) cb(d); },
     _triggerExit(code: number) { onExitCb?.({ exitCode: code }); },
     pid: 1234,
     cols: 220,
@@ -41,6 +48,8 @@ function makeSession(pty: IPty, overrides: Partial<ManagedSession> = {}): Manage
     username: 'testuser',
     platform: 'linux',
     outputBuffer: '',
+    inFlight: false,
+    disposables: [],
     ...overrides,
   };
 }
@@ -134,6 +143,54 @@ describe('sshSessionExecute', () => {
 
     await promise;
     expect(store.get(session.id)!.lastActivity).toBeGreaterThan(oldActivity);
+    store.destroy();
+  });
+
+  it('rejects concurrent execute on same session', async () => {
+    const store = new SessionStore();
+    const pty = makeFakePty();
+    const session = makeSession(pty);
+    store.add(session);
+
+    // Start first command (will not resolve because we don't send a prompt)
+    const first = sshSessionExecute(store, {
+      session_id: session.id,
+      command: 'sleep 10',
+      timeout_ms: 5000,
+    });
+
+    await new Promise(r => setTimeout(r, 0));
+
+    // Second concurrent call should be rejected
+    await expect(
+      sshSessionExecute(store, { session_id: session.id, command: 'echo hi' })
+    ).rejects.toThrow('A command is already running on this session');
+
+    // Now resolve the first command
+    pty._triggerData('testuser@test-host:~$ ');
+    await first;
+    store.destroy();
+  });
+
+  it('disposes onData listener after command completes', async () => {
+    const store = new SessionStore();
+    const pty = makeFakePty();
+    const session = makeSession(pty);
+    store.add(session);
+
+    const promise = sshSessionExecute(store, {
+      session_id: session.id,
+      command: 'ls',
+      timeout_ms: 5000,
+    });
+
+    await new Promise(r => setTimeout(r, 0));
+    pty._triggerData('testuser@test-host:~$ ');
+
+    await promise;
+    // disposables should be cleaned up
+    expect(session.disposables).toHaveLength(0);
+    expect(session.inFlight).toBe(false);
     store.destroy();
   });
 });

--- a/test/unit/ssh-session-execute.test.ts
+++ b/test/unit/ssh-session-execute.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit tests for ssh-session-execute and ssh-session-close (mocks node-pty)
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { IPty } from 'node-pty';
+import type { ManagedSession } from '../../src/ssh/session-store.js';
+import { SessionStore } from '../../src/ssh/session-store.js';
+import { sshSessionExecute } from '../../src/tools/ssh-session-execute.js';
+import { sshSessionClose } from '../../src/tools/ssh-session-close.js';
+
+function makeFakePty(): IPty & { _triggerData: (d: string) => void; _triggerExit: (code: number) => void; write: ReturnType<typeof vi.fn>; kill: ReturnType<typeof vi.fn> } {
+  let onDataCb: ((d: string) => void) | null = null;
+  let onExitCb: ((ev: { exitCode: number }) => void) | null = null;
+
+  const fakePty = {
+    write: vi.fn(),
+    kill: vi.fn(),
+    onData(cb: (d: string) => void) { onDataCb = cb; },
+    onExit(cb: (ev: { exitCode: number }) => void) { onExitCb = cb; },
+    _triggerData(d: string) { onDataCb?.(d); },
+    _triggerExit(code: number) { onExitCb?.({ exitCode: code }); },
+    pid: 1234,
+    cols: 220,
+    rows: 24,
+    process: 'ssh',
+    handleFlowControl: false,
+    resize: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+  };
+  return fakePty as unknown as typeof fakePty;
+}
+
+function makeSession(pty: IPty, overrides: Partial<ManagedSession> = {}): ManagedSession {
+  return {
+    id: crypto.randomUUID(),
+    ptyProcess: pty,
+    lastActivity: Date.now(),
+    host: 'test-host',
+    username: 'testuser',
+    platform: 'linux',
+    outputBuffer: '',
+    ...overrides,
+  };
+}
+
+describe('sshSessionExecute', () => {
+  it('writes command to PTY and returns scrubbed output', async () => {
+    const store = new SessionStore();
+    const pty = makeFakePty();
+    const session = makeSession(pty);
+    store.add(session);
+
+    const promise = sshSessionExecute(store, {
+      session_id: session.id,
+      command: 'uname -a',
+      timeout_ms: 5000,
+    });
+
+    // Simulate PTY emitting command output then prompt
+    await new Promise(r => setTimeout(r, 0));
+    pty._triggerData('Linux test-host 5.15.0\r\ntestuser@test-host:~$ ');
+
+    const result = await promise;
+    expect(result.session_id).toBe(session.id);
+    expect(result.output).toContain('Linux test-host');
+    expect(result.exit_code).toBeNull();
+    expect(pty.write).toHaveBeenCalledWith('uname -a\n');
+    store.destroy();
+  });
+
+  it('strips ANSI escape codes from output', async () => {
+    const store = new SessionStore();
+    const pty = makeFakePty();
+    const session = makeSession(pty);
+    store.add(session);
+
+    const promise = sshSessionExecute(store, {
+      session_id: session.id,
+      command: 'ls',
+      timeout_ms: 5000,
+    });
+
+    await new Promise(r => setTimeout(r, 0));
+    pty._triggerData('\x1B[32mfile.txt\x1B[0m\r\ntestuser@test-host:~$ ');
+
+    const result = await promise;
+    expect(result.output).not.toContain('\x1B[');
+    expect(result.output).toContain('file.txt');
+    store.destroy();
+  });
+
+  it('throws "Session not found or expired" for unknown session_id', async () => {
+    const store = new SessionStore();
+    await expect(
+      sshSessionExecute(store, { session_id: crypto.randomUUID(), command: 'echo hi' })
+    ).rejects.toThrow('Session not found or expired');
+    store.destroy();
+  });
+
+  it('rejects on timeout', async () => {
+    const store = new SessionStore();
+    const pty = makeFakePty();
+    const session = makeSession(pty);
+    store.add(session);
+
+    const promise = sshSessionExecute(store, {
+      session_id: session.id,
+      command: 'sleep 60',
+      timeout_ms: 50,
+    });
+
+    // Never send a prompt — let it time out
+    await expect(promise).rejects.toThrow(/timed out/i);
+    store.destroy();
+  });
+
+  it('updates lastActivity timestamp', async () => {
+    const store = new SessionStore();
+    const pty = makeFakePty();
+    const oldActivity = Date.now() - 10_000;
+    const session = makeSession(pty, { lastActivity: oldActivity });
+    store.add(session);
+
+    const promise = sshSessionExecute(store, {
+      session_id: session.id,
+      command: 'date',
+      timeout_ms: 5000,
+    });
+
+    await new Promise(r => setTimeout(r, 0));
+    pty._triggerData('testuser@test-host:~$ ');
+
+    await promise;
+    expect(store.get(session.id)!.lastActivity).toBeGreaterThan(oldActivity);
+    store.destroy();
+  });
+});
+
+describe('sshSessionClose', () => {
+  it('writes exit and kills PTY then removes from store', async () => {
+    const store = new SessionStore();
+    const pty = makeFakePty();
+    const session = makeSession(pty);
+    store.add(session);
+
+    const result = await sshSessionClose(store, { session_id: session.id });
+
+    expect(result.message).toBe('Session closed');
+    expect(pty.write).toHaveBeenCalledWith('exit\n');
+    expect(pty.kill).toHaveBeenCalled();
+    expect(store.get(session.id)).toBeUndefined();
+    store.destroy();
+  });
+
+  it('throws "Session not found or expired" for unknown session_id', async () => {
+    const store = new SessionStore();
+    await expect(
+      sshSessionClose(store, { session_id: crypto.randomUUID() })
+    ).rejects.toThrow('Session not found or expired');
+    store.destroy();
+  });
+});

--- a/test/unit/ssh-session-open.test.ts
+++ b/test/unit/ssh-session-open.test.ts
@@ -7,8 +7,8 @@ import type { MockInstance } from 'vitest';
 
 // ---- node-pty mock -------------------------------------------------------
 interface FakePtyHandlers {
-  onData: (cb: (data: string) => void) => void;
-  onExit: (cb: (ev: { exitCode: number }) => void) => void;
+  onData: (cb: (data: string) => void) => { dispose: ReturnType<typeof vi.fn> };
+  onExit: (cb: (ev: { exitCode: number }) => void) => { dispose: ReturnType<typeof vi.fn> };
   write: MockInstance;
   kill: MockInstance;
 }
@@ -23,8 +23,8 @@ vi.mock('node-pty', () => {
   fakeWrite = vi.fn();
   fakeKill = vi.fn();
   spawnMock = vi.fn((): FakePtyHandlers => ({
-    onData: (cb) => { fakeOnData = cb; },
-    onExit: (cb) => { fakeOnExit = cb; },
+    onData: (cb) => { fakeOnData = cb; return { dispose: vi.fn(() => { fakeOnData = null; }) }; },
+    onExit: (cb) => { fakeOnExit = cb; return { dispose: vi.fn(() => { fakeOnExit = null; }) }; },
     write: fakeWrite,
     kill: fakeKill,
   }));

--- a/test/unit/ssh-session-open.test.ts
+++ b/test/unit/ssh-session-open.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for ssh-session-open (mocks node-pty)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { MockInstance } from 'vitest';
+
+// ---- node-pty mock -------------------------------------------------------
+interface FakePtyHandlers {
+  onData: (cb: (data: string) => void) => void;
+  onExit: (cb: (ev: { exitCode: number }) => void) => void;
+  write: MockInstance;
+  kill: MockInstance;
+}
+
+let fakeOnData: ((data: string) => void) | null = null;
+let fakeOnExit: ((ev: { exitCode: number }) => void) | null = null;
+let fakeWrite: MockInstance;
+let fakeKill: MockInstance;
+let spawnMock: MockInstance;
+
+vi.mock('node-pty', () => {
+  fakeWrite = vi.fn();
+  fakeKill = vi.fn();
+  spawnMock = vi.fn((): FakePtyHandlers => ({
+    onData: (cb) => { fakeOnData = cb; },
+    onExit: (cb) => { fakeOnExit = cb; },
+    write: fakeWrite,
+    kill: fakeKill,
+  }));
+  return { default: { spawn: spawnMock } };
+});
+// -------------------------------------------------------------------------
+
+import { SessionStore } from '../../src/ssh/session-store.js';
+import { sshSessionOpen } from '../../src/tools/ssh-session-open.js';
+import type { CredentialRegistry } from '../../src/credentials/registry.js';
+
+function makeRegistry(overrides: Partial<CredentialRegistry> = {}): CredentialRegistry {
+  return {
+    getBackend: vi.fn().mockReturnValue({
+      isAvailable: vi.fn().mockResolvedValue(true),
+      getCredential: vi.fn().mockResolvedValue({
+        username: 'testuser',
+        password: Buffer.from('testpass'),
+      }),
+      cleanup: vi.fn().mockResolvedValue(undefined),
+    }),
+    register: vi.fn(),
+    ...overrides,
+  } as unknown as CredentialRegistry;
+}
+
+beforeEach(() => {
+  fakeOnData = null;
+  fakeOnExit = null;
+  vi.clearAllMocks();
+});
+
+describe('sshSessionOpen', () => {
+  it('returns a session_id and adds session to store on successful connect', async () => {
+    const store = new SessionStore();
+    const registry = makeRegistry();
+
+    const promise = sshSessionOpen(registry, store, {
+      host: 'test-host',
+      username: 'eric',
+      platform: 'linux',
+      timeout_ms: 5000,
+    });
+
+    // Let dynamic import resolve
+    await new Promise(r => setTimeout(r, 0));
+
+    // Simulate shell prompt appearing
+    fakeOnData!('eric@test-host:~$ ');
+
+    const result = await promise;
+    expect(result.session_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+    expect(result.host).toBe('test-host');
+    expect(result.username).toBe('eric');
+    expect(result.message).toBe('Session opened successfully');
+
+    // Session should be in the store
+    expect(store.get(result.session_id)).toBeDefined();
+    store.destroy();
+  });
+
+  it('sends password when prompted and resolves on shell prompt', async () => {
+    const store = new SessionStore();
+    const registry = makeRegistry();
+
+    const promise = sshSessionOpen(registry, store, {
+      host: 'test-host',
+      credential_ref: 'my-cred',
+      credential_backend: 'bitwarden',
+      platform: 'linux',
+      timeout_ms: 5000,
+    });
+
+    await new Promise(r => setTimeout(r, 0));
+
+    // Simulate password prompt, then shell prompt
+    fakeOnData!('Password: ');
+    await new Promise(r => setTimeout(r, 10));
+    fakeOnData!('eric@test-host:~$ ');
+
+    const result = await promise;
+    expect(result.session_id).toBeDefined();
+    expect(fakeWrite).toHaveBeenCalledWith(expect.stringContaining('testpass'));
+    store.destroy();
+  });
+
+  it('rejects on timeout', async () => {
+    const store = new SessionStore();
+    const registry = makeRegistry();
+
+    const promise = sshSessionOpen(registry, store, {
+      host: 'test-host',
+      username: 'eric',
+      platform: 'linux',
+      timeout_ms: 50,
+    });
+
+    // Never send a prompt — let it time out
+    await expect(promise).rejects.toThrow(/timed out/i);
+    expect(fakeKill).toHaveBeenCalled();
+    store.destroy();
+  });
+
+  it('rejects with error when PTY exits before prompt', async () => {
+    const store = new SessionStore();
+    const registry = makeRegistry();
+
+    const promise = sshSessionOpen(registry, store, {
+      host: 'test-host',
+      username: 'eric',
+      platform: 'linux',
+      timeout_ms: 5000,
+    });
+
+    await new Promise(r => setTimeout(r, 0));
+
+    // PTY exits before we see a prompt
+    fakeOnExit!({ exitCode: 255 });
+
+    await expect(promise).rejects.toThrow(/exited unexpectedly/i);
+    store.destroy();
+  });
+});


### PR DESCRIPTION
## Summary

Implements #11 — persistent SSH session management via 3 new MCP tools.

## New Tools

| Tool | Description |
|------|-------------|
| `ssh_session_open` | Open an interactive SSH shell; returns `session_id` |
| `ssh_session_execute` | Run a command in an existing session; waits for prompt |
| `ssh_session_close` | Gracefully close a session |

## Architecture

- **`src/ssh/session-store.ts`** — `SessionStore` class with in-memory Map, idle eviction timer (configurable, default 5 min), and `destroy()` for graceful shutdown
- **`src/tools/ssh-session-open.ts`** — resolves credentials, spawns interactive PTY (`ssh -tt`), waits for initial shell prompt, stores session
- **`src/tools/ssh-session-execute.ts`** — writes command, waits for next prompt, scrubs output
- **`src/tools/ssh-session-close.ts`** — sends `exit`, kills PTY, removes from store

## Security

- Session IDs are `crypto.randomUUID()` — never logged, never in error messages
- Passwords as `Buffer`, zero-filled immediately after PTY handshake
- Env allowlist matches `pty-manager.ts` — no full `process.env` leak
- Dynamic import for `node-pty` (same pattern as existing tools, enables mocking)

## Output Scrubber Improvement

Extended `scrubOutput()` to also strip DEC private mode sequences (e.g. bracketed-paste `ESC[?2004h/l`). These appeared in real E2E output on Ubuntu hosts.

## README

Added comprehensive `## Persistent SSH Sessions` section with:
- When to use sessions vs `ssh_execute`
- Session lifecycle diagram
- Auto-expiry behavior
- Security notes
- Multi-step workflow examples (Linux server + NX-OS config workflow)

## Tests

| Suite | Tests |
|-------|-------|
| `session-store.test.ts` | 7 (add/get/delete, idle eviction, destroy) |
| `ssh-session-open.test.ts` | 4 (happy path, password prompt, timeout, early exit) |
| `ssh-session-execute.test.ts` | 5 (output, ANSI scrub, not-found, timeout, lastActivity update) |
| `ssh-session-close.test.ts` | 2 (happy path, not-found) — in same file |
| **Total new** | **18** |
| **All tests** | **130 ✅** |

## E2E Validation (real Bitwarden + real SSH to surface-aac-1.local)

```
✅ ssh_session_open  → session_id: e663e98b-2873-43a4-bd28-1c656132ccc6
✅ ssh_session_execute (uname -a) → Linux surface-aac-1 6.18.7-surface-1 #1 SMP ...
✅ ssh_session_execute (hostname) → surface-aac-1
✅ ssh_session_close → {"message": "Session closed"}
✅ execute after close → isError: true ("Session not found or expired")
```

## Quality Gates

```
npm run lint   → 0 errors (7 pre-existing warnings in smoke test)
npm run build  → tsc clean
npm test       → 130/130 passed
```