### PR TITLE
feat: honor ~/.ssh/config via ssh -G (issue #75)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ server.tool(
   {
     host: z.string().describe('Hostname or IP address of the remote target'),
     command: z.string().describe('Command to execute on the remote host'),
-    username: z.string().optional().describe('SSH username (overrides credential ref username)'),
+    username: z.string().optional().describe('SSH username (overrides credential ref username and ~/.ssh/config User)'),
     credential_ref: z.string().optional().describe('Credential reference string understood by the selected backend'),
     credential_backend: z.string().optional().describe('Name of the credential backend (default: google-secret-manager)'),
     platform: z
@@ -85,6 +85,7 @@ server.tool(
       .optional()
       .describe('Platform hint for prompt detection (default: auto)'),
     timeout_ms: z.number().int().positive().optional().describe('Connection + command timeout in milliseconds (default: 30000)'),
+    use_ssh_config: z.boolean().optional().describe('When true (default), honor ~/.ssh/config for User, Port, IdentityFile, ProxyJump, etc. Set false to skip.'),
   },
   async (input) => {
     try {
@@ -175,9 +176,10 @@ server.tool(
   'Verify SSH connectivity to a host without executing commands.',
   {
     host: z.string().describe('Hostname or IP address to check'),
-    port: z.number().int().min(1).max(65535).optional().describe('SSH port (default: 22)'),
+    port: z.number().int().min(1).max(65535).optional().describe('SSH port (default: 22, or from ~/.ssh/config)'),
     username: z.string().optional().describe('SSH username for the connectivity check'),
     timeout_ms: z.number().int().positive().optional().describe('Connection timeout in milliseconds (default: 5000)'),
+    use_ssh_config: z.boolean().optional().describe('When true (default), honor ~/.ssh/config for User, Port, IdentityFile, ProxyJump, etc. Set false to skip.'),
   },
   async (input) => {
     try {
@@ -198,7 +200,7 @@ server.tool(
   'Open a persistent interactive SSH shell session. Returns a session_id for use with ssh_session_execute and ssh_session_close.',
   {
     host: z.string().describe('Hostname or IP address of the remote target'),
-    username: z.string().optional().describe('SSH username (overrides credential ref username)'),
+    username: z.string().optional().describe('SSH username (overrides credential ref username and ~/.ssh/config User)'),
     credential_ref: z.string().optional().describe('Credential reference string understood by the selected backend'),
     credential_backend: z.string().optional().describe('Name of the credential backend (default: google-secret-manager)'),
     platform: z
@@ -207,6 +209,7 @@ server.tool(
       .describe('Platform hint for prompt detection (default: auto)'),
     timeout_ms: z.number().int().positive().optional().describe('Connect + initial prompt timeout in milliseconds (default: 30000)'),
     idle_timeout_ms: z.number().int().positive().optional().describe('Inactivity auto-close timeout in milliseconds (default: 300000)'),
+    use_ssh_config: z.boolean().optional().describe('When true (default), honor ~/.ssh/config for User, Port, IdentityFile, ProxyJump, etc. Set false to skip.'),
   },
   async (input) => {
     try {

--- a/src/ssh/pty-manager.ts
+++ b/src/ssh/pty-manager.ts
@@ -9,16 +9,27 @@
 import { detectPasswordPrompt, detectPrompt, type PlatformHint } from './prompt-detector.js';
 import { scrubOutput } from './output-scrubber.js';
 import { SSH_PTY_OPTIONS } from './pty-options.js';
+import { resolveSshConfig } from './ssh-config-reader.js';
 
 export interface PtySessionOptions {
   host: string;
-  username: string;
+  /** SSH username. Optional when use_ssh_config is true and ~/.ssh/config provides a User. */
+  username?: string;
   /** Password as Buffer — zeroed by caller after this function resolves/rejects.
    *  Optional: omit when using SSH key / agent authentication. */
   password?: Buffer;
   command: string;
   platform?: PlatformHint;
   timeout_ms?: number;
+  /** SSH port override. When omitted, resolved from ~/.ssh/config or defaults to 22. */
+  port?: number;
+  /**
+   * When true (default), resolve ~/.ssh/config for the given host alias using
+   * `ssh -G <host>` and apply User, Port, IdentityFile, ProxyJump, etc. as
+   * defaults (tool arguments always take precedence).
+   * Set to false to skip config lookup entirely.
+   */
+  use_ssh_config?: boolean;
 }
 
 export interface PtySessionResult {
@@ -41,23 +52,49 @@ export interface PtySessionResult {
 export async function runSshSession(opts: PtySessionOptions): Promise<PtySessionResult> {
   const {
     host,
-    username,
     password,
     command,
     platform = 'auto',
     timeout_ms = 30000,
+    use_ssh_config = true,
   } = opts;
+
+  // ── SSH config resolution ─────────────────────────────────────────────────
+  // Resolve ~/.ssh/config for this host alias (handles Include, Match, patterns).
+  // Tool-provided values always override config values.
+  let resolvedUsername = opts.username;
+  let resolvedPort = opts.port;
+
+  if (use_ssh_config) {
+    const cfg = await resolveSshConfig(host);
+    if (cfg) {
+      // Apply config values only where the caller didn't provide an explicit value
+      resolvedUsername ??= cfg.user;
+      resolvedPort ??= cfg.port !== 22 ? cfg.port : undefined;
+    }
+  }
+
+  if (!resolvedUsername) {
+    throw new Error(
+      'username is required. Provide username, a credential_ref with a username, ' +
+      'or add a User directive to ~/.ssh/config for this host.',
+    );
+  }
 
   // Dynamic import to allow mocking in tests (matches ssh-multi-execute.ts pattern)
   const { default: pty } = await import('node-pty');
 
-  const sshArgs = [
+  // Build SSH args — pass the original host alias so SSH can apply its own
+  // config (HostName, IdentityFile, ProxyJump, Ciphers, etc.) naturally.
+  const sshArgs: string[] = [
     '-o', 'StrictHostKeyChecking=accept-new',
     '-o', 'NumberOfPasswordPrompts=1',
     '-o', 'ConnectTimeout=10',
-    `${username}@${host}`,
-    command,
   ];
+  if (resolvedPort !== undefined && resolvedPort !== 22) {
+    sshArgs.push('-p', String(resolvedPort));
+  }
+  sshArgs.push(`${resolvedUsername}@${host}`, command);
 
   // Build a filtered environment allowlist — never expose full process.env
   // to SSH child processes.

--- a/src/ssh/pty-manager.ts
+++ b/src/ssh/pty-manager.ts
@@ -94,7 +94,7 @@ export async function runSshSession(opts: PtySessionOptions): Promise<PtySession
   if (resolvedPort !== undefined && resolvedPort !== 22) {
     sshArgs.push('-p', String(resolvedPort));
   }
-  sshArgs.push(`${resolvedUsername}@${host}`, command);
+  sshArgs.push('--', `${resolvedUsername}@${host}`, command);
 
   // Build a filtered environment allowlist — never expose full process.env
   // to SSH child processes.

--- a/src/ssh/ssh-config-reader.ts
+++ b/src/ssh/ssh-config-reader.ts
@@ -1,0 +1,127 @@
+/**
+ * SSH config resolver — uses `ssh -G <host>` to parse ~/.ssh/config
+ * (including Include directives, Match blocks, and Host patterns) via the
+ * OpenSSH binary itself. This is the canonical way to resolve SSH config
+ * without re-implementing the full ssh_config(5) grammar.
+ *
+ * Falls back gracefully when the ssh binary is unavailable or the config
+ * does not exist.
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { resolveSshBin } from '../utils/cli-resolver.js';
+
+const execFileAsync = promisify(execFile);
+
+export interface SshConfigValues {
+  /** Resolved HostName (may differ from the alias passed in). */
+  hostname: string;
+  /** User directive from ssh config. */
+  user?: string;
+  /** Port (default 22 when not in config). */
+  port: number;
+  /** Resolved identity files (may include ~ paths). */
+  identityFiles: string[];
+  /** ProxyJump value (e.g. "bastion.example.com"). */
+  proxyJump?: string;
+  /** ProxyCommand value. */
+  proxyCommand?: string;
+  /** ConnectTimeout in seconds from config. */
+  connectTimeout?: number;
+}
+
+/**
+ * Resolve ~/.ssh/config for `host` using `ssh -G <host>`.
+ *
+ * Returns `null` when the ssh binary is not found, `ssh -G` fails (e.g.
+ * no config file, or an older SSH version without -G), or the call times out.
+ * Callers should treat null as "no config available" and proceed with
+ * explicit parameters only.
+ */
+export async function resolveSshConfig(host: string): Promise<SshConfigValues | null> {
+  let sshBin: string;
+  try {
+    sshBin = await resolveSshBin();
+  } catch {
+    return null;
+  }
+
+  try {
+    const { stdout } = await execFileAsync(sshBin, ['-G', host], {
+      timeout: 5_000,
+      // Never inherit parent env for security — only pass HOME so ssh can find ~/.ssh/config
+      env: {
+        HOME: process.env.HOME ?? process.env.USERPROFILE ?? '',
+        PATH: process.env.PATH ?? '',
+        // Windows compat
+        USERPROFILE: process.env.USERPROFILE,
+        HOMEDRIVE: process.env.HOMEDRIVE,
+        HOMEPATH: process.env.HOMEPATH,
+        SystemRoot: process.env.SystemRoot,
+      } as Record<string, string>,
+    });
+    return parseSshGOutput(stdout, host);
+  } catch {
+    // ssh -G is not fatal — just means we have no config to apply
+    return null;
+  }
+}
+
+/**
+ * Parse the key-value output of `ssh -G <host>`.
+ *
+ * `ssh -G` emits one "key value" pair per line (lower-cased keys).
+ * Multi-value keys like `identityfile` may appear multiple times.
+ */
+function parseSshGOutput(output: string, originalHost: string): SshConfigValues {
+  const lines = output.split('\n');
+
+  const get = (key: string): string | undefined => {
+    const lower = key.toLowerCase();
+    const line = lines.find(l => l.toLowerCase().startsWith(lower + ' '));
+    return line ? line.slice(lower.length + 1).trim() : undefined;
+  };
+
+  const getAll = (key: string): string[] => {
+    const lower = key.toLowerCase();
+    return lines
+      .filter(l => l.toLowerCase().startsWith(lower + ' '))
+      .map(l => l.slice(lower.length + 1).trim())
+      .filter(Boolean);
+  };
+
+  const hostname = get('hostname') ?? originalHost;
+
+  const user = get('user') || undefined;
+
+  const portStr = get('port');
+  const port = portStr ? parseInt(portStr, 10) : 22;
+
+  // ssh -G may emit "identityfile none" when no identity is configured
+  const identityFiles = getAll('identityfile').filter(f => f !== 'none' && f !== '');
+
+  const proxyJump = get('proxyjump');
+  // "none" means explicitly disabled
+  const resolvedProxyJump = proxyJump && proxyJump.toLowerCase() !== 'none' ? proxyJump : undefined;
+
+  const proxyCommand = get('proxycommand');
+  const resolvedProxyCommand =
+    proxyCommand && proxyCommand.toLowerCase() !== 'none' ? proxyCommand : undefined;
+
+  const connectTimeoutStr = get('connecttimeout');
+  const connectTimeout =
+    connectTimeoutStr && connectTimeoutStr !== '0'
+      ? parseInt(connectTimeoutStr, 10)
+      : undefined;
+
+  return {
+    hostname,
+    user,
+    port,
+    identityFiles,
+    proxyJump: resolvedProxyJump,
+    proxyCommand: resolvedProxyCommand,
+    connectTimeout,
+  };
+}

--- a/src/ssh/ssh-config-reader.ts
+++ b/src/ssh/ssh-config-reader.ts
@@ -96,7 +96,8 @@ function parseSshGOutput(output: string, originalHost: string): SshConfigValues 
   const user = get('user') || undefined;
 
   const portStr = get('port');
-  const port = portStr ? parseInt(portStr, 10) : 22;
+  const parsedPort = portStr ? parseInt(portStr, 10) : 22;
+  const port = Number.isFinite(parsedPort) && parsedPort >= 1 && parsedPort <= 65535 ? parsedPort : 22;
 
   // ssh -G may emit "identityfile none" when no identity is configured
   const identityFiles = getAll('identityfile').filter(f => f !== 'none' && f !== '');
@@ -110,9 +111,13 @@ function parseSshGOutput(output: string, originalHost: string): SshConfigValues 
     proxyCommand && proxyCommand.toLowerCase() !== 'none' ? proxyCommand : undefined;
 
   const connectTimeoutStr = get('connecttimeout');
-  const connectTimeout =
+  const parsedConnectTimeout =
     connectTimeoutStr && connectTimeoutStr !== '0'
       ? parseInt(connectTimeoutStr, 10)
+      : undefined;
+  const connectTimeout =
+    parsedConnectTimeout !== undefined && Number.isFinite(parsedConnectTimeout) && parsedConnectTimeout > 0
+      ? parsedConnectTimeout
       : undefined;
 
   return {

--- a/src/ssh/ssh-config-reader.ts
+++ b/src/ssh/ssh-config-reader.ts
@@ -48,7 +48,7 @@ export async function resolveSshConfig(host: string): Promise<SshConfigValues | 
   }
 
   try {
-    const { stdout } = await execFileAsync(sshBin, ['-G', host], {
+    const { stdout } = await execFileAsync(sshBin, ['-G', '--', host], {
       timeout: 5_000,
       // Never inherit parent env for security — only pass HOME so ssh can find ~/.ssh/config
       env: {

--- a/src/tools/ssh-check.ts
+++ b/src/tools/ssh-check.ts
@@ -6,6 +6,7 @@
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { resolveSshBin } from '../utils/cli-resolver.js';
+import { resolveSshConfig } from '../ssh/ssh-config-reader.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -14,6 +15,13 @@ export interface SshCheckInput {
   port?: number;
   username?: string;
   timeout_ms?: number;
+  /**
+   * When true (default), resolve ~/.ssh/config for the given host alias so that
+   * ssh_config(5) directives (HostName, User, Port, IdentityFile, ProxyJump, etc.)
+   * are applied. Tool arguments always take precedence over config values.
+   * Set to false to bypass ssh config lookup entirely.
+   */
+  use_ssh_config?: boolean;
 }
 
 export interface SshCheckResult {
@@ -23,7 +31,18 @@ export interface SshCheckResult {
 }
 
 export async function sshCheckHost(input: SshCheckInput): Promise<SshCheckResult> {
-  const { host, port = 22, username, timeout_ms = 5000 } = input;
+  const { host, timeout_ms = 5000, use_ssh_config = true } = input;
+  let { port, username } = input;
+
+  if (use_ssh_config) {
+    const cfg = await resolveSshConfig(host);
+    if (cfg) {
+      port ??= cfg.port !== 22 ? cfg.port : undefined;
+      username ??= cfg.user;
+    }
+  }
+
+  const resolvedPort = port ?? 22;
 
   const sshBin = await resolveSshBin();
   const timeoutSec = Math.max(1, Math.ceil(timeout_ms / 1000));
@@ -34,7 +53,7 @@ export async function sshCheckHost(input: SshCheckInput): Promise<SshCheckResult
     '-o', 'BatchMode=yes',
     '-o', `ConnectTimeout=${timeoutSec}`,
     '-o', 'StrictHostKeyChecking=accept-new',
-    '-p', String(port),
+    '-p', String(resolvedPort),
     target,
     'exit',
   ];

--- a/src/tools/ssh-check.ts
+++ b/src/tools/ssh-check.ts
@@ -54,6 +54,7 @@ export async function sshCheckHost(input: SshCheckInput): Promise<SshCheckResult
     '-o', `ConnectTimeout=${timeoutSec}`,
     '-o', 'StrictHostKeyChecking=accept-new',
     '-p', String(resolvedPort),
+    '--',
     target,
     'exit',
   ];

--- a/src/tools/ssh-execute.ts
+++ b/src/tools/ssh-execute.ts
@@ -14,6 +14,13 @@ export interface SshExecuteInput {
   credential_backend?: string;
   platform?: PlatformHint;
   timeout_ms?: number;
+  /**
+   * When true (default), resolve ~/.ssh/config for the given host alias so that
+   * ssh_config(5) directives (HostName, User, Port, IdentityFile, ProxyJump, etc.)
+   * are applied. Tool arguments always take precedence over config values.
+   * Set to false to bypass ssh config lookup entirely.
+   */
+  use_ssh_config?: boolean;
 }
 
 export interface SshExecuteResult {
@@ -70,17 +77,21 @@ export async function sshExecute(
     }
   }
 
-  if (!resolvedUsername) throw new Error('username is required (provide username or a credential_ref with a username)');
+  if (!resolvedUsername) {
+    // Don't throw here — pty-manager will attempt ssh config resolution first
+    // (if use_ssh_config is enabled) and throw with a better error message.
+  }
 
   // Run the PTY session
   try {
     const result = await runSshSession({
       host,
-      username: resolvedUsername,
+      username: resolvedUsername || undefined,
       password: passwordBuffer,
       command,
       platform,
       timeout_ms,
+      use_ssh_config: input.use_ssh_config ?? true,
     });
     return result;
   } finally {

--- a/src/tools/ssh-execute.ts
+++ b/src/tools/ssh-execute.ts
@@ -77,10 +77,9 @@ export async function sshExecute(
     }
   }
 
-  if (!resolvedUsername) {
-    // Don't throw here — pty-manager will attempt ssh config resolution first
-    // (if use_ssh_config is enabled) and throw with a better error message.
-  }
+  // Don't throw here when resolvedUsername is empty — pty-manager will attempt
+  // ssh config resolution first (if use_ssh_config is enabled) and throw with
+  // a better error message if username resolution still fails.
 
   // Run the PTY session
   try {

--- a/src/tools/ssh-session-open.ts
+++ b/src/tools/ssh-session-open.ts
@@ -11,6 +11,7 @@ import type { CredentialRegistry } from '../credentials/registry.js';
 import type { SessionStore } from '../ssh/session-store.js';
 import { detectPasswordPrompt, detectPrompt } from '../ssh/prompt-detector.js';
 import { SSH_PTY_OPTIONS } from '../ssh/pty-options.js';
+import { resolveSshConfig } from '../ssh/ssh-config-reader.js';
 
 export interface SshSessionOpenInput {
   host: string;
@@ -20,6 +21,13 @@ export interface SshSessionOpenInput {
   platform?: PlatformHint;
   timeout_ms?: number;      // connect + initial prompt timeout (default: 30000)
   idle_timeout_ms?: number; // inactivity auto-close passed to SessionStore (default: 300000)
+  /**
+   * When true (default), resolve ~/.ssh/config for the given host alias so that
+   * ssh_config(5) directives (HostName, User, Port, IdentityFile, ProxyJump, etc.)
+   * are applied. Tool arguments always take precedence over config values.
+   * Set to false to bypass ssh config lookup entirely.
+   */
+  use_ssh_config?: boolean;
 }
 
 export interface SshSessionOpenResult {
@@ -42,6 +50,7 @@ export async function sshSessionOpen(
     platform = 'auto',
     timeout_ms = 30_000,
     idle_timeout_ms,
+    use_ssh_config = true,
   } = input;
 
   if (!host) throw new Error('host is required');
@@ -70,9 +79,23 @@ export async function sshSessionOpen(
     }
   }
 
+  // ── SSH config resolution ───────────────────────────────────────────────
+  // Resolve ~/.ssh/config for this host alias before spawning the PTY.
+  // Tool-provided values always win; config fills in what was not supplied.
+  let resolvedPort: number | undefined;
+
+  if (use_ssh_config) {
+    const cfg = await resolveSshConfig(host);
+    if (cfg) {
+      if (!resolvedUsername) resolvedUsername = cfg.user ?? '';
+      if (cfg.port !== 22) resolvedPort = cfg.port;
+    }
+  }
+
   if (!resolvedUsername) {
     throw new Error(
-      'username is required (provide username or a credential_ref with a username)',
+      'username is required. Provide username, a credential_ref with a username, ' +
+      'or add a User directive to ~/.ssh/config for this host.',
     );
   }
 
@@ -94,14 +117,17 @@ export async function sshSessionOpen(
   childEnv.TERM ??= 'xterm-color';
 
   // ── Spawn interactive shell (no command in argv → opens a shell) ──────────
-  const sshArgs = [
+  // Pass the original host alias — SSH applies its own config (HostName, IdentityFile, ProxyJump, etc.)
+  const sshArgs: string[] = [
     '-tt',
     '-o', 'StrictHostKeyChecking=accept-new',
     '-o', 'NumberOfPasswordPrompts=1',
     '-o', 'ConnectTimeout=10',
-    `${resolvedUsername}@${host}`,
-    // Intentionally no command — we want an interactive shell
   ];
+  if (resolvedPort !== undefined && resolvedPort !== 22) {
+    sshArgs.push('-p', String(resolvedPort));
+  }
+  sshArgs.push(`${resolvedUsername}@${host}`);
 
   return new Promise<SshSessionOpenResult>((resolve, reject) => {
     let term: import('node-pty').IPty;

--- a/test/unit/pty-manager.test.ts
+++ b/test/unit/pty-manager.test.ts
@@ -6,6 +6,12 @@
 import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest';
 import type { PtySessionOptions } from '../../src/ssh/pty-manager.js';
 
+// ---- ssh-config-reader mock (return null — tests supply username explicitly) ---
+vi.mock('../../src/ssh/ssh-config-reader.js', () => ({
+  resolveSshConfig: vi.fn().mockResolvedValue(null),
+}));
+// -------------------------------------------------------------------------
+
 // ---- node-pty mock -------------------------------------------------------
 interface FakePtyHandlers {
   onData: (cb: (data: string) => void) => void;
@@ -58,8 +64,8 @@ describe('runSshSession', () => {
   it('returns output and exit_code on successful command', async () => {
     const promise = runSshSession(makeOpts());
 
-    // Let the dynamic import inside runSshSession resolve before interacting
-    await new Promise(r => setTimeout(r, 0));
+    // Let the config resolution + dynamic import inside runSshSession resolve
+    await new Promise(r => setTimeout(r, 20));
 
     // Simulate command output then exit
     fakeOnData!('eric@test-host:~$ ');
@@ -79,8 +85,8 @@ describe('runSshSession', () => {
   it('handles password prompt and sends password', async () => {
     const promise = runSshSession(makeOpts({ password: Buffer.from('mypassword') }));
 
-    // Let the dynamic import inside runSshSession resolve before interacting
-    await new Promise(r => setTimeout(r, 0));
+    // Let the config resolution + dynamic import inside runSshSession resolve
+    await new Promise(r => setTimeout(r, 20));
 
     // Simulate password prompt then shell prompt then exit
     fakeOnData!('Password: ');
@@ -112,8 +118,8 @@ describe('runSshSession', () => {
   it('scrubs ANSI escape sequences from output', async () => {
     const promise = runSshSession(makeOpts());
 
-    // Let the dynamic import inside runSshSession resolve before interacting
-    await new Promise(r => setTimeout(r, 0));
+    // Let the config resolution + dynamic import inside runSshSession resolve
+    await new Promise(r => setTimeout(r, 20));
 
     // Simulate output with ANSI codes
     fakeOnData!('\x1B[32mhello\x1B[0m\r\neric@test-host:~$ ');

--- a/test/unit/ssh-config-reader.test.ts
+++ b/test/unit/ssh-config-reader.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for ssh-config-reader.ts
+ * Mocks execFile (via cli-resolver + child_process) to avoid calling real ssh.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock resolveSshBin ──────────────────────────────────────────────────────
+vi.mock('../../src/utils/cli-resolver.js', () => ({
+  resolveSshBin: vi.fn().mockResolvedValue('/usr/bin/ssh'),
+  resolveSshPass: vi.fn().mockResolvedValue('/usr/bin/sshpass'),
+}));
+
+// ── Mock child_process.execFile ─────────────────────────────────────────────
+const execFileMock = vi.fn();
+vi.mock('child_process', () => ({
+  execFile: vi.fn((_bin, _args, _opts, cb) => {
+    // promisify wraps execFile — we intercept the raw call here
+    execFileMock(_bin, _args, _opts, cb);
+  }),
+}));
+
+// ── Import AFTER mocks are set up ──────────────────────────────────────────
+const { resolveSshConfig } = await import('../../src/ssh/ssh-config-reader.js');
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Build fake `ssh -G` output lines as a multi-line string. */
+function buildSshGOutput(overrides: Record<string, string | string[]> = {}): string {
+  const defaults: Record<string, string | string[]> = {
+    hostname: 'actual-host.example.com',
+    user: 'alice',
+    port: '22',
+    identityfile: ['~/.ssh/id_rsa', '~/.ssh/id_ed25519'],
+    proxyjump: 'none',
+    proxycommand: 'none',
+    connecttimeout: '0',
+  };
+  const merged = { ...defaults, ...overrides };
+
+  const lines: string[] = [];
+  for (const [key, val] of Object.entries(merged)) {
+    if (Array.isArray(val)) {
+      for (const v of val) lines.push(`${key} ${v}`);
+    } else {
+      lines.push(`${key} ${val}`);
+    }
+  }
+  return lines.join('\n') + '\n';
+}
+
+/** Make execFileMock resolve with a given stdout string. */
+function mockSshGSuccess(stdout: string): void {
+  execFileMock.mockImplementation((_bin: string, _args: string[], _opts: object, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+    cb(null, { stdout, stderr: '' });
+  });
+}
+
+/** Make execFileMock reject (simulates ssh -G failure). */
+function mockSshGFailure(message = 'ssh -G failed'): void {
+  execFileMock.mockImplementation((_bin: string, _args: string[], _opts: object, cb: (err: Error) => void) => {
+    cb(new Error(message));
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('resolveSshConfig', () => {
+  it('returns hostname, user, port, identityFiles from ssh -G output', async () => {
+    mockSshGSuccess(buildSshGOutput({
+      hostname: 'real-host.corp.example.com',
+      user: 'deploy',
+      port: '2222',
+      identityfile: ['~/.ssh/deploy_key'],
+    }));
+
+    const cfg = await resolveSshConfig('my-alias');
+
+    expect(cfg).not.toBeNull();
+    expect(cfg!.hostname).toBe('real-host.corp.example.com');
+    expect(cfg!.user).toBe('deploy');
+    expect(cfg!.port).toBe(2222);
+    expect(cfg!.identityFiles).toContain('~/.ssh/deploy_key');
+  });
+
+  it('resolves proxyJump when set', async () => {
+    mockSshGSuccess(buildSshGOutput({
+      proxyjump: 'bastion.example.com',
+    }));
+
+    const cfg = await resolveSshConfig('internal-host');
+    expect(cfg!.proxyJump).toBe('bastion.example.com');
+  });
+
+  it('sets proxyJump to undefined when value is "none"', async () => {
+    mockSshGSuccess(buildSshGOutput({ proxyjump: 'none' }));
+    const cfg = await resolveSshConfig('some-host');
+    expect(cfg!.proxyJump).toBeUndefined();
+  });
+
+  it('sets proxyCommand to undefined when value is "none"', async () => {
+    mockSshGSuccess(buildSshGOutput({ proxycommand: 'none' }));
+    const cfg = await resolveSshConfig('some-host');
+    expect(cfg!.proxyCommand).toBeUndefined();
+  });
+
+  it('collects multiple identityfile entries', async () => {
+    mockSshGSuccess(buildSshGOutput({
+      identityfile: ['~/.ssh/id_rsa', '~/.ssh/id_ed25519', '~/.ssh/corp_key'],
+    }));
+
+    const cfg = await resolveSshConfig('multi-key-host');
+    expect(cfg!.identityFiles).toHaveLength(3);
+    expect(cfg!.identityFiles).toContain('~/.ssh/corp_key');
+  });
+
+  it('filters out "none" identityfile entries', async () => {
+    mockSshGSuccess(buildSshGOutput({
+      identityfile: 'none',
+    }));
+    const cfg = await resolveSshConfig('no-key-host');
+    expect(cfg!.identityFiles).toHaveLength(0);
+  });
+
+  it('returns null when ssh -G fails', async () => {
+    mockSshGFailure('No such file or directory');
+    const cfg = await resolveSshConfig('unknown-host');
+    expect(cfg).toBeNull();
+  });
+
+  it('parses connectTimeout when set', async () => {
+    mockSshGSuccess(buildSshGOutput({ connecttimeout: '15' }));
+    const cfg = await resolveSshConfig('slow-host');
+    expect(cfg!.connectTimeout).toBe(15);
+  });
+
+  it('leaves connectTimeout undefined when value is 0', async () => {
+    mockSshGSuccess(buildSshGOutput({ connecttimeout: '0' }));
+    const cfg = await resolveSshConfig('default-host');
+    expect(cfg!.connectTimeout).toBeUndefined();
+  });
+
+  it('falls back to original host when hostname line is missing', async () => {
+    // Minimal output with no hostname line
+    mockSshGSuccess('user alice\nport 22\n');
+    const cfg = await resolveSshConfig('my-alias');
+    expect(cfg!.hostname).toBe('my-alias');
+  });
+
+  it('returns null when resolveSshBin throws', async () => {
+    const { resolveSshBin } = await import('../../src/utils/cli-resolver.js');
+    vi.mocked(resolveSshBin).mockRejectedValueOnce(new Error('ssh not found'));
+
+    const cfg = await resolveSshConfig('some-host');
+    expect(cfg).toBeNull();
+  });
+});

--- a/test/unit/ssh-session-open.test.ts
+++ b/test/unit/ssh-session-open.test.ts
@@ -5,6 +5,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { MockInstance } from 'vitest';
 
+// ---- ssh-config-reader mock (return null — tests supply username explicitly) ---
+vi.mock('../../src/ssh/ssh-config-reader.js', () => ({
+  resolveSshConfig: vi.fn().mockResolvedValue(null),
+}));
+// -------------------------------------------------------------------------
+
 // ---- node-pty mock -------------------------------------------------------
 interface FakePtyHandlers {
   onData: (cb: (data: string) => void) => { dispose: ReturnType<typeof vi.fn> };
@@ -69,8 +75,8 @@ describe('sshSessionOpen', () => {
       timeout_ms: 5000,
     });
 
-    // Let dynamic import resolve
-    await new Promise(r => setTimeout(r, 0));
+    // Let config resolution + dynamic import resolve
+    await new Promise(r => setTimeout(r, 20));
 
     // Simulate shell prompt appearing
     fakeOnData!('eric@test-host:~$ ');
@@ -100,7 +106,7 @@ describe('sshSessionOpen', () => {
       timeout_ms: 5000,
     });
 
-    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 20));
 
     // Simulate password prompt, then shell prompt
     fakeOnData!('Password: ');
@@ -141,7 +147,7 @@ describe('sshSessionOpen', () => {
       timeout_ms: 5000,
     });
 
-    await new Promise(r => setTimeout(r, 0));
+    await new Promise(r => setTimeout(r, 20));
 
     // PTY exits before we see a prompt
     fakeOnExit!({ exitCode: 255 });


### PR DESCRIPTION
## Summary

Resolves #75

Adds full `~/.ssh/config` support across all SSH tools by using `ssh -G <host>` to resolve config (including `Include` directives, `Match` blocks, and Host patterns via the OpenSSH binary itself).

## Changes

### New
- `src/ssh/ssh-config-reader.ts` — runs `ssh -G <host>` and parses the output into a typed `SshConfigValues` object. Resolves: `HostName`, `User`, `Port`, `IdentityFile`, `ProxyJump`, `ProxyCommand`, `ConnectTimeout`. Returns `null` gracefully when SSH binary is unavailable or config parsing fails.
- `test/unit/ssh-config-reader.test.ts` — 11 new unit tests

### Modified
- `src/ssh/pty-manager.ts` — `username` is now optional; resolves SSH config before spawning PTY; passes original host alias to SSH so it can natively apply `IdentityFile`, `ProxyJump`, `Ciphers`, etc.
- `src/tools/ssh-execute.ts` — adds `use_ssh_config` param, relaxes username-required guard
- `src/tools/ssh-session-open.ts` — adds `use_ssh_config` param, applies `User`/`Port` from config
- `src/tools/ssh-check.ts` — adds `use_ssh_config` param, applies `Port`/`User` from config
- `src/index.ts` — exposes `use_ssh_config` in MCP tool schemas for all three tools
- `test/unit/pty-manager.test.ts` — mock ssh-config-reader, update timing for async config resolution
- `test/unit/ssh-session-open.test.ts` — same

## Acceptance Criteria

- [x] `ssh_execute(host="my-alias", command="...")` resolves alias from `~/.ssh/config` without other args
- [x] `Include` directives are followed (handled natively by OpenSSH)
- [x] Tool arguments override SSH config values
- [x] `use_ssh_config: false` disables the lookup
- [ ] Documented in README with examples *(follow-up can be done in this PR or separately)*

## Test Results

```
Test Files  16 passed (18)
Tests       159 passed | 5 skipped (164)
```