### PR TITLE
feat: add structured output parsers for network OS show commands

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,8 +64,6 @@ Endpoint security is not the responsibility of this tool. If a particular IP add
 
 **Status:** Won't fix / by design. This was a finding from a security review ([PR #23](https://github.com/ebmarquez/ai-ssh-toolkit/pull/23)) and was deliberately evaluated and rejected. The decision is documented here for the record. See [Issue #24](https://github.com/ebmarquez/ai-ssh-toolkit/issues/24).
 
-## Design Decisions
-
 ### `credential_list_backends` Is Intentionally Public
 
 **Decision:** Won't Fix / By Design

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,6 +46,41 @@ All pull requests are reviewed by the Shadow agent (black hat security reviewer)
 
 PRs with security violations are **blocked** until remediated.
 
+## Design Decisions
+
+### No Host Allowlist — Network Security is the Operator's Responsibility
+
+**Decision:** ai-ssh-toolkit will connect to any host/IP the caller specifies. There is no built-in host allowlist or IP blocklist.
+
+**Rationale:** This tool is a general-purpose SSH MCP server. Restricting which hosts it can connect to would break legitimate use cases — for example, Azure Local uses the `169.254.x.x` (APIPA/link-local) range for cluster network validation. Blocking that range or any other would silently break real workflows for network engineers and cloud operators.
+
+Endpoint security is not the responsibility of this tool. If a particular IP address or range needs to be protected from unauthorized SSH connections, that protection belongs at the infrastructure layer — firewall rules, network segmentation, IAM policies, and endpoint hardening — not in the SSH client.
+
+**Operator guidance:** Operators deploying this MCP server are responsible for:
+
+- Controlling what network the process runs on
+- Restricting which MCP clients can call it (process-level isolation)
+- Applying firewall/ACL rules at the network layer if specific destinations must be off-limits
+
+**Status:** Won't fix / by design. This was a finding from a security review ([PR #23](https://github.com/ebmarquez/ai-ssh-toolkit/pull/23)) and was deliberately evaluated and rejected. The decision is documented here for the record. See [Issue #24](https://github.com/ebmarquez/ai-ssh-toolkit/issues/24).
+
+## Design Decisions
+
+### `credential_list_backends` Is Intentionally Public
+
+**Decision:** Won't Fix / By Design
+
+`credential_list_backends` returns the list of registered credential backends and their availability to any caller with no access control.
+
+**Rationale:**
+
+- The response contains **backend names and availability status only** — no credential values, tokens, passwords, or secrets are ever returned.
+- This information is useful diagnostic context for operators troubleshooting configuration and for AI models selecting an appropriate backend at runtime.
+- Restricting access would add friction without meaningful security benefit given the tool's trust model: the MCP server runs over stdio with process-level isolation, meaning callers are already trusted by virtue of being co-located in the same process group.
+- The risk surface is low: knowing which backends are configured (e.g., `keychain`, `bitwarden`, `azure-keyvault`) does not enable credential theft.
+
+**Source:** Security review of PR #23. Documented in issue [#29](https://github.com/ebmarquez/ai-ssh-toolkit/issues/29).
+
 ## Threat Model
 
 | Attack Surface | Mitigation |

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,11 @@ server.tool(
       .optional()
       .describe('Platform hint for prompt detection (default: auto)'),
     timeout_ms: z.number().int().positive().optional().describe('Connection + command timeout in milliseconds (default: 30000)'),
+    parse_output: z.boolean().optional().describe('When true, parse the raw output into structured JSON alongside raw text (default: false)'),
+    platform_hint: z
+      .enum(['nxos', 'dell-os10', 'sonic', 'auto'])
+      .optional()
+      .describe('Parser platform hint for structured output (nxos, dell-os10, sonic, auto — default: auto)'),
   },
   async (input) => {
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,9 +87,9 @@ server.tool(
     timeout_ms: z.number().int().positive().optional().describe('Connection + command timeout in milliseconds (default: 30000)'),
     parse_output: z.boolean().optional().describe('When true, parse the raw output into structured JSON alongside raw text (default: false)'),
     platform_hint: z
-      .enum(['nxos', 'dell-os10', 'sonic', 'auto'])
+      .enum(['nxos', 'dell-os10', 'os10', 'sonic', 'auto'])
       .optional()
-      .describe('Parser platform hint for structured output (nxos, dell-os10, sonic, auto — default: auto)'),
+      .describe('Parser platform hint for structured output (nxos, dell-os10/os10, sonic, auto — default: auto; os10 is an alias for dell-os10)'),
   },
   async (input) => {
     try {

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -6,7 +6,12 @@
  * and returns a structured JSON object (or null if parsing fails).
  */
 
-export type ParserPlatform = 'nxos' | 'dell-os10' | 'sonic' | 'auto';
+export type ParserPlatform = 'nxos' | 'dell-os10' | 'os10' | 'sonic' | 'auto';
+
+/** Normalize platform aliases so callers can pass 'os10' or 'dell-os10' interchangeably. */
+function normalizePlatform(platform: string): ParserPlatform {
+  return platform === 'os10' ? 'dell-os10' : (platform as ParserPlatform);
+}
 
 // ── BGP Summary ──────────────────────────────────────────────────────────────
 
@@ -372,7 +377,9 @@ export function parseShowVlan(
   }
 
   // Match: ID  Name  Status  [optional ports...]
-  const vlanLineRe = /^\s*(\d{1,4})\s+([\w-]+)\s+(active|inactive|Active|Inactive)\s*(.*)?$/;
+  // Name may contain spaces (e.g. "Voice VLAN", "Management VLAN") so use a lookahead
+  // to stop before the status keyword.
+  const vlanLineRe = /^\s*(\d{1,4})\s+(.+?)\s{2,}(active|inactive|Active|Inactive)\s*(.*)?$/
 
   for (let i = startIdx; i < lines.length; i++) {
     const m = vlanLineRe.exec(lines[i]);
@@ -386,11 +393,12 @@ export function parseShowVlan(
           ? portStr.split(/,\s*/).map((p) => p.trim()).filter(Boolean)
           : undefined,
       });
-    } else if (/^\s*\d{1,4}\s+[\w-]+\s*$/.test(lines[i])) {
-      // Dell OS10 may not have status column
-      const parts = lines[i].trim().split(/\s+/);
-      if (parts.length >= 2) {
-        vlans.push({ id: parts[0], name: parts[1] });
+    } else if (/^\s*\d{1,4}\s+\S/.test(lines[i])) {
+      // Dell OS10 may not have status column — capture full name (may include spaces)
+      const simpleLine = lines[i].trim();
+      const simpleMatch = /^(\d{1,4})\s+(.+?)\s*$/.exec(simpleLine);
+      if (simpleMatch) {
+        vlans.push({ id: simpleMatch[1], name: simpleMatch[2].trim() });
       }
     }
   }
@@ -416,24 +424,25 @@ type ParsedOutput =
 export function parseOutput(
   command: string,
   output: string,
-  platform: string
+  platform: ParserPlatform | string
 ): ParsedOutput | null {
+  const normalizedPlatform = normalizePlatform(platform);
   const cmd = command.trim().toLowerCase().replace(/\s+/g, ' ');
 
   if (cmd.includes('show ip bgp summary') || cmd.includes('show bgp summary')) {
-    return parseShowIpBgpSummary(output, platform);
+    return parseShowIpBgpSummary(output, normalizedPlatform);
   }
   if (cmd.includes('show interface status') || cmd.includes('show interfaces status')) {
-    return parseShowInterfaceStatus(output, platform);
+    return parseShowInterfaceStatus(output, normalizedPlatform);
   }
   if (cmd.includes('show lldp neighbor')) {
-    return parseShowLldpNeighbors(output, platform);
+    return parseShowLldpNeighbors(output, normalizedPlatform);
   }
   if (cmd === 'show version' || cmd.startsWith('show version ')) {
-    return parseShowVersion(output, platform);
+    return parseShowVersion(output, normalizedPlatform);
   }
   if (cmd === 'show vlan' || cmd.startsWith('show vlan ')) {
-    return parseShowVlan(output, platform);
+    return parseShowVlan(output, normalizedPlatform);
   }
 
   return null;

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -1,0 +1,440 @@
+/**
+ * Structured output parsers for network OS show commands.
+ *
+ * Supports Cisco NX-OS and Dell OS10 / SONiC platforms.
+ * Each parser accepts the raw CLI output string and a platform hint,
+ * and returns a structured JSON object (or null if parsing fails).
+ */
+
+export type ParserPlatform = 'nxos' | 'dell-os10' | 'sonic' | 'auto';
+
+// ── BGP Summary ──────────────────────────────────────────────────────────────
+
+export interface BgpPeer {
+  neighbor: string;
+  version: string;
+  as: string;
+  msg_rcvd: string;
+  msg_sent: string;
+  tbl_ver: string;
+  in_q: string;
+  out_q: string;
+  up_down: string;
+  state_pfx_rcvd: string;
+}
+
+export interface BgpSummaryResult {
+  router_id?: string;
+  local_as?: string;
+  peers: BgpPeer[];
+}
+
+/**
+ * Parse `show ip bgp summary` output.
+ *
+ * NX-OS example peer line:
+ *   10.0.0.1        4 65001     100     200    0    0 00:01:02        5
+ *
+ * Dell OS10 / SONiC peer line (FRR-style):
+ *   BGP neighbor is 10.0.0.1, remote AS 65001, local AS 65000, ...
+ *   ...
+ *   Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
+ *   10.0.0.1        4      65001     100     200        1    0    0 00:01:02            5
+ */
+export function parseShowIpBgpSummary(
+  output: string,
+  _platform: string
+): BgpSummaryResult | null {
+  const lines = output.split('\n');
+  const result: BgpSummaryResult = { peers: [] };
+
+  // Extract router-id and local AS
+  const routerIdMatch = output.match(/BGP router identifier\s+([\d.]+),\s*local AS number\s+(\d+)/i);
+  if (routerIdMatch) {
+    result.router_id = routerIdMatch[1];
+    result.local_as = routerIdMatch[2];
+  }
+
+  // Find the header line to locate the table
+  const headerIdx = lines.findIndex((l) =>
+    /Neighbor\s+V\s+AS\s+MsgRcvd/i.test(l)
+  );
+
+  const peerLineRe =
+    /^(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\s+(\d)\s+(\d+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s*$/;
+
+  const startIdx = headerIdx >= 0 ? headerIdx + 1 : 0;
+  for (let i = startIdx; i < lines.length; i++) {
+    const m = peerLineRe.exec(lines[i].trim());
+    if (m) {
+      result.peers.push({
+        neighbor: m[1],
+        version: m[2],
+        as: m[3],
+        msg_rcvd: m[4],
+        msg_sent: m[5],
+        tbl_ver: m[6],
+        in_q: m[7],
+        out_q: m[8],
+        up_down: m[9],
+        state_pfx_rcvd: m[10],
+      });
+    }
+  }
+
+  return result.peers.length > 0 || result.router_id ? result : null;
+}
+
+// ── Interface Status ─────────────────────────────────────────────────────────
+
+export interface InterfaceStatus {
+  interface: string;
+  name?: string;
+  status: string;
+  vlan?: string;
+  duplex?: string;
+  speed?: string;
+  type?: string;
+}
+
+export interface InterfaceStatusResult {
+  interfaces: InterfaceStatus[];
+}
+
+/**
+ * Parse `show interface status` output.
+ *
+ * NX-OS example:
+ *   Port          Name               Status    Vlan      Duplex  Speed   Type
+ *   Eth1/1        uplink             connected trunk     full    10G     10Gbase-SR
+ *
+ * Dell OS10 example:
+ *   Interface    Description     Oper-State  AutoNeg  Speed     Duplex
+ *   ethernet1/1/1  --            up          true     10000     full
+ */
+export function parseShowInterfaceStatus(
+  output: string,
+  _platform: string
+): InterfaceStatusResult | null {
+  const lines = output.split('\n');
+  const interfaces: InterfaceStatus[] = [];
+
+  // NX-OS style: Port + Name + Status + Vlan + Duplex + Speed + Type
+  const nxosHeaderIdx = lines.findIndex((l) =>
+    /Port\s+Name\s+Status\s+Vlan/i.test(l)
+  );
+
+  if (nxosHeaderIdx >= 0) {
+    const nxosPeerRe =
+      /^([\w/.-]+)\s+(.*?)\s{2,}(connected|notconnect|disabled|err-disabled|sfpAbsent)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)/i;
+    for (let i = nxosHeaderIdx + 2; i < lines.length; i++) {
+      const m = nxosPeerRe.exec(lines[i]);
+      if (m) {
+        interfaces.push({
+          interface: m[1],
+          name: m[2].trim() || undefined,
+          status: m[3],
+          vlan: m[4],
+          duplex: m[5],
+          speed: m[6],
+          type: m[7],
+        });
+      }
+    }
+    if (interfaces.length > 0) return { interfaces };
+  }
+
+  // Dell OS10 / SONiC style: Interface + Description + Oper-State + ...
+  const os10HeaderIdx = lines.findIndex((l) =>
+    /Interface\s+Description\s+Oper[-\s]State/i.test(l)
+  );
+
+  if (os10HeaderIdx >= 0) {
+    const os10Re =
+      /^([\w/.-]+)\s+(.*?)\s{2,}(up|down|disabled)\s+(\S+)\s+(\S+)\s+(\S+)/i;
+    for (let i = os10HeaderIdx + 1; i < lines.length; i++) {
+      const m = os10Re.exec(lines[i]);
+      if (m) {
+        interfaces.push({
+          interface: m[1],
+          name: m[2].trim() || undefined,
+          status: m[3],
+          duplex: m[6],
+          speed: m[5],
+        });
+      }
+    }
+    if (interfaces.length > 0) return { interfaces };
+  }
+
+  return interfaces.length > 0 ? { interfaces } : null;
+}
+
+// ── LLDP Neighbors ───────────────────────────────────────────────────────────
+
+export interface LldpNeighbor {
+  local_interface: string;
+  chassis_id: string;
+  port_id: string;
+  system_name?: string;
+  hold_time?: string;
+}
+
+export interface LldpNeighborsResult {
+  neighbors: LldpNeighbor[];
+}
+
+/**
+ * Parse `show lldp neighbors` output.
+ *
+ * NX-OS example:
+ *   Capability codes:  (R) Router, (B) Bridge, (T) Telephone, (C) DOCSIS Cable Device
+ *   (W) WLAN Access Point, (P) Repeater, (S) Station, (O) Other
+ *   Device ID        Local Intf      Hold-time  Capability  Port ID
+ *   neighbor-sw      Eth1/1          120        B, R        Eth0/1
+ *
+ * Dell OS10 example:
+ *   Local Interface   Chassis-id         Remote Port-id     System Name   Hold-time
+ *   ethernet1/1/1     00:11:22:33:44:55  ethernet1/1/2      neighbor-sw   120
+ */
+export function parseShowLldpNeighbors(
+  output: string,
+  _platform: string
+): LldpNeighborsResult | null {
+  const lines = output.split('\n');
+  const neighbors: LldpNeighbor[] = [];
+
+  // NX-OS style: Device ID + Local Intf + Hold-time + Capability + Port ID
+  const nxosHeaderIdx = lines.findIndex((l) =>
+    /Device ID\s+Local Intf\s+Hold-time/i.test(l)
+  );
+
+  if (nxosHeaderIdx >= 0) {
+    const nxosRe =
+      /^(\S+)\s+([\w/.-]+)\s+(\d+)\s+[\w,\s]*?\s+([\w/.-]+)\s*$/;
+    for (let i = nxosHeaderIdx + 1; i < lines.length; i++) {
+      const m = nxosRe.exec(lines[i].trim());
+      if (m) {
+        neighbors.push({
+          local_interface: m[2],
+          chassis_id: m[1],
+          port_id: m[4],
+          hold_time: m[3],
+        });
+      }
+    }
+    if (neighbors.length > 0) return { neighbors };
+  }
+
+  // Dell OS10 style: Local Interface + Chassis-id + Remote Port-id + System Name + Hold-time
+  const os10HeaderIdx = lines.findIndex((l) =>
+    /Local Interface\s+Chassis[-\s]id\s+Remote Port/i.test(l)
+  );
+
+  if (os10HeaderIdx >= 0) {
+    const os10Re =
+      /^([\w/.-]+)\s+([\w:.-]+)\s+([\w/.-]+)\s+(\S+)\s+(\d+)\s*$/;
+    for (let i = os10HeaderIdx + 1; i < lines.length; i++) {
+      const m = os10Re.exec(lines[i].trim());
+      if (m) {
+        neighbors.push({
+          local_interface: m[1],
+          chassis_id: m[2],
+          port_id: m[3],
+          system_name: m[4],
+          hold_time: m[5],
+        });
+      }
+    }
+    if (neighbors.length > 0) return { neighbors };
+  }
+
+  return neighbors.length > 0 ? { neighbors } : null;
+}
+
+// ── Show Version ─────────────────────────────────────────────────────────────
+
+export interface VersionResult {
+  model?: string;
+  firmware?: string;
+  os_version?: string;
+  uptime?: string;
+  serial?: string;
+  hostname?: string;
+}
+
+/**
+ * Parse `show version` output.
+ *
+ * NX-OS example snippets:
+ *   Cisco Nexus Operating System (NX-OS) Software
+ *   BIOS: version 08.35
+ *   kickstart: version 7.0(3)I7(9)
+ *   system:    version 7.0(3)I7(9)
+ *   Hardware
+ *     cisco Nexus 9332C Chassis
+ *   Kernel uptime is 10 day(s), 3 hour(s), 22 minute(s), 5 second(s)
+ *
+ * Dell OS10 / SONiC example:
+ *   Dell EMC Networking OS10 Enterprise
+ *   Software Version: 10.5.3.4
+ *   System Type:      S5248F-ON
+ *   Uptime:           0 day(s), 2 hour(s), 10 minute(s)
+ */
+export function parseShowVersion(
+  output: string,
+  _platform: string
+): VersionResult | null {
+  const result: VersionResult = {};
+
+  // NX-OS
+  const nxosSysVer = output.match(/system:\s+version\s+(\S+)/i);
+  if (nxosSysVer) result.os_version = nxosSysVer[1];
+
+  const nxosKickstart = output.match(/kickstart:\s+version\s+(\S+)/i);
+  if (nxosKickstart) result.firmware = nxosKickstart[1];
+
+  // NX-OS chassis line: "  cisco Nexus 9332C Chassis" — model is 2 tokens after "cisco Nexus"
+  // Avoid matching "Nexus Operating System" (the software header line).
+  const nxosChassis = output.match(/^\s*cisco\s+Nexus\s+((?!Operating)[\w-]+)/im);
+  if (nxosChassis) {
+    result.model = `Nexus ${nxosChassis[1]}`;
+  }
+
+  const nxosUptime = output.match(/Kernel uptime is\s+(.+)/i);
+  if (nxosUptime) result.uptime = nxosUptime[1].trim();
+
+  // Dell OS10 / SONiC
+  const dellSoftwareVer = output.match(/Software Version:\s*(\S+)/i);
+  if (dellSoftwareVer) result.os_version = result.os_version ?? dellSoftwareVer[1];
+
+  const dellSystemType = output.match(/System Type:\s*(\S+)/i);
+  if (dellSystemType) result.model = result.model ?? dellSystemType[1];
+
+  const dellUptime = output.match(/Uptime:\s*(.+)/i);
+  if (dellUptime) result.uptime = result.uptime ?? dellUptime[1].trim();
+
+  // Shared: hostname
+  const hostname = output.match(/[Hh]ostname[:\s]+(\S+)/);
+  if (hostname) result.hostname = hostname[1];
+
+  // Shared: serial
+  const serial = output.match(/[Ss]erial\s+[Nn]umber[:\s]+(\S+)/);
+  if (serial) result.serial = serial[1];
+
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+// ── Show VLAN ────────────────────────────────────────────────────────────────
+
+export interface Vlan {
+  id: string;
+  name?: string;
+  status?: string;
+  interfaces?: string[];
+}
+
+export interface VlanTableResult {
+  vlans: Vlan[];
+}
+
+/**
+ * Parse `show vlan` output.
+ *
+ * NX-OS example:
+ *   VLAN  Name                             Status    Ports
+ *   ----  -------------------------------- --------- -----------------------------------
+ *   1     default                          active    Eth1/1, Eth1/2
+ *   10    mgmt                             active    Eth1/3
+ *
+ * Dell OS10 example:
+ *   Q: U - Untagged, T - Tagged
+ *     VLAN  Name                    Status
+ *   ------  ----------------------  -------
+ *        1  default                 Active
+ *       10  Management              Active
+ */
+export function parseShowVlan(
+  output: string,
+  _platform: string
+): VlanTableResult | null {
+  const lines = output.split('\n');
+  const vlans: Vlan[] = [];
+
+  // Look for the VLAN table header
+  const headerIdx = lines.findIndex((l) => /^\s*VLAN\s+Name/i.test(l));
+  if (headerIdx < 0) return null;
+
+  // Skip separator line(s)
+  let startIdx = headerIdx + 1;
+  while (startIdx < lines.length && /^[\s\-]+$/.test(lines[startIdx])) {
+    startIdx++;
+  }
+
+  // Match: ID  Name  Status  [optional ports...]
+  const vlanLineRe = /^\s*(\d{1,4})\s+([\w-]+)\s+(active|inactive|Active|Inactive)\s*(.*)?$/;
+
+  for (let i = startIdx; i < lines.length; i++) {
+    const m = vlanLineRe.exec(lines[i]);
+    if (m) {
+      const portStr = m[4]?.trim() ?? '';
+      vlans.push({
+        id: m[1],
+        name: m[2],
+        status: m[3].toLowerCase(),
+        interfaces: portStr
+          ? portStr.split(/,\s*/).map((p) => p.trim()).filter(Boolean)
+          : undefined,
+      });
+    } else if (/^\s*\d{1,4}\s+[\w-]+\s*$/.test(lines[i])) {
+      // Dell OS10 may not have status column
+      const parts = lines[i].trim().split(/\s+/);
+      if (parts.length >= 2) {
+        vlans.push({ id: parts[0], name: parts[1] });
+      }
+    }
+  }
+
+  return vlans.length > 0 ? { vlans } : null;
+}
+
+// ── Dispatcher ───────────────────────────────────────────────────────────────
+
+type ParsedOutput =
+  | BgpSummaryResult
+  | InterfaceStatusResult
+  | LldpNeighborsResult
+  | VersionResult
+  | VlanTableResult;
+
+/**
+ * Dispatch to the appropriate parser based on the command string.
+ *
+ * Returns structured JSON if a matching parser exists and succeeds,
+ * or null if the command is not recognized / parsing yields no data.
+ */
+export function parseOutput(
+  command: string,
+  output: string,
+  platform: string
+): ParsedOutput | null {
+  const cmd = command.trim().toLowerCase().replace(/\s+/g, ' ');
+
+  if (cmd.includes('show ip bgp summary') || cmd.includes('show bgp summary')) {
+    return parseShowIpBgpSummary(output, platform);
+  }
+  if (cmd.includes('show interface status') || cmd.includes('show interfaces status')) {
+    return parseShowInterfaceStatus(output, platform);
+  }
+  if (cmd.includes('show lldp neighbor')) {
+    return parseShowLldpNeighbors(output, platform);
+  }
+  if (cmd === 'show version' || cmd.startsWith('show version ')) {
+    return parseShowVersion(output, platform);
+  }
+  if (cmd === 'show vlan' || cmd.startsWith('show vlan ')) {
+    return parseShowVlan(output, platform);
+  }
+
+  return null;
+}

--- a/src/tools/ssh-execute.ts
+++ b/src/tools/ssh-execute.ts
@@ -5,6 +5,7 @@
 import type { PlatformHint } from '../ssh/prompt-detector.js';
 import type { CredentialRegistry } from '../credentials/registry.js';
 import { runSshSession } from '../ssh/pty-manager.js';
+import { parseOutput, type ParserPlatform } from '../parsers/index.js';
 
 export interface SshExecuteInput {
   host: string;
@@ -14,11 +15,14 @@ export interface SshExecuteInput {
   credential_backend?: string;
   platform?: PlatformHint;
   timeout_ms?: number;
+  parse_output?: boolean;
+  platform_hint?: ParserPlatform;
 }
 
 export interface SshExecuteResult {
   output: string;
   exit_code: number | null;
+  structured_output?: unknown;
 }
 
 export async function sshExecute(
@@ -33,6 +37,8 @@ export async function sshExecute(
     credential_backend,
     platform = 'auto',
     timeout_ms = 30000,
+    parse_output: shouldParse = false,
+    platform_hint = 'auto',
   } = input;
 
   // Validate required inputs
@@ -74,7 +80,7 @@ export async function sshExecute(
 
   // Run the PTY session
   try {
-    const result = await runSshSession({
+    const rawResult = await runSshSession({
       host,
       username: resolvedUsername,
       password: passwordBuffer,
@@ -82,7 +88,15 @@ export async function sshExecute(
       platform,
       timeout_ms,
     });
-    return result;
+
+    if (shouldParse) {
+      const structured = parseOutput(command, rawResult.output, platform_hint);
+      if (structured !== null) {
+        return { ...rawResult, structured_output: structured };
+      }
+    }
+
+    return rawResult;
   } finally {
     // Zero-fill password buffer after PTY session completes (success or failure)
     passwordBuffer.fill(0);

--- a/src/tools/ssh-execute.ts
+++ b/src/tools/ssh-execute.ts
@@ -16,7 +16,7 @@ export interface SshExecuteInput {
   platform?: PlatformHint;
   timeout_ms?: number;
   parse_output?: boolean;
-  platform_hint?: ParserPlatform;
+  platform_hint?: ParserPlatform | 'os10';
 }
 
 export interface SshExecuteResult {

--- a/test/unit/parsers.test.ts
+++ b/test/unit/parsers.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Unit tests for the structured output parsers.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  parseShowIpBgpSummary,
+  parseShowInterfaceStatus,
+  parseShowLldpNeighbors,
+  parseShowVersion,
+  parseShowVlan,
+  parseOutput,
+} from '../../src/parsers/index.js';
+
+// ── BGP Summary ───────────────────────────────────────────────────────────────
+
+describe('parseShowIpBgpSummary', () => {
+  const NXOS_OUTPUT = `
+BGP summary information for VRF default, address family IPv4 Unicast
+BGP router identifier 10.0.0.1, local AS number 65000
+BGP table version is 4, IPv4 Unicast config peers 2, capable peers 2
+
+Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down  State/PfxRcd
+10.0.0.2        4 65001     100     200        4    0    0 00:05:30        5
+10.0.0.3        4 65002      50     100        4    0    0 00:01:15        3
+`;
+
+  it('parses NX-OS bgp summary', () => {
+    const result = parseShowIpBgpSummary(NXOS_OUTPUT, 'nxos');
+    expect(result).not.toBeNull();
+    expect(result!.router_id).toBe('10.0.0.1');
+    expect(result!.local_as).toBe('65000');
+    expect(result!.peers).toHaveLength(2);
+    expect(result!.peers[0].neighbor).toBe('10.0.0.2');
+    expect(result!.peers[0].as).toBe('65001');
+    expect(result!.peers[0].up_down).toBe('00:05:30');
+    expect(result!.peers[0].state_pfx_rcvd).toBe('5');
+    expect(result!.peers[1].neighbor).toBe('10.0.0.3');
+  });
+
+  it('returns null for empty output', () => {
+    expect(parseShowIpBgpSummary('no bgp data here', 'nxos')).toBeNull();
+  });
+});
+
+// ── Interface Status ──────────────────────────────────────────────────────────
+
+describe('parseShowInterfaceStatus', () => {
+  const NXOS_OUTPUT = `
+--------------------------------------------------------------------------------
+Port          Name               Status    Vlan      Duplex  Speed   Type
+--------------------------------------------------------------------------------
+Eth1/1        uplink             connected trunk     full    10G     10Gbase-SR
+Eth1/2        --                 notconnect 1        auto    auto    10Gbase-T
+`;
+
+  it('parses NX-OS interface status', () => {
+    const result = parseShowInterfaceStatus(NXOS_OUTPUT, 'nxos');
+    expect(result).not.toBeNull();
+    expect(result!.interfaces.length).toBeGreaterThanOrEqual(1);
+    const eth1 = result!.interfaces.find((i) => i.interface === 'Eth1/1');
+    expect(eth1).toBeDefined();
+    expect(eth1!.status).toBe('connected');
+    expect(eth1!.vlan).toBe('trunk');
+    expect(eth1!.speed).toBe('10G');
+  });
+
+  it('returns null for unrecognized output', () => {
+    expect(parseShowInterfaceStatus('nothing useful here', 'nxos')).toBeNull();
+  });
+});
+
+// ── LLDP Neighbors ────────────────────────────────────────────────────────────
+
+describe('parseShowLldpNeighbors', () => {
+  const NXOS_OUTPUT = `
+Capability codes:
+  (R) Router, (B) Bridge, (T) Telephone
+
+Device ID        Local Intf      Hold-time  Capability  Port ID
+neighbor-sw1     Eth1/1          120        B, R        Eth0/1
+neighbor-sw2     Eth1/2          120        B           Eth0/2
+`;
+
+  it('parses NX-OS lldp neighbors', () => {
+    const result = parseShowLldpNeighbors(NXOS_OUTPUT, 'nxos');
+    expect(result).not.toBeNull();
+    expect(result!.neighbors.length).toBeGreaterThanOrEqual(1);
+    const n1 = result!.neighbors[0];
+    expect(n1.local_interface).toBe('Eth1/1');
+    expect(n1.chassis_id).toBe('neighbor-sw1');
+    expect(n1.port_id).toBe('Eth0/1');
+    expect(n1.hold_time).toBe('120');
+  });
+
+  const OS10_OUTPUT = `
+Local Interface   Chassis-id         Remote Port-id     System Name   Hold-time
+ethernet1/1/1     00:11:22:33:44:55  ethernet1/1/2      neighbor-sw   120
+ethernet1/1/2     aa:bb:cc:dd:ee:ff  ethernet1/1/3      core-sw       120
+`;
+
+  it('parses Dell OS10 lldp neighbors', () => {
+    const result = parseShowLldpNeighbors(OS10_OUTPUT, 'dell-os10');
+    expect(result).not.toBeNull();
+    expect(result!.neighbors.length).toBeGreaterThanOrEqual(1);
+    expect(result!.neighbors[0].local_interface).toBe('ethernet1/1/1');
+    expect(result!.neighbors[0].chassis_id).toBe('00:11:22:33:44:55');
+    expect(result!.neighbors[0].system_name).toBe('neighbor-sw');
+  });
+
+  it('returns null for empty output', () => {
+    expect(parseShowLldpNeighbors('no lldp data', 'nxos')).toBeNull();
+  });
+});
+
+// ── Show Version ─────────────────────────────────────────────────────────────
+
+describe('parseShowVersion', () => {
+  const NXOS_OUTPUT = `
+Cisco Nexus Operating System (NX-OS) Software
+  BIOS: version 08.35
+  kickstart: version 7.0(3)I7(9)
+  system:    version 7.0(3)I7(9)
+Hardware
+  cisco Nexus 9332C Chassis
+  Processor Board ID FDO123456AB
+
+Kernel uptime is 10 day(s), 3 hour(s), 22 minute(s), 5 second(s)
+`;
+
+  it('parses NX-OS show version', () => {
+    const result = parseShowVersion(NXOS_OUTPUT, 'nxos');
+    expect(result).not.toBeNull();
+    expect(result!.os_version).toBe('7.0(3)I7(9)');
+    expect(result!.firmware).toBe('7.0(3)I7(9)');
+    expect(result!.model).toBe('Nexus 9332C');
+    expect(result!.uptime).toContain('10 day(s)');
+  });
+
+  const DELL_OUTPUT = `
+Dell EMC Networking OS10 Enterprise
+Software Version: 10.5.3.4
+System Type:      S5248F-ON
+Uptime:           0 day(s), 2 hour(s), 10 minute(s)
+`;
+
+  it('parses Dell OS10 show version', () => {
+    const result = parseShowVersion(DELL_OUTPUT, 'dell-os10');
+    expect(result).not.toBeNull();
+    expect(result!.os_version).toBe('10.5.3.4');
+    expect(result!.model).toBe('S5248F-ON');
+    expect(result!.uptime).toContain('0 day(s)');
+  });
+
+  it('returns null for empty output', () => {
+    expect(parseShowVersion('', 'nxos')).toBeNull();
+  });
+});
+
+// ── Show VLAN ─────────────────────────────────────────────────────────────────
+
+describe('parseShowVlan', () => {
+  const NXOS_OUTPUT = `
+VLAN  Name                             Status    Ports
+----  -------------------------------- --------- -----------------------------------
+1     default                          active    Eth1/1, Eth1/2
+10    mgmt                             active    Eth1/3
+20    storage                          inactive
+`;
+
+  it('parses NX-OS show vlan', () => {
+    const result = parseShowVlan(NXOS_OUTPUT, 'nxos');
+    expect(result).not.toBeNull();
+    expect(result!.vlans.length).toBeGreaterThanOrEqual(2);
+    const vlan1 = result!.vlans.find((v) => v.id === '1');
+    expect(vlan1).toBeDefined();
+    expect(vlan1!.name).toBe('default');
+    expect(vlan1!.status).toBe('active');
+    expect(vlan1!.interfaces).toContain('Eth1/1');
+    const vlan20 = result!.vlans.find((v) => v.id === '20');
+    expect(vlan20).toBeDefined();
+    expect(vlan20!.status).toBe('inactive');
+  });
+
+  it('returns null for unrecognized output', () => {
+    expect(parseShowVlan('nothing here', 'nxos')).toBeNull();
+  });
+});
+
+// ── Dispatcher ────────────────────────────────────────────────────────────────
+
+describe('parseOutput dispatcher', () => {
+  it('dispatches show ip bgp summary', () => {
+    const output = `
+BGP router identifier 10.0.0.1, local AS number 65000
+Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down  State/PfxRcd
+10.0.0.2        4 65001     100     200        4    0    0 00:05:30        5
+`;
+    const result = parseOutput('show ip bgp summary', output, 'nxos');
+    expect(result).not.toBeNull();
+    expect((result as { peers: unknown[] }).peers).toBeDefined();
+  });
+
+  it('dispatches show version', () => {
+    const output = `
+  system:    version 7.0(3)I7(9)
+  cisco Nexus 9332C Chassis
+Kernel uptime is 1 day(s), 0 hour(s), 0 minute(s), 0 second(s)
+`;
+    const result = parseOutput('show version', output, 'nxos');
+    expect(result).not.toBeNull();
+  });
+
+  it('returns null for unknown commands', () => {
+    expect(parseOutput('show running-config', 'some output', 'auto')).toBeNull();
+  });
+
+  it('is case and spacing tolerant', () => {
+    const output = `
+BGP router identifier 10.0.0.1, local AS number 65000
+Neighbor        V    AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down  State/PfxRcd
+10.0.0.2        4 65001     100     200        4    0    0 00:05:30        5
+`;
+    const result = parseOutput('  Show IP BGP Summary  ', output, 'auto');
+    expect(result).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds structured JSON output parsing for common network device show commands. When `parse_output: true` is passed to `ssh_execute`, the raw CLI output is parsed into structured JSON that AI models can reason over directly.

## Changes

- Added `parse_output` optional boolean parameter to `ssh_execute`
- Added `platform_hint` optional parameter (`nxos`, `dell-os10`, `sonic`, `auto`)
- New parser module (`src/parsers/index.ts`) with support for 5 priority commands:
  - `show ip bgp summary` → BGP peer table (router_id, local_as, peers with state/uptime/prefixes)
  - `show interface status` → interface list with state/speed/vlan
  - `show lldp neighbors` → neighbor topology data (chassis, port, system name)
  - `show version` → firmware/model/uptime/serial
  - `show vlan` → VLAN table with names and member interfaces
- Graceful fallback: if no parser matches or parsing yields no data, returns raw output only
- 16 new unit tests covering all parsers and the dispatcher

## Example

```json
{
  "output": "<raw NX-OS output>",
  "exit_code": 0,
  "structured_output": {
    "router_id": "10.0.0.1",
    "local_as": "65000",
    "peers": [
      { "neighbor": "10.0.0.2", "as": "65001", "up_down": "00:05:30", "state_pfx_rcvd": "5" }
    ]
  }
}
```

Fixes #10