### PR TITLE
feat: add Azure Key Vault integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
           cache: npm
 
       - name: Azure Login (OIDC)
-        uses: azure/login@a457da9ea143b4060f3ec7de2bc94f69e1e0e403 # v2
+        uses: azure/login@8c334a195cbb38e46038007b304988d888bf676a # v2.0.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,43 @@
+name: Integration Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  id-token: write   # Required for OIDC
+  contents: read
+
+jobs:
+  azure-kv-integration:
+    name: Azure Key Vault Integration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Azure Login (OIDC)
+        uses: azure/login@a457da9ea143b4060f3ec7de2bc94f69e1e0e403 # v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run Azure KV integration tests
+        env:
+          AZURE_KV_ENABLED: 'true'
+          AZURE_KV_NAME: ${{ secrets.AZURE_KV_NAME }}
+        run: npx vitest run test/integration/azure-keyvault.integration.test.ts

--- a/README.md
+++ b/README.md
@@ -140,6 +140,43 @@ npm run build
 npm test
 ```
 
+## Integration Tests
+
+Integration tests run against live Azure resources and require the `az` CLI to be authenticated.
+
+### Run locally
+
+```bash
+# Authenticate first (SP login or az login)
+bash ~/.config/azure/sp-login.sh   # service principal
+# or
+az login
+
+# Run Azure Key Vault integration tests
+AZURE_KV_ENABLED=true AZURE_KV_NAME=rg-ut-bw npx vitest run test/integration/
+```
+
+The SSH end-to-end test also requires `SSH_E2E_ENABLED=true` and `surface-aac-1.local` to be reachable:
+
+```bash
+AZURE_KV_ENABLED=true SSH_E2E_ENABLED=true AZURE_KV_NAME=rg-ut-bw npx vitest run test/integration/mcp-azure-keyvault.integration.test.ts
+```
+
+### GitHub Actions
+
+The `.github/workflows/integration.yml` workflow runs the Azure KV integration test automatically on push and pull request using **OIDC authentication** — no long-lived secrets or credentials to rotate.
+
+Required repository secrets:
+
+| Secret | Description |
+|---|---|
+| `AZURE_CLIENT_ID` | OIDC app registration client ID |
+| `AZURE_TENANT_ID` | Azure AD tenant ID |
+| `AZURE_SUBSCRIPTION_ID` | Azure subscription ID |
+| `AZURE_KV_NAME` | Key vault name (e.g. `rg-ut-bw`) |
+
+> **Note:** The SSH E2E test is excluded from CI — `surface-aac-1.local` is not reachable from GitHub runners. Run it locally.
+
 ## License
 
 MIT

--- a/test/integration/azure-keyvault.integration.test.ts
+++ b/test/integration/azure-keyvault.integration.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Live integration test for AzureKeyVaultBackend.
+ *
+ * Requires:
+ *   - AZURE_KV_ENABLED=true
+ *   - az CLI authenticated (az login or SP via ~/.config/azure/sp-login.sh)
+ *   - AZURE_KV_NAME env var (defaults to 'rg-ut-bw')
+ *   - Secret 'surface-aac-1' in the vault with JSON {"username":"eric","password":"..."}
+ *
+ * Run locally:
+ *   AZURE_KV_ENABLED=true AZURE_KV_NAME=rg-ut-bw npx vitest run test/integration/azure-keyvault.integration.test.ts
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { AzureKeyVaultBackend } from '../../src/credentials/azure-keyvault.js';
+
+const SKIP = process.env.AZURE_KV_ENABLED !== 'true';
+const KV_NAME = process.env.AZURE_KV_NAME ?? 'rg-ut-bw';
+const SECRET_REF = `${KV_NAME}/surface-aac-1`;
+
+describe.skipIf(SKIP)('AzureKeyVaultBackend — live integration', () => {
+  let backend: AzureKeyVaultBackend;
+
+  beforeAll(() => {
+    backend = new AzureKeyVaultBackend();
+  });
+
+  it('isAvailable() returns true when az CLI is authenticated', async () => {
+    const available = await backend.isAvailable();
+    expect(available).toBe(true);
+  });
+
+  it('getCredential() retrieves username and password from vault', async () => {
+    const cred = await backend.getCredential(SECRET_REF);
+    expect(cred.username).toBe('eric');
+    expect(cred.password).toBeInstanceOf(Buffer);
+    expect(cred.password.length).toBeGreaterThan(0);
+    // Zero-fill after test
+    cred.password.fill(0);
+    await backend.cleanup();
+  });
+
+  it('getMetadata() returns has_password: true for existing secret', async () => {
+    const meta = await backend.getMetadata(SECRET_REF);
+    expect(meta.has_password).toBe(true);
+    expect(meta.backend).toBe('azure-keyvault');
+  });
+
+  it('getCredential() throws for non-existent secret', async () => {
+    await expect(backend.getCredential(`${KV_NAME}/does-not-exist-xyz`))
+      .rejects.toThrow();
+    await backend.cleanup();
+  });
+});

--- a/test/integration/mcp-azure-keyvault.integration.test.ts
+++ b/test/integration/mcp-azure-keyvault.integration.test.ts
@@ -1,0 +1,172 @@
+/**
+ * End-to-end MCP integration test: packaged server + Azure Key Vault + real SSH.
+ *
+ * Requires:
+ *   - AZURE_KV_ENABLED=true
+ *   - SSH_E2E_ENABLED=true
+ *   - az CLI authenticated
+ *   - surface-aac-1.local reachable via SSH (local network only)
+ *
+ * NOTE: This test is intentionally excluded from CI (surface-aac-1.local is not
+ * reachable from GitHub runners). Run locally only.
+ *
+ * Run locally:
+ *   AZURE_KV_ENABLED=true SSH_E2E_ENABLED=true npx vitest run test/integration/mcp-azure-keyvault.integration.test.ts
+ */
+
+import { describe, it, expect, afterAll } from 'vitest';
+import { execSync, spawn, ChildProcess } from 'child_process';
+import { mkdtempSync, rmSync } from 'fs';
+import { resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { tmpdir } from 'os';
+
+const SKIP_KV = process.env.AZURE_KV_ENABLED !== 'true';
+const SKIP_SSH = process.env.SSH_E2E_ENABLED !== 'true';
+const SKIP = SKIP_KV || SKIP_SSH;
+
+const REPO_ROOT = resolve(fileURLToPath(new URL('.', import.meta.url)), '../..');
+
+/**
+ * Send JSON-RPC messages to the MCP server via stdin and collect stdout responses.
+ * Uses a long-lived server process for the E2E test.
+ */
+function sendMcpMessages(serverPath: string, messages: object[], timeoutMs = 60_000): Promise<object[]> {
+  return new Promise((resolve, reject) => {
+    const proc: ChildProcess = spawn('node', [serverPath], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env },
+    });
+
+    let stdout = '';
+
+    proc.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+
+    proc.stderr?.on('data', (_chunk: Buffer) => {
+      // Suppress server stderr in test output
+    });
+
+    proc.on('error', reject);
+
+    // Set up timeout before registering close handler so it is always defined
+    const timer = setTimeout(() => {
+      proc.kill('SIGTERM');
+      reject(new Error(`MCP server timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    proc.on('close', () => {
+      clearTimeout(timer);
+      try {
+        const lines = stdout
+          .split('\n')
+          .filter(l => l.trim().length > 0)
+          .map(l => JSON.parse(l));
+        resolve(lines);
+      } catch (parseErr) {
+        reject(new Error(`Failed to parse MCP responses: ${parseErr}\nRaw stdout: ${stdout}`));
+      }
+    });
+
+    // Write all messages then close stdin so the server exits cleanly
+    const input = messages.map(m => JSON.stringify(m)).join('\n') + '\n';
+    proc.stdin?.write(input);
+    proc.stdin?.end();
+  });
+}
+
+describe.skipIf(SKIP)('MCP + Azure Key Vault + SSH E2E', { timeout: 60_000 }, () => {
+  let tmpDir: string;
+  let serverPath: string;
+
+  // Pack and install the tarball in a temp dir once for all tests
+  // (vitest doesn't support beforeAll returning a value we can use for path,
+  //  so we do it synchronously at describe scope)
+  try {
+    if (!SKIP) {
+      tmpDir = mkdtempSync(resolve(tmpdir(), 'mcp-e2e-'));
+
+      // Pack the tarball from repo root
+      const packOutput = execSync('npm pack --json', {
+        cwd: REPO_ROOT,
+        encoding: 'utf-8',
+      });
+      const tarball = JSON.parse(packOutput)[0].filename;
+      const tarballPath = resolve(REPO_ROOT, tarball);
+
+      // Install into temp dir
+      execSync(`npm install --prefix ${tmpDir} ${tarballPath}`, { encoding: 'utf-8' });
+
+      // Server entrypoint inside the installed package
+      serverPath = resolve(tmpDir, 'node_modules/ai-ssh-toolkit/dist/index.js');
+    }
+  } catch {
+    // If pack/install fails, tests will fail at runtime — that's correct behavior
+  }
+
+  afterAll(() => {
+    if (tmpDir) {
+      try {
+        rmSync(tmpDir, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup
+      }
+    }
+    // Clean up tarball left in repo root
+    try {
+      execSync('rm -f *.tgz', { cwd: REPO_ROOT });
+    } catch {
+      // Ignore
+    }
+  });
+
+  it('ssh_execute via azure-keyvault backend returns exit_code 0 and hostname output', async () => {
+    const responses = await sendMcpMessages(serverPath!, [
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'e2e-test', version: '1.0' },
+        },
+      },
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'notifications/initialized',
+      },
+      {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'ssh_execute',
+          arguments: {
+            host: 'surface-aac-1.local',
+            command: 'hostname',
+            credential_backend: 'azure-keyvault',
+            credential_ref: 'rg-ut-bw/surface-aac-1',
+          },
+        },
+      },
+    ], 60_000);
+
+    const toolResponse = responses.find((r: any) => r.id === 3) as any;
+    expect(toolResponse).toBeDefined();
+    expect(toolResponse.result).toBeDefined();
+
+    const resultText: string = toolResponse.result.content?.[0]?.text ?? '';
+    let parsed: any;
+    try {
+      parsed = JSON.parse(resultText);
+    } catch {
+      throw new Error(`Expected JSON result from ssh_execute, got: ${resultText}`);
+    }
+
+    expect(parsed.exit_code).toBe(0);
+    expect(parsed.stdout ?? parsed.output ?? '').toContain('surface-aac-1');
+  });
+});

--- a/test/integration/mcp-azure-keyvault.integration.test.ts
+++ b/test/integration/mcp-azure-keyvault.integration.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, expect, afterAll } from 'vitest';
-import { execSync, spawn, ChildProcess } from 'child_process';
+import { execSync, spawnSync, spawn, ChildProcess } from 'child_process';
 import { mkdtempSync, rmSync } from 'fs';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
@@ -95,8 +95,11 @@ describe.skipIf(SKIP)('MCP + Azure Key Vault + SSH E2E', { timeout: 60_000 }, ()
       const tarball = JSON.parse(packOutput)[0].filename;
       const tarballPath = resolve(REPO_ROOT, tarball);
 
-      // Install into temp dir
-      execSync(`npm install --prefix ${tmpDir} ${tarballPath}`, { encoding: 'utf-8' });
+      // Install into temp dir — use spawnSync with arg array to avoid shell injection (CodeQL)
+      spawnSync('npm', ['install', '--prefix', tmpDir, tarballPath], {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+      });
 
       // Server entrypoint inside the installed package
       serverPath = resolve(tmpDir, 'node_modules/ai-ssh-toolkit/dist/index.js');


### PR DESCRIPTION
## Summary

Adds live integration tests and a CI workflow for the Azure Key Vault credential backend.

## What's added

### `test/integration/azure-keyvault.integration.test.ts`
Vitest integration tests against the real `AzureKeyVaultBackend`:
- `isAvailable()` — asserts az CLI is authenticated
- `getCredential()` — retrieves username + password Buffer from vault; zero-fills after
- `getMetadata()` — asserts `has_password: true` and correct backend name
- `getCredential()` on non-existent secret — asserts rejection

All tests skip unless `AZURE_KV_ENABLED=true` is set.

### `test/integration/mcp-azure-keyvault.integration.test.ts`
End-to-end test: packs the npm artifact, installs it in a temp dir, spawns the real MCP server, calls `ssh_execute` via Azure KV credentials against `surface-aac-1.local`, and asserts `exit_code: 0` + hostname in output.

Skips unless `AZURE_KV_ENABLED=true` AND `SSH_E2E_ENABLED=true`. **Excluded from CI** — `surface-aac-1.local` is not reachable from GitHub runners.

### `.github/workflows/integration.yml`
New CI workflow:
- Triggers on push/PR to main and `workflow_dispatch`
- Uses OIDC authentication (no long-lived secrets)
- Pinned action SHAs matching `ci.yml`
- Uses `azure/login@a457da9ea143b4060f3ec7de2bc94f69e1e0e403` (v2)

### `README.md`
New **Integration Tests** section explaining local and CI run instructions.

## Quality gates

| Check | Result |
|-------|--------|
| `npm run lint` | ✅ 0 errors |
| `npm run build` | ✅ tsc clean |
| `npm test` | ✅ 112 pass, 5 skipped (integration skipped without env var) |
| Live integration test | ✅ 4/4 pass against `rg-ut-bw` vault |

## Local run
```bash
bash ~/.config/azure/sp-login.sh
AZURE_KV_ENABLED=true AZURE_KV_NAME=rg-ut-bw npx vitest run test/integration/azure-keyvault.integration.test.ts
```