### PR TITLE
fix: decode base64 payload from Google Secret Manager response

### DIFF
--- a/src/credentials/google-secret-manager.ts
+++ b/src/credentials/google-secret-manager.ts
@@ -112,7 +112,8 @@ export class GoogleSecretManagerBackend implements CredentialBackend {
     const gcloud = await this.resolveGcloud();
     const { project, secretName, version } = this.parseRef(ref);
 
-    // Retrieve password — captured to string temporarily, then moved to Buffer
+    // Retrieve password — use --format get(payload.data) which returns base64-encoded bytes.
+    // Decode from base64 into a Buffer immediately; never assign the decoded value to a string.
     const { stdout: passwordRaw } = await execFileAsync(
       gcloud,
       [
@@ -124,8 +125,8 @@ export class GoogleSecretManagerBackend implements CredentialBackend {
       { env: { ...process.env } }
     );
 
-    // Convert to Buffer immediately, wipe the string reference
-    const password = Buffer.from(passwordRaw.trim());
+    // payload.data is base64-encoded — decode directly into Buffer
+    const password = Buffer.from(passwordRaw.trim(), 'base64');
 
     // Username: derive from secret name convention "name-username" suffix
     // or fall back to empty string (caller should supply username separately)
@@ -150,10 +151,12 @@ export class GoogleSecretManagerBackend implements CredentialBackend {
     try {
       const { stdout } = await execFileAsync(
         gcloud,
-        ['secrets', 'versions', 'access', 'latest', '--secret', usernameSecret, '--project', project],
+        ['secrets', 'versions', 'access', 'latest', '--secret', usernameSecret, '--project', project,
+         '--format', 'get(payload.data)'],
         { env: { ...process.env } }
       );
-      return stdout.trim();
+      // payload.data is base64-encoded
+      return Buffer.from(stdout.trim(), 'base64').toString('utf-8');
     } catch {
       return '';
     }

--- a/src/credentials/google-secret-manager.ts
+++ b/src/credentials/google-secret-manager.ts
@@ -145,13 +145,13 @@ export class GoogleSecretManagerBackend implements CredentialBackend {
     gcloud: string,
     project: string,
     secretName: string,
-    _version: string
+    version: string
   ): Promise<string> {
     const usernameSecret = `${secretName}-username`;
     try {
       const { stdout } = await execFileAsync(
         gcloud,
-        ['secrets', 'versions', 'access', 'latest', '--secret', usernameSecret, '--project', project,
+        ['secrets', 'versions', 'access', version, '--secret', usernameSecret, '--project', project,
          '--format', 'get(payload.data)'],
         { env: { ...process.env } }
       );

--- a/src/credentials/google-secret-manager.ts
+++ b/src/credentials/google-secret-manager.ts
@@ -148,18 +148,25 @@ export class GoogleSecretManagerBackend implements CredentialBackend {
     version: string
   ): Promise<string> {
     const usernameSecret = `${secretName}-username`;
-    try {
-      const { stdout } = await execFileAsync(
-        gcloud,
-        ['secrets', 'versions', 'access', version, '--secret', usernameSecret, '--project', project,
-         '--format', 'get(payload.data)'],
-        { env: { ...process.env } }
-      );
-      // payload.data is base64-encoded
-      return Buffer.from(stdout.trim(), 'base64').toString('utf-8');
-    } catch {
-      return '';
+    // Try the requested version first; fall back to 'latest' if not found.
+    // This handles the common case where username secrets don't have the same
+    // version history as password secrets.
+    const versionsToTry = version === 'latest' ? ['latest'] : [version, 'latest'];
+    for (const v of versionsToTry) {
+      try {
+        const { stdout } = await execFileAsync(
+          gcloud,
+          ['secrets', 'versions', 'access', v, '--secret', usernameSecret, '--project', project,
+           '--format', 'get(payload.data)'],
+          { env: { ...process.env } }
+        );
+        // payload.data is base64-encoded
+        return Buffer.from(stdout.trim(), 'base64').toString('utf-8');
+      } catch {
+        // try next version or fall through to ''
+      }
     }
+    return '';
   }
 
   async getMetadata(ref: string): Promise<CredentialMetadata> {

--- a/test/unit/google-secret-manager-backend.test.ts
+++ b/test/unit/google-secret-manager-backend.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for GoogleSecretManagerBackend
+ *
+ * Mocks the promisified execFile so no real gcloud CLI or GCP project is needed.
+ * Key focus: base64 decode of payload.data (the bug fixed in this PR).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// vi.hoisted ensures the mock fn is created before vi.mock factories run
+const mockExecFileAsync = vi.hoisted(() => vi.fn());
+
+vi.mock('child_process', () => ({ execFile: vi.fn() }));
+vi.mock('util', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('util')>();
+  return {
+    ...actual,
+    promisify: (_fn: unknown) => mockExecFileAsync,
+  };
+});
+
+import { GoogleSecretManagerBackend } from '../../src/credentials/google-secret-manager.js';
+
+// ---- mock helper ----------------------------------------------------------
+// The backend calls: execFileAsync(cmd, argv, opts?)
+// We match on argv (joined) to return the right stdout.
+
+function setupMock(map: Record<string, string | Error>) {
+  mockExecFileAsync.mockImplementation(
+    (_cmd: string, argv: string[], _opts?: object) => {
+      const key = argv.join(' ');
+      const entry = Object.entries(map).find(([k]) => key.includes(k));
+      if (entry) {
+        const val = entry[1];
+        if (val instanceof Error) return Promise.reject(val);
+        return Promise.resolve({ stdout: val, stderr: '' });
+      }
+      // default: which gcloud resolution
+      return Promise.resolve({ stdout: '/usr/bin/gcloud', stderr: '' });
+    },
+  );
+}
+// --------------------------------------------------------------------------
+
+describe('GoogleSecretManagerBackend', () => {
+  let backend: GoogleSecretManagerBackend;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    backend = new GoogleSecretManagerBackend();
+    delete process.env['GCLOUD_PROJECT'];
+    delete process.env['GOOGLE_CLOUD_PROJECT'];
+  });
+
+  afterEach(() => {
+    delete process.env['GCLOUD_PROJECT'];
+    delete process.env['GOOGLE_CLOUD_PROJECT'];
+  });
+
+  // ── isAvailable ──────────────────────────────────────────────────────────
+
+  describe('isAvailable', () => {
+    it('returns true when gcloud auth succeeds', async () => {
+      setupMock({ 'auth print-access-token': 'ya29.token' });
+      expect(await backend.isAvailable()).toBe(true);
+    });
+
+    it('returns false when gcloud auth fails', async () => {
+      mockExecFileAsync.mockRejectedValue(new Error('gcloud not found'));
+      expect(await backend.isAvailable()).toBe(false);
+    });
+  });
+
+  // ── getCredential - base64 decode ────────────────────────────────────────
+
+  describe('getCredential - base64 decode', () => {
+    it('decodes base64 password from payload.data', async () => {
+      const rawPassword = 'supersecret';
+      const b64Password = Buffer.from(rawPassword).toString('base64');
+
+      setupMock({
+        'versions access latest --secret my-secret --project my-project': b64Password,
+        'my-secret-username': new Error('not found'),
+      });
+
+      const result = await backend.getCredential('my-project/my-secret');
+
+      expect(result.password.toString('utf-8')).toBe(rawPassword);
+      expect(result.username).toBe('');
+    });
+
+    it('decodes base64 username from paired secret', async () => {
+      const rawPassword = 'mypassword';
+      const rawUsername = 'admin';
+      const b64Password = Buffer.from(rawPassword).toString('base64');
+      const b64Username = Buffer.from(rawUsername).toString('base64');
+
+      setupMock({
+        'versions access latest --secret my-creds --project proj': b64Password,
+        'my-creds-username': b64Username,
+      });
+
+      const result = await backend.getCredential('proj/my-creds');
+
+      expect(result.password.toString('utf-8')).toBe(rawPassword);
+      expect(result.username).toBe(rawUsername);
+    });
+
+    it('handles specific version in ref (project/secret/version)', async () => {
+      const b64 = Buffer.from('versioned-pass').toString('base64');
+
+      setupMock({
+        'versions access 3 --secret my-secret --project my-project': b64,
+        'my-secret-username': new Error('not found'),
+      });
+
+      const result = await backend.getCredential('my-project/my-secret/3');
+      expect(result.password.toString('utf-8')).toBe('versioned-pass');
+    });
+
+    it('returns a Buffer, not a raw base64 string', async () => {
+      const rawPassword = 'p@$$w0rd!';
+      const b64 = Buffer.from(rawPassword).toString('base64');
+
+      setupMock({
+        'versions access latest --secret s --project p': b64,
+        's-username': new Error('not found'),
+      });
+
+      const result = await backend.getCredential('p/s');
+      expect(Buffer.isBuffer(result.password)).toBe(true);
+      expect(result.password.toString('utf-8')).toBe(rawPassword);
+      // Must NOT be the raw base64 string
+      expect(result.password.toString('utf-8')).not.toBe(b64);
+    });
+  });
+
+  // ── parseRef / ref formats ───────────────────────────────────────────────
+
+  describe('parseRef / ref formats', () => {
+    it('throws if ref has no project and GCLOUD_PROJECT is not set', async () => {
+      setupMock({});
+      await expect(backend.getCredential('just-secret')).rejects.toThrow('GCLOUD_PROJECT');
+    });
+
+    it('uses GCLOUD_PROJECT env var for single-part ref', async () => {
+      process.env['GCLOUD_PROJECT'] = 'env-project';
+      const b64 = Buffer.from('envpass').toString('base64');
+
+      setupMock({
+        'versions access latest --secret just-secret --project env-project': b64,
+        'just-secret-username': new Error('not found'),
+      });
+
+      const result = await backend.getCredential('just-secret');
+      expect(result.password.toString('utf-8')).toBe('envpass');
+    });
+
+    it('uses GOOGLE_CLOUD_PROJECT env var as fallback', async () => {
+      process.env['GOOGLE_CLOUD_PROJECT'] = 'gcp-project';
+      const b64 = Buffer.from('gcppass').toString('base64');
+
+      setupMock({
+        'versions access latest --secret my-secret --project gcp-project': b64,
+        'my-secret-username': new Error('not found'),
+      });
+
+      const result = await backend.getCredential('my-secret');
+      expect(result.password.toString('utf-8')).toBe('gcppass');
+    });
+
+    it('throws for invalid ref with too many parts', async () => {
+      setupMock({});
+      await expect(backend.getCredential('a/b/c/d')).rejects.toThrow('Invalid Google Secret Manager reference');
+    });
+  });
+
+  // ── getMetadata ───────────────────────────────────────────────────────────
+
+  describe('getMetadata', () => {
+    it('returns metadata with has_password=true', async () => {
+      const b64Username = Buffer.from('eric').toString('base64');
+
+      setupMock({
+        'versions describe latest --secret my-secret --project my-project': 'state: ENABLED',
+        'my-secret-username': b64Username,
+      });
+
+      const meta = await backend.getMetadata('my-project/my-secret');
+      expect(meta.has_password).toBe(true);
+      expect(meta.backend).toBe('google-secret-manager');
+      expect(meta.username).toBe('eric');
+    });
+  });
+
+  // ── cleanup ───────────────────────────────────────────────────────────────
+
+  describe('cleanup', () => {
+    it('resolves without error', async () => {
+      await expect(backend.cleanup()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/test/unit/google-secret-manager-backend.test.ts
+++ b/test/unit/google-secret-manager-backend.test.ts
@@ -108,14 +108,17 @@ describe('GoogleSecretManagerBackend', () => {
 
     it('handles specific version in ref (project/secret/version)', async () => {
       const b64 = Buffer.from('versioned-pass').toString('base64');
+      const b64User = Buffer.from('versioned-user').toString('base64');
 
       setupMock({
         'versions access 3 --secret my-secret --project my-project': b64,
-        'my-secret-username': new Error('not found'),
+        // username secret should also be fetched with version 3, not latest
+        'versions access 3 --secret my-secret-username': b64User,
       });
 
       const result = await backend.getCredential('my-project/my-secret/3');
       expect(result.password.toString('utf-8')).toBe('versioned-pass');
+      expect(result.username).toBe('versioned-user');
     });
 
     it('returns a Buffer, not a raw base64 string', async () => {

--- a/test/unit/google-secret-manager-backend.test.ts
+++ b/test/unit/google-secret-manager-backend.test.ts
@@ -29,14 +29,18 @@ function setupMock(map: Record<string, string | Error>) {
   mockExecFileAsync.mockImplementation(
     (_cmd: string, argv: string[], _opts?: object) => {
       const key = argv.join(' ');
+      // 'which gcloud' resolution — always succeeds
+      if (_cmd === 'which') {
+        return Promise.resolve({ stdout: '/usr/bin/gcloud', stderr: '' });
+      }
       const entry = Object.entries(map).find(([k]) => key.includes(k));
       if (entry) {
         const val = entry[1];
         if (val instanceof Error) return Promise.reject(val);
         return Promise.resolve({ stdout: val, stderr: '' });
       }
-      // default: which gcloud resolution
-      return Promise.resolve({ stdout: '/usr/bin/gcloud', stderr: '' });
+      // Fail explicitly so unexpected calls surface in tests
+      return Promise.reject(new Error(`Unexpected execFileAsync call: ${_cmd} ${key}`));
     },
   );
 }


### PR DESCRIPTION
## Problem
The `gcloud secrets versions access --format 'get(payload.data)'` command returns **base64-encoded** bytes, not the raw secret value. The backend was calling `Buffer.from(raw.trim())` which created a Buffer of the base64 string — so the wrong value was being sent as the SSH password, causing `Permission denied` errors.

## Fix
Changed to `Buffer.from(raw.trim(), 'base64')` in both the password and username fetch paths.

## Found via
Live E2E testing: `ssh_execute` with `credential_backend: 'google-secret-manager'` against `homeiot-360121/surface-aac-1` was returning `Permission denied` despite correct credentials in the vault.

## Validation
- `npm run lint` ✅ (0 errors)
- `npm run build` ✅ (tsc clean)
- `npm test` ✅ (112/112 passed)
- **Live E2E**: `ssh_execute` via Google Secret Manager → surface-aac-1.local → real kernel output, exit_code 0 ✅