### PR TITLE
docs: document design decision — no command validation in ssh_execute

### DIFF
--- a/DESIGN-DECISIONS.md
+++ b/DESIGN-DECISIONS.md
@@ -12,7 +12,7 @@ This document records architectural and security design decisions for `ai-ssh-to
 
 ### Decision
 
-The `command` field in `ssh_execute` (and related tools) accepts any string with no allowlist, blocklist, or length restriction. This is intentional and will not change.
+The `command` field in `ssh_execute` (and related tools) accepts any non-empty string. The tool does not impose an allowlist, blocklist, or other content-based validation on commands; basic sanity checks such as rejecting empty input are still enforced. This is intentional and will not change.
 
 ### Rationale
 
@@ -28,18 +28,16 @@ Imposing a command allowlist or blocklist would:
 
 ### Security Contract
 
-The tool's security contract is narrowly scoped:
+The tool is designed to avoid exposing credentials used during tool-managed SSH authentication flows. Everything else is out of scope.
 
-> **Credentials used to establish the SSH session must never leak.** Everything else is out of scope.
-
-Concretely, the tool guarantees:
-- Passwords are stored as `Buffer` and zero-filled after every use — never as plain strings
+Concretely, the current implementation provides these protections:
+- Passwords are kept in memory as `Buffer` objects where practical, converted to a JS string only transiently at PTY write time (because `node-pty` requires strings), and the `Buffer` is zero-filled after every use
 - Credentials are never written to disk (no temp files)
-- Credentials are never passed as command-line arguments (use stdin piping)
-- PTY output is scrubbed to remove password echoes before returning to the MCP client
-- MCP responses never contain credential values
+- Password values are not placed in process arguments (`argv`)
+- PTY output receives best-effort scrubbing of common credential prompt patterns before returning to the MCP client — this is not a guarantee against arbitrary echoed secret content
+- MCP responses are intended not to include credentials supplied by the tool itself, but may still contain secrets printed by remote commands or remote hosts
 
-Command content, access control, and authorization are the responsibility of the operator and the infrastructure being accessed (e.g., SSH server ACLs, sudoers policy, network device privilege levels).
+Command content, access control, and authorization are the responsibility of the operator and the infrastructure being accessed (e.g., SSH server ACLs, sudoers policy, network device privilege levels). Operators must not run commands that print passwords, tokens, or private keys if they do not want those values returned to the MCP client.
 
 ### What This Means for Operators
 

--- a/DESIGN-DECISIONS.md
+++ b/DESIGN-DECISIONS.md
@@ -1,0 +1,81 @@
+# Design Decisions
+
+This document records architectural and security design decisions for `ai-ssh-toolkit`. Each entry explains what was decided, why, and the outcome — including decisions to _not_ implement a feature.
+
+---
+
+## DD-001: No command validation in `ssh_execute`
+
+**Status:** Won't Fix / By Design  
+**Issue:** [#28](https://github.com/ebmarquez/ai-ssh-toolkit/issues/28)  
+**Came from:** Security review of PR #23
+
+### Decision
+
+The `command` field in `ssh_execute` (and related tools) accepts any string with no allowlist, blocklist, or length restriction. This is intentional and will not change.
+
+### Rationale
+
+`ai-ssh-toolkit` is a **general-purpose SSH execution tool**. The set of commands that callers might legitimately submit is unbounded — from simple `show` commands on network devices, to multi-stage configuration sequences, to arbitrary shell pipelines on Linux hosts.
+
+Imposing a command allowlist or blocklist would:
+
+- Break legitimate use cases across the diverse set of supported hosts and platforms
+- Create a false sense of security (blocklists are easily bypassed)
+- Shift responsibility away from the operator, where it belongs
+
+**What commands are submitted to the destination host is the caller's and operator's responsibility — not the tool's.**
+
+### Security Contract
+
+The tool's security contract is narrowly scoped:
+
+> **Credentials used to establish the SSH session must never leak.** Everything else is out of scope.
+
+Concretely, the tool guarantees:
+- Passwords are stored as `Buffer` and zero-filled after every use — never as plain strings
+- Credentials are never written to disk (no temp files)
+- Credentials are never passed as command-line arguments (use stdin piping)
+- PTY output is scrubbed to remove password echoes before returning to the MCP client
+- MCP responses never contain credential values
+
+Command content, access control, and authorization are the responsibility of the operator and the infrastructure being accessed (e.g., SSH server ACLs, sudoers policy, network device privilege levels).
+
+### What This Means for Operators
+
+If you need command-level restrictions, implement them at the infrastructure layer:
+
+- SSH server `ForceCommand` or `Match` blocks in `sshd_config`
+- Network device privilege levels and command authorization (AAA/TACACS+)
+- Linux `sudoers` with command allowlists
+- Bastion host or jump server policies
+
+---
+
+## DD-002: No Host Allowlist — Network Security is the Operator's Responsibility
+
+**Status:** Won't Fix / By Design  
+**Issue:** [#24](https://github.com/ebmarquez/ai-ssh-toolkit/issues/24)  
+**Came from:** Security review of PR #23
+
+### Decision
+
+`ai-ssh-toolkit` will connect to any host/IP the caller specifies. There is no built-in host allowlist or IP blocklist.
+
+### Rationale
+
+This tool is a general-purpose SSH MCP server. Restricting which hosts it can connect to would break legitimate use cases — for example, Azure Local uses the `169.254.x.x` (APIPA/link-local) range for cluster network validation. Blocking that range or any other would silently break real workflows for network engineers and cloud operators.
+
+Endpoint security is not the responsibility of this tool. If a particular IP address or range needs to be protected from unauthorized SSH connections, that protection belongs at the infrastructure layer — firewall rules, network segmentation, IAM policies, and endpoint hardening — not in the SSH client.
+
+### What This Means for Operators
+
+Operators deploying this MCP server are responsible for:
+
+- Controlling what network the process runs on
+- Restricting which MCP clients can call it (process-level isolation)
+- Applying firewall/ACL rules at the network layer if specific destinations must be off-limits
+
+---
+
+*Additional design decisions will be added here as they arise.*

--- a/README.md
+++ b/README.md
@@ -289,6 +289,12 @@ credential_ref: "MY_SWITCH"  → reads MY_SWITCH_USERNAME and MY_SWITCH_PASSWORD
 - `StrictHostKeyChecking=no` is never used
 - External CLI paths resolved to absolute at startup
 
+### Command Validation: Out of Scope (By Design)
+
+`ssh_execute` and related tools accept any command string with no allowlist, blocklist, or length restriction. This is intentional — `ai-ssh-toolkit` is a general-purpose tool and restricting commands would break legitimate use cases. The tool's security contract covers **credential protection only**; command-level access control is the operator's responsibility (via `sshd_config`, TACACS+, sudoers, etc.).
+
+See [DESIGN-DECISIONS.md](DESIGN-DECISIONS.md) for the full rationale.
+
 See [SECURITY.md](SECURITY.md) for full details and vulnerability reporting.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ credential_ref: "MY_SWITCH"  → reads MY_SWITCH_USERNAME and MY_SWITCH_PASSWORD
 
 ### Command Validation: Out of Scope (By Design)
 
-`ssh_execute` and related tools accept any command string with no allowlist, blocklist, or length restriction. This is intentional — `ai-ssh-toolkit` is a general-purpose tool and restricting commands would break legitimate use cases. The tool's security contract covers **credential protection only**; command-level access control is the operator's responsibility (via `sshd_config`, TACACS+, sudoers, etc.).
+`ssh_execute` and related tools accept any non-empty command string and do not enforce an allowlist, blocklist, or length restriction. This is intentional — `ai-ssh-toolkit` is a general-purpose tool and restricting commands would break legitimate use cases. Command validation and command-level authorization are out of scope; those controls remain the operator's responsibility (via `sshd_config`, TACACS+, sudoers, etc.). The tool's security guarantees cover credential handling and transport hardening — see [SECURITY.md](SECURITY.md) for details.
 
 See [DESIGN-DECISIONS.md](DESIGN-DECISIONS.md) for the full rationale.
 


### PR DESCRIPTION
## Summary

Documents the design decision that `ssh_execute` intentionally accepts any command string with no validation.

## Changes

- **`DESIGN-DECISIONS.md`** (new file) — Full rationale for DD-001: no command allowlist/blocklist in `ssh_execute`. Explains the general-purpose tool philosophy, the narrow security contract (credential protection only), and guidance for operators who need command-level restrictions.
- **`README.md`** — Added a "Command Validation: Out of Scope" callout in the Security Model section with a link to DESIGN-DECISIONS.md.

## Rationale

The tool's security contract is narrowly: credentials must never leak. Command validation is out of scope for a general-purpose SSH tool — restricting commands would break legitimate use cases and create a false sense of security.

## Testing

Documentation-only change. All 148 unit/smoke tests pass.

Fixes ebmarquez/ai-ssh-toolkit#28