### PR TITLE
fix: set PTY rows to 0 to disable --More-- pagination on network devices

### DIFF
--- a/src/ssh/pty-manager.ts
+++ b/src/ssh/pty-manager.ts
@@ -93,7 +93,11 @@ export async function runSshSession(opts: PtySessionOptions): Promise<PtySession
       term = pty.spawn('ssh', sshArgs, {
         name: 'xterm-color',
         cols: 220,
-        rows: 24,
+        // rows: 0 negotiates an "infinite" terminal height with the SSH server.
+        // Network devices (Cisco, Dell, Juniper, etc.) interpret this as
+        // disable paging — equivalent to 'terminal length 0' — so output is
+        // returned in full without --More-- interruptions.
+        rows: 0,
         env: childEnv,
       });
     } catch (err) {

--- a/src/ssh/pty-manager.ts
+++ b/src/ssh/pty-manager.ts
@@ -8,6 +8,7 @@
 
 import { detectPasswordPrompt, detectPrompt, type PlatformHint } from './prompt-detector.js';
 import { scrubOutput } from './output-scrubber.js';
+import { SSH_PTY_OPTIONS } from './pty-options.js';
 
 export interface PtySessionOptions {
   host: string;
@@ -91,14 +92,7 @@ export async function runSshSession(opts: PtySessionOptions): Promise<PtySession
     let term: import('node-pty').IPty;
     try {
       term = pty.spawn('ssh', sshArgs, {
-        name: 'xterm-color',
-        cols: 220,
-        // rows: 0 is a compatibility tactic that often reduces or disables
-        // paging on some SSH servers and network devices. On certain CLIs
-        // (for example, some Cisco-style devices), this can behave similarly
-        // to commands such as 'terminal length 0', helping return output
-        // without --More-- interruptions.
-        rows: 0,
+        ...SSH_PTY_OPTIONS,
         env: childEnv,
       });
     } catch (err) {

--- a/src/ssh/pty-manager.ts
+++ b/src/ssh/pty-manager.ts
@@ -93,10 +93,11 @@ export async function runSshSession(opts: PtySessionOptions): Promise<PtySession
       term = pty.spawn('ssh', sshArgs, {
         name: 'xterm-color',
         cols: 220,
-        // rows: 0 negotiates an "infinite" terminal height with the SSH server.
-        // Network devices (Cisco, Dell, Juniper, etc.) interpret this as
-        // disable paging — equivalent to 'terminal length 0' — so output is
-        // returned in full without --More-- interruptions.
+        // rows: 0 is a compatibility tactic that often reduces or disables
+        // paging on some SSH servers and network devices. On certain CLIs
+        // (for example, some Cisco-style devices), this can behave similarly
+        // to commands such as 'terminal length 0', helping return output
+        // without --More-- interruptions.
         rows: 0,
         env: childEnv,
       });

--- a/src/ssh/pty-options.ts
+++ b/src/ssh/pty-options.ts
@@ -1,8 +1,8 @@
 /**
- * Shared PTY spawn options for all SSH sessions.
+ * Shared PTY spawn options used across all SSH session tools.
  *
- * Centralised here so both pty-manager and ssh-multi-execute stay in sync
- * when defaults change.
+ * Centralised here so pty-manager, ssh-multi-execute, and ssh-session-open
+ * stay in sync when defaults change.
  */
 
 export const SSH_PTY_OPTIONS = {

--- a/src/ssh/pty-options.ts
+++ b/src/ssh/pty-options.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared PTY spawn options for all SSH sessions.
+ *
+ * Centralised here so both pty-manager and ssh-multi-execute stay in sync
+ * when defaults change.
+ */
+
+export const SSH_PTY_OPTIONS = {
+  name: 'xterm-color',
+  cols: 220,
+  // rows: 0 is a compatibility tactic that often reduces or disables
+  // paging on some SSH servers and network devices. On certain CLIs
+  // (for example, some Cisco-style devices), this can behave similarly
+  // to commands such as 'terminal length 0', helping return output
+  // without --More-- interruptions.
+  rows: 0,
+} as const;

--- a/src/tools/ssh-multi-execute.ts
+++ b/src/tools/ssh-multi-execute.ts
@@ -245,8 +245,10 @@ async function runSshCommands(opts: RunSshOptions): Promise<string> {
     const proc = pty.spawn("ssh", sshArgs, {
       name: "xterm-color",
       cols: 220,
-      rows: 40,
-      // Pass filtered env only — never expose full process.env to SSH children.
+      // rows: 0 negotiates an "infinite" terminal height with the SSH server.
+      // Network devices interpret this as disable paging so output is
+      // returned in full without --More-- interruptions.
+      rows: 0,
       env: childEnv,
     });
 

--- a/src/tools/ssh-multi-execute.ts
+++ b/src/tools/ssh-multi-execute.ts
@@ -1,6 +1,7 @@
 import { PlatformHint, detectPrompt, detectPasswordPrompt } from "../ssh/prompt-detector.js";
 import { scrubOutput } from "../ssh/output-scrubber.js";
 import { CredentialRegistry } from "../credentials/registry.js";
+import { SSH_PTY_OPTIONS } from "../ssh/pty-options.js";
 
 export interface SshMultiExecuteInput {
   hosts: string[];
@@ -243,14 +244,7 @@ async function runSshCommands(opts: RunSshOptions): Promise<string> {
     childEnv.TERM ??= "xterm-color";
 
     const proc = pty.spawn("ssh", sshArgs, {
-      name: "xterm-color",
-      cols: 220,
-      // rows: 0 is a compatibility tactic that often reduces or disables
-      // paging on some SSH servers and network devices. On certain CLIs
-      // (for example, some Cisco-style devices), this can behave similarly
-      // to commands such as 'terminal length 0', helping return output
-      // without --More-- interruptions.
-      rows: 0,
+      ...SSH_PTY_OPTIONS,
       // Intentionally pass only the allowlisted child environment here
       // instead of process.env to avoid leaking unrelated or sensitive
       // parent-process variables into the SSH child process.

--- a/src/tools/ssh-multi-execute.ts
+++ b/src/tools/ssh-multi-execute.ts
@@ -245,10 +245,15 @@ async function runSshCommands(opts: RunSshOptions): Promise<string> {
     const proc = pty.spawn("ssh", sshArgs, {
       name: "xterm-color",
       cols: 220,
-      // rows: 0 negotiates an "infinite" terminal height with the SSH server.
-      // Network devices interpret this as disable paging so output is
-      // returned in full without --More-- interruptions.
+      // rows: 0 is a compatibility tactic that often reduces or disables
+      // paging on some SSH servers and network devices. On certain CLIs
+      // (for example, some Cisco-style devices), this can behave similarly
+      // to commands such as 'terminal length 0', helping return output
+      // without --More-- interruptions.
       rows: 0,
+      // Intentionally pass only the allowlisted child environment here
+      // instead of process.env to avoid leaking unrelated or sensitive
+      // parent-process variables into the SSH child process.
       env: childEnv,
     });
 

--- a/src/tools/ssh-session-open.ts
+++ b/src/tools/ssh-session-open.ts
@@ -10,6 +10,7 @@ import type { PlatformHint } from '../ssh/prompt-detector.js';
 import type { CredentialRegistry } from '../credentials/registry.js';
 import type { SessionStore } from '../ssh/session-store.js';
 import { detectPasswordPrompt, detectPrompt } from '../ssh/prompt-detector.js';
+import { SSH_PTY_OPTIONS } from '../ssh/pty-options.js';
 
 export interface SshSessionOpenInput {
   host: string;
@@ -106,9 +107,7 @@ export async function sshSessionOpen(
     let term: import('node-pty').IPty;
     try {
       term = pty.spawn('ssh', sshArgs, {
-        name: 'xterm-color',
-        cols: 220,
-        rows: 24,
+        ...SSH_PTY_OPTIONS,
         env: childEnv,
       });
     } catch (err) {

--- a/test/unit/pty-manager.test.ts
+++ b/test/unit/pty-manager.test.ts
@@ -68,6 +68,12 @@ describe('runSshSession', () => {
     const result = await promise;
     expect(result.exit_code).toBe(0);
     expect(typeof result.output).toBe('string');
+    // Verify rows:0 is passed to prevent --More-- pagination on network devices
+    expect(spawnMock).toHaveBeenCalledWith(
+      'ssh',
+      expect.any(Array),
+      expect.objectContaining({ rows: 0 }),
+    );
   });
 
   it('handles password prompt and sends password', async () => {

--- a/test/unit/ssh-multi-execute.test.ts
+++ b/test/unit/ssh-multi-execute.test.ts
@@ -72,6 +72,12 @@ describe("executeSingleHost", () => {
     expect(result.success).toBe(true);
     expect(result.output).toContain("NX-OS 10.0");
     expect(result.error).toBeUndefined();
+    // Verify rows:0 is passed to prevent --More-- pagination on network devices
+    expect(vi.mocked(pty.spawn)).toHaveBeenCalledWith(
+      "ssh",
+      expect.any(Array),
+      expect.objectContaining({ rows: 0 }),
+    );
   });
 
   it("returns failure when SSH exits with non-zero code", async () => {


### PR DESCRIPTION
## Summary

Sets `rows: 0` across all SSH PTY spawn calls so the SSH server negotiates an unspecified/zero terminal height. Many network devices treat this as disable paging — no `--More--` interruptions in command output.

An MCP server has no human reading paginated output, so a fixed terminal row count serves no purpose. `rows: 0` is applied consistently across all three SSH session tools.

## Changes

- `src/ssh/pty-options.ts` *(new)* — shared `SSH_PTY_OPTIONS` constant (`rows: 0`, `cols: 220`, `name: xterm-color`) used by all SSH tools
- `src/ssh/pty-manager.ts` — `rows: 24` → `SSH_PTY_OPTIONS` (spread)
- `src/tools/ssh-multi-execute.ts` — `rows: 40` → `SSH_PTY_OPTIONS` (spread)
- `src/tools/ssh-session-open.ts` — `rows: 24` → `SSH_PTY_OPTIONS` (spread); interactive sessions also benefit from no paging since the MCP caller processes output programmatically
- `test/unit/pty-manager.test.ts` — added assertion that `pty.spawn` is called with `rows: 0`
- `test/unit/ssh-multi-execute.test.ts` — added assertion that `pty.spawn` is called with `rows: 0`

## Why this works

The SSH protocol negotiates terminal dimensions as part of the PTY request. A `rows` value of 0 means unspecified/unknown. Many network devices use the negotiated row count to decide when to paginate output — setting rows to 0 at the PTY level often achieves the same effect as `terminal length 0` (Cisco) or equivalent, before any command is sent, without platform-specific commands.

## Testing

Verified node-pty accepts `rows: 0` without error. All 148 unit tests pass. Spawn assertions added to prevent regression.

Fixes ebmarquez/ai-ssh-toolkit#73