### PR TITLE
feat: add credential-map file for host→credential resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,48 @@ credential_ref: "admin:SHA256:abc123..."   # username:fingerprint (select specif
 
 The SSH child process inherits `SSH_AUTH_SOCK` automatically, so agent-based auth works without any additional configuration.
 
+## Credential Map
+
+The credential map provides automatic host→credential resolution so you don't need to specify `credential_backend` and `credential_ref` on every tool call.
+
+### Configuration
+
+Create a JSON file at:
+
+- **Linux/macOS:** `~/.config/ai-ssh-toolkit/credential-map.json`
+- **Windows:** `%APPDATA%\ai-ssh-toolkit\credential-map.json`
+
+### Format
+
+```json
+{
+  "rules": [
+    { "match": "*.prod.example.com", "backend": "bitwarden", "ref": "af83b31a", "username": "admin" },
+    { "match": "build-*", "backend": "ssh-agent" },
+    { "match": "10.218.191.*", "backend": "env", "ref": "SWITCH_USER:SWITCH_PASS" },
+    { "match_regex": "^db-\\d+\\.internal$", "match": "*", "backend": "bitwarden", "ref": "db-cred" },
+    { "match": "*", "backend": "ssh-agent" }
+  ]
+}
+```
+
+### Rule fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `match` | Yes | Glob pattern (`*` matches anything, `?` matches one char) |
+| `match_regex` | No | If present, used as a regex instead of the glob pattern |
+| `backend` | Yes | Credential backend name (bitwarden, azure-keyvault, env, google-secret-manager, ssh-agent) |
+| `ref` | No | Credential reference string passed to the backend |
+| `username` | No | SSH username override |
+
+### Behavior
+
+- **First-match-wins:** rules are evaluated top-to-bottom; the first match is used.
+- **Tool arguments override:** explicit `credential_backend`/`credential_ref` in tool calls always take precedence over the map.
+- **Missing file = no-op:** if the config file doesn't exist, tools continue with existing behavior (no credentials).
+- **Diagnostics:** use the `credential_diagnose` tool to test which rule matches a given host.
+
 ## Platform Support
 
 | Platform | SSH Client | PTY Type |

--- a/src/credentials/credential-map.ts
+++ b/src/credentials/credential-map.ts
@@ -1,0 +1,123 @@
+/**
+ * CredentialMap — host→credential resolution via a JSON rules file.
+ *
+ * Loads rules from a JSON config file and resolves hosts to credential
+ * backend+ref using first-match-wins semantics with glob or regex patterns.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { platform, homedir } from 'os';
+
+export interface CredentialMapRule {
+  match: string;
+  match_regex?: string;
+  backend: string;
+  ref?: string;
+  username?: string;
+}
+
+export interface CredentialMapFile {
+  rules: CredentialMapRule[];
+}
+
+export interface CredentialMapResult {
+  backend: string;
+  ref?: string;
+  username?: string;
+  /** The rule that matched (for diagnostics) */
+  matched_rule?: CredentialMapRule;
+}
+
+/**
+ * Convert a simple glob pattern to a RegExp.
+ * Supports: * (anything), ? (single char). Escapes other regex chars.
+ */
+function globToRegex(pattern: string): RegExp {
+  let regex = '';
+  for (let i = 0; i < pattern.length; i++) {
+    const ch = pattern[i];
+    if (ch === '*') {
+      regex += '.*';
+    } else if (ch === '?') {
+      regex += '.';
+    } else if ('.+^${}()|[]\\'.includes(ch)) {
+      regex += '\\' + ch;
+    } else {
+      regex += ch;
+    }
+  }
+  return new RegExp('^' + regex + '$', 'i');
+}
+
+export class CredentialMap {
+  private rules: CredentialMapRule[] = [];
+  private filePath: string;
+
+  constructor(filePath?: string) {
+    this.filePath = filePath ?? CredentialMap.defaultPath();
+    this.load();
+  }
+
+  /** Platform-appropriate default config path */
+  static defaultPath(): string {
+    if (platform() === 'win32') {
+      const appData = process.env.APPDATA ?? join(homedir(), 'AppData', 'Roaming');
+      return join(appData, 'ai-ssh-toolkit', 'credential-map.json');
+    }
+    return join(homedir(), '.config', 'ai-ssh-toolkit', 'credential-map.json');
+  }
+
+  /** Load (or reload) rules from the config file. Silent no-op on missing/invalid file. */
+  reload(): void {
+    this.load();
+  }
+
+  /** Resolve a host to a credential backend+ref. Returns null if no rule matches. */
+  resolve(host: string): CredentialMapResult | null {
+    for (const rule of this.rules) {
+      if (this.matches(rule, host)) {
+        return {
+          backend: rule.backend,
+          ref: rule.ref,
+          username: rule.username,
+          matched_rule: rule,
+        };
+      }
+    }
+    return null;
+  }
+
+  /** Get loaded rules (for diagnostics) */
+  getRules(): ReadonlyArray<CredentialMapRule> {
+    return this.rules;
+  }
+
+  private load(): void {
+    try {
+      const raw = readFileSync(this.filePath, 'utf-8');
+      const parsed = JSON.parse(raw) as CredentialMapFile;
+      if (Array.isArray(parsed.rules)) {
+        this.rules = parsed.rules;
+      } else {
+        this.rules = [];
+      }
+    } catch {
+      // Missing file or invalid JSON — silent no-op
+      this.rules = [];
+    }
+  }
+
+  private matches(rule: CredentialMapRule, host: string): boolean {
+    if (rule.match_regex) {
+      try {
+        const re = new RegExp(rule.match_regex, 'i');
+        return re.test(host);
+      } catch {
+        return false;
+      }
+    }
+    const re = globToRegex(rule.match);
+    return re.test(host);
+  }
+}

--- a/src/credentials/credential-map.ts
+++ b/src/credentials/credential-map.ts
@@ -17,6 +17,12 @@ export interface CredentialMapRule {
   username?: string;
 }
 
+/** Internal representation with pre-compiled regex for performance and ReDoS mitigation. */
+interface CompiledRule {
+  rule: CredentialMapRule;
+  regex: RegExp;
+}
+
 export interface CredentialMapFile {
   rules: CredentialMapRule[];
 }
@@ -27,6 +33,8 @@ export interface CredentialMapResult {
   username?: string;
   /** The rule that matched (for diagnostics) */
   matched_rule?: CredentialMapRule;
+  /** Index of the matched rule in the rules array */
+  matched_rule_index?: number;
 }
 
 /**
@@ -51,7 +59,7 @@ function globToRegex(pattern: string): RegExp {
 }
 
 export class CredentialMap {
-  private rules: CredentialMapRule[] = [];
+  private compiledRules: CompiledRule[] = [];
   private filePath: string;
 
   constructor(filePath?: string) {
@@ -75,14 +83,23 @@ export class CredentialMap {
 
   /** Resolve a host to a credential backend+ref. Returns null if no rule matches. */
   resolve(host: string): CredentialMapResult | null {
-    for (const rule of this.rules) {
-      if (this.matches(rule, host)) {
-        return {
-          backend: rule.backend,
-          ref: rule.ref,
-          username: rule.username,
-          matched_rule: rule,
-        };
+    for (let i = 0; i < this.compiledRules.length; i++) {
+      const { rule, regex } = this.compiledRules[i];
+      // ReDoS note: regex is pre-compiled at load time. User-supplied patterns
+      // could still be expensive; consider restricting pattern complexity in docs.
+      try {
+        if (regex.test(host)) {
+          return {
+            backend: rule.backend,
+            ref: rule.ref,
+            username: rule.username,
+            matched_rule: rule,
+            matched_rule_index: i,
+          };
+        }
+      } catch {
+        // Skip rules whose regex throws (should not happen with pre-compiled, but defensive)
+        continue;
       }
     }
     return null;
@@ -90,7 +107,12 @@ export class CredentialMap {
 
   /** Get loaded rules (for diagnostics) */
   getRules(): ReadonlyArray<CredentialMapRule> {
-    return this.rules;
+    return this.compiledRules.map(cr => cr.rule);
+  }
+
+  /** Get the config file path */
+  getFilePath(): string {
+    return this.filePath;
   }
 
   private load(): void {
@@ -98,26 +120,29 @@ export class CredentialMap {
       const raw = readFileSync(this.filePath, 'utf-8');
       const parsed = JSON.parse(raw) as CredentialMapFile;
       if (Array.isArray(parsed.rules)) {
-        this.rules = parsed.rules;
+        // Validate: skip entries missing required fields
+        const validRules = parsed.rules.filter(
+          (r): r is CredentialMapRule =>
+            typeof r.match === 'string' && typeof r.backend === 'string'
+        );
+        // Pre-compile all regexes at load time to avoid per-resolve overhead
+        this.compiledRules = [];
+        for (const rule of validRules) {
+          try {
+            const regex = rule.match_regex
+              ? new RegExp(rule.match_regex, 'i')
+              : globToRegex(rule.match);
+            this.compiledRules.push({ rule, regex });
+          } catch {
+            // Skip rules with invalid regex patterns
+          }
+        }
       } else {
-        this.rules = [];
+        this.compiledRules = [];
       }
     } catch {
       // Missing file or invalid JSON — silent no-op
-      this.rules = [];
+      this.compiledRules = [];
     }
-  }
-
-  private matches(rule: CredentialMapRule, host: string): boolean {
-    if (rule.match_regex) {
-      try {
-        const re = new RegExp(rule.match_regex, 'i');
-        return re.test(host);
-      } catch {
-        return false;
-      }
-    }
-    const re = globToRegex(rule.match);
-    return re.test(host);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { sshCheckHost } from './tools/ssh-check.js';
 import { versionCheck } from './tools/version-check.js';
 import { credentialDiagnose } from './tools/credential-diagnose.js';
 import { CredentialRegistry } from './credentials/registry.js';
+import { CredentialMap } from './credentials/credential-map.js';
 import { BitwardenBackend } from './credentials/bitwarden.js';
 import { AzureKeyVaultBackend } from './credentials/azure-keyvault.js';
 import { EnvCredentialBackend } from './credentials/env.js';
@@ -66,6 +67,7 @@ registry.register(new GoogleSecretManagerBackend());
 registry.register(new SshAgentBackend());
 
 const sessionStore = new SessionStore();
+const credentialMap = new CredentialMap();
 
 // Graceful shutdown: destroy all sessions before exiting
 const shutdown = () => { sessionStore.destroy(); process.exit(0); };
@@ -92,7 +94,7 @@ server.tool(
   },
   async (input) => {
     try {
-      const result = await sshExecute(registry, input);
+      const result = await sshExecute(registry, input, credentialMap);
       return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
     } catch (err: unknown) {
       return {
@@ -123,7 +125,7 @@ server.tool(
   },
   async (input) => {
     try {
-      const result = await sshMultiExecute(input, registry);
+      const result = await sshMultiExecute(input, registry, credentialMap);
       return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
     } catch (err: unknown) {
       return {
@@ -186,7 +188,7 @@ server.tool(
   },
   async (input) => {
     try {
-      const result = await sshCheckHost(input);
+      const result = await sshCheckHost(input, credentialMap);
       return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
     } catch (err: unknown) {
       return {
@@ -216,7 +218,7 @@ server.tool(
   },
   async (input) => {
     try {
-      const result = await sshSessionOpen(registry, sessionStore, input);
+      const result = await sshSessionOpen(registry, sessionStore, input, credentialMap);
       return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
     } catch (err: unknown) {
       return {
@@ -278,8 +280,28 @@ server.tool(
   },
   async (input) => {
     try {
-      const result = await credentialDiagnose(registry, input);
+      const result = await credentialDiagnose(registry, input, credentialMap);
       return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── credential_map_reload ─────────────────────────────────────────────────────
+server.tool(
+  'credential_map_reload',
+  'Reload the credential map configuration from disk.',
+  {},
+  async () => {
+    try {
+      credentialMap.reload();
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify({ success: true, path: credentialMap.getFilePath() }) }],
+      };
     } catch (err: unknown) {
       return {
         content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import { credentialGet } from './tools/credential-get.js';
 import { credentialListBackends } from './tools/credential-list.js';
 import { sshCheckHost } from './tools/ssh-check.js';
 import { versionCheck } from './tools/version-check.js';
+import { credentialDiagnose } from './tools/credential-diagnose.js';
 import { CredentialRegistry } from './credentials/registry.js';
 import { BitwardenBackend } from './credentials/bitwarden.js';
 import { AzureKeyVaultBackend } from './credentials/azure-keyvault.js';
@@ -258,6 +259,26 @@ server.tool(
   async (input) => {
     try {
       const result = await sshSessionClose(sessionStore, input);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── credential_diagnose ──────────────────────────────────────────────────────
+server.tool(
+  'credential_diagnose',
+  'Diagnose credential map resolution for a given host. Shows which rule matched and whether the backend is available.',
+  {
+    host: z.string().describe('Hostname or IP address to diagnose credential resolution for'),
+  },
+  async (input) => {
+    try {
+      const result = await credentialDiagnose(registry, input);
       return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
     } catch (err: unknown) {
       return {

--- a/src/tools/credential-diagnose.ts
+++ b/src/tools/credential-diagnose.ts
@@ -1,0 +1,62 @@
+/**
+ * credential_diagnose tool handler — shows which credential map rule
+ * matches a given host and whether the backend is available.
+ */
+
+import type { CredentialRegistry } from '../credentials/registry.js';
+import { CredentialMap } from '../credentials/credential-map.js';
+
+export interface CredentialDiagnoseInput {
+  host: string;
+}
+
+export interface CredentialDiagnoseResult {
+  host: string;
+  matched_rule: {
+    match: string;
+    match_regex?: string;
+    backend: string;
+    ref?: string;
+    username?: string;
+  } | null;
+  backend_available: boolean;
+}
+
+export async function credentialDiagnose(
+  registry: CredentialRegistry,
+  input: CredentialDiagnoseInput,
+): Promise<CredentialDiagnoseResult> {
+  const { host } = input;
+  if (!host) throw new Error('host is required');
+
+  const credMap = new CredentialMap();
+  const resolved = credMap.resolve(host);
+
+  if (!resolved || !resolved.matched_rule) {
+    return {
+      host,
+      matched_rule: null,
+      backend_available: false,
+    };
+  }
+
+  let backendAvailable = false;
+  try {
+    const backend = registry.getBackend(resolved.backend);
+    backendAvailable = await backend.isAvailable();
+  } catch {
+    backendAvailable = false;
+  }
+
+  return {
+    host,
+    matched_rule: {
+      match: resolved.matched_rule.match,
+      match_regex: resolved.matched_rule.match_regex,
+      backend: resolved.matched_rule.backend,
+      ref: resolved.matched_rule.ref,
+      username: resolved.matched_rule.username,
+    },
+    backend_available: backendAvailable,
+  };
+}

--- a/src/tools/credential-diagnose.ts
+++ b/src/tools/credential-diagnose.ts
@@ -4,7 +4,7 @@
  */
 
 import type { CredentialRegistry } from '../credentials/registry.js';
-import { CredentialMap } from '../credentials/credential-map.js';
+import type { CredentialMap } from '../credentials/credential-map.js';
 
 export interface CredentialDiagnoseInput {
   host: string;
@@ -19,23 +19,25 @@ export interface CredentialDiagnoseResult {
     ref?: string;
     username?: string;
   } | null;
+  matched_rule_index: number | null;
   backend_available: boolean;
 }
 
 export async function credentialDiagnose(
   registry: CredentialRegistry,
   input: CredentialDiagnoseInput,
+  credentialMap: CredentialMap,
 ): Promise<CredentialDiagnoseResult> {
   const { host } = input;
   if (!host) throw new Error('host is required');
 
-  const credMap = new CredentialMap();
-  const resolved = credMap.resolve(host);
+  const resolved = credentialMap.resolve(host);
 
   if (!resolved || !resolved.matched_rule) {
     return {
       host,
       matched_rule: null,
+      matched_rule_index: null,
       backend_available: false,
     };
   }
@@ -57,6 +59,7 @@ export async function credentialDiagnose(
       ref: resolved.matched_rule.ref,
       username: resolved.matched_rule.username,
     },
+    matched_rule_index: resolved.matched_rule_index ?? null,
     backend_available: backendAvailable,
   };
 }

--- a/src/tools/credential-diagnose.ts
+++ b/src/tools/credential-diagnose.ts
@@ -47,7 +47,7 @@ export async function credentialDiagnose(
     const backend = registry.getBackend(resolved.backend);
     backendAvailable = await backend.isAvailable();
   } catch {
-    backendAvailable = false;
+    // backend not found or unavailable
   }
 
   return {

--- a/src/tools/ssh-check.ts
+++ b/src/tools/ssh-check.ts
@@ -7,7 +7,7 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { resolveSshBin } from '../utils/cli-resolver.js';
 import { resolveSshConfig } from '../ssh/ssh-config-reader.js';
-import { CredentialMap } from '../credentials/credential-map.js';
+import type { CredentialMap } from '../credentials/credential-map.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -31,14 +31,13 @@ export interface SshCheckResult {
   error?: string;
 }
 
-export async function sshCheckHost(input: SshCheckInput): Promise<SshCheckResult> {
+export async function sshCheckHost(input: SshCheckInput, credentialMap: CredentialMap): Promise<SshCheckResult> {
   const { host, timeout_ms = 5000, use_ssh_config = true } = input;
   let { port, username } = input;
 
   // Credential map fallback for username resolution
   if (!username) {
-    const credMap = new CredentialMap();
-    const mapped = credMap.resolve(host);
+    const mapped = credentialMap.resolve(host);
     if (mapped?.username) {
       username = mapped.username;
     }

--- a/src/tools/ssh-check.ts
+++ b/src/tools/ssh-check.ts
@@ -7,6 +7,7 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { resolveSshBin } from '../utils/cli-resolver.js';
 import { resolveSshConfig } from '../ssh/ssh-config-reader.js';
+import { CredentialMap } from '../credentials/credential-map.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -33,6 +34,15 @@ export interface SshCheckResult {
 export async function sshCheckHost(input: SshCheckInput): Promise<SshCheckResult> {
   const { host, timeout_ms = 5000, use_ssh_config = true } = input;
   let { port, username } = input;
+
+  // Credential map fallback for username resolution
+  if (!username) {
+    const credMap = new CredentialMap();
+    const mapped = credMap.resolve(host);
+    if (mapped?.username) {
+      username = mapped.username;
+    }
+  }
 
   if (use_ssh_config) {
     const cfg = await resolveSshConfig(host);

--- a/src/tools/ssh-execute.ts
+++ b/src/tools/ssh-execute.ts
@@ -5,7 +5,7 @@
 import type { PlatformHint } from '../ssh/prompt-detector.js';
 import type { CredentialRegistry } from '../credentials/registry.js';
 import { runSshSession } from '../ssh/pty-manager.js';
-import { CredentialMap } from '../credentials/credential-map.js';
+import type { CredentialMap } from '../credentials/credential-map.js';
 
 export interface SshExecuteInput {
   host: string;
@@ -31,7 +31,8 @@ export interface SshExecuteResult {
 
 export async function sshExecute(
   registry: CredentialRegistry,
-  input: SshExecuteInput
+  input: SshExecuteInput,
+  credentialMap: CredentialMap,
 ): Promise<SshExecuteResult> {
   let {
     credential_ref,
@@ -45,21 +46,20 @@ export async function sshExecute(
     timeout_ms = 30000,
   } = input;
 
+  // Validate required inputs before any lookups
+  if (!host) throw new Error('host is required');
+  if (!command) throw new Error('command is required');
+
   // Credential map fallback: if no explicit backend/ref, consult the map
   let mappedUsername: string | undefined;
   if (credential_backend === undefined && credential_ref === undefined) {
-    const credMap = new CredentialMap();
-    const mapped = credMap.resolve(host);
+    const mapped = credentialMap.resolve(host);
     if (mapped) {
       credential_backend = mapped.backend;
       credential_ref = mapped.ref;
       mappedUsername = mapped.username;
     }
   }
-
-  // Validate required inputs
-  if (!host) throw new Error('host is required');
-  if (!command) throw new Error('command is required');
 
   // Resolve credentials
   let resolvedUsername = username ?? mappedUsername ?? '';

--- a/src/tools/ssh-execute.ts
+++ b/src/tools/ssh-execute.ts
@@ -5,6 +5,7 @@
 import type { PlatformHint } from '../ssh/prompt-detector.js';
 import type { CredentialRegistry } from '../credentials/registry.js';
 import { runSshSession } from '../ssh/pty-manager.js';
+import { CredentialMap } from '../credentials/credential-map.js';
 
 export interface SshExecuteInput {
   host: string;
@@ -32,22 +33,36 @@ export async function sshExecute(
   registry: CredentialRegistry,
   input: SshExecuteInput
 ): Promise<SshExecuteResult> {
+  let {
+    credential_ref,
+    credential_backend,
+  } = input;
   const {
     host,
     command,
     username,
-    credential_ref,
-    credential_backend,
     platform = 'auto',
     timeout_ms = 30000,
   } = input;
+
+  // Credential map fallback: if no explicit backend/ref, consult the map
+  let mappedUsername: string | undefined;
+  if (credential_backend === undefined && credential_ref === undefined) {
+    const credMap = new CredentialMap();
+    const mapped = credMap.resolve(host);
+    if (mapped) {
+      credential_backend = mapped.backend;
+      credential_ref = mapped.ref;
+      mappedUsername = mapped.username;
+    }
+  }
 
   // Validate required inputs
   if (!host) throw new Error('host is required');
   if (!command) throw new Error('command is required');
 
   // Resolve credentials
-  let resolvedUsername = username ?? '';
+  let resolvedUsername = username ?? mappedUsername ?? '';
   // node Buffer — use ArrayBufferLike to satisfy TS6 strict generic check
   let passwordBuffer: Buffer<ArrayBufferLike> = Buffer.alloc(0);
 

--- a/src/tools/ssh-multi-execute.ts
+++ b/src/tools/ssh-multi-execute.ts
@@ -2,6 +2,7 @@ import { PlatformHint, detectPrompt, detectPasswordPrompt } from "../ssh/prompt-
 import { scrubOutput } from "../ssh/output-scrubber.js";
 import { CredentialRegistry } from "../credentials/registry.js";
 import { SSH_PTY_OPTIONS } from "../ssh/pty-options.js";
+import type { CredentialMap } from "../credentials/credential-map.js";
 
 export interface SshMultiExecuteInput {
   hosts: string[];
@@ -39,10 +40,24 @@ export async function executeSingleHost(
   host: string,
   input: SshMultiExecuteInput,
   registry?: CredentialRegistry,
+  credentialMap?: CredentialMap,
 ): Promise<HostResult> {
+  // Credential map fallback: if no explicit backend/ref, consult the map for this host
+  let effectiveBackend = input.credential_backend;
+  let effectiveRef = input.credential_ref;
+  let effectiveUsername = input.username;
+  if (effectiveBackend === undefined && effectiveRef === undefined && credentialMap) {
+    const mapped = credentialMap.resolve(host);
+    if (mapped) {
+      effectiveBackend = mapped.backend;
+      effectiveRef = mapped.ref;
+      if (mapped.username) effectiveUsername = mapped.username;
+    }
+  }
+
   // Validate credential params upfront
-  if ((input.credential_backend && !input.credential_ref) ||
-      (!input.credential_backend && input.credential_ref)) {
+  if ((effectiveBackend && !effectiveRef) ||
+      (!effectiveBackend && effectiveRef)) {
     return {
       host,
       success: false,
@@ -50,7 +65,7 @@ export async function executeSingleHost(
       duration_ms: 0,
     };
   }
-  if (input.credential_backend && !registry) {
+  if (effectiveBackend && !registry) {
     return {
       host,
       success: false,
@@ -64,14 +79,14 @@ export async function executeSingleHost(
   let password: Buffer | undefined;
   try {
     // Resolve credentials if a backend is configured
-    let username = input.username;
+    let username = effectiveUsername;
 
-    if (input.credential_backend && input.credential_ref && registry) {
-      const backend = registry.getBackend(input.credential_backend);
+    if (effectiveBackend && effectiveRef && registry) {
+      const backend = registry.getBackend(effectiveBackend);
       try {
         const cred = await registry.getCredential(
-          input.credential_backend,
-          input.credential_ref,
+          effectiveBackend,
+          effectiveRef,
         );
         username = cred.username;
         password = cred.password;
@@ -117,6 +132,7 @@ export async function executeSingleHost(
 export async function sshMultiExecute(
   input: SshMultiExecuteInput,
   registry?: CredentialRegistry,
+  credentialMap?: CredentialMap,
   executor: typeof executeSingleHost = executeSingleHost,
 ): Promise<SshMultiExecuteOutput> {
   const wallStart = Date.now();
@@ -146,7 +162,7 @@ export async function sshMultiExecute(
         const { host, idx } = queue[queuePos++];
         activeSlots++;
 
-        executor(host, input, registry)
+        executor(host, input, registry, credentialMap)
           .catch((err): HostResult => ({
             // Capture host in closure so rejection fallback has the right name
             host,

--- a/src/tools/ssh-session-open.ts
+++ b/src/tools/ssh-session-open.ts
@@ -12,7 +12,7 @@ import type { SessionStore } from '../ssh/session-store.js';
 import { detectPasswordPrompt, detectPrompt } from '../ssh/prompt-detector.js';
 import { SSH_PTY_OPTIONS } from '../ssh/pty-options.js';
 import { resolveSshConfig } from '../ssh/ssh-config-reader.js';
-import { CredentialMap } from '../credentials/credential-map.js';
+import type { CredentialMap } from '../credentials/credential-map.js';
 
 export interface SshSessionOpenInput {
   host: string;
@@ -42,6 +42,7 @@ export async function sshSessionOpen(
   registry: CredentialRegistry,
   sessionStore: SessionStore,
   input: SshSessionOpenInput,
+  credentialMap: CredentialMap,
 ): Promise<SshSessionOpenResult> {
   const {
     host,
@@ -61,8 +62,7 @@ export async function sshSessionOpen(
   // Credential map fallback: if no explicit backend/ref, consult the map
   let mappedUsername: string | undefined;
   if (credential_backend === undefined && credential_ref === undefined) {
-    const credMap = new CredentialMap();
-    const mapped = credMap.resolve(host);
+    const mapped = credentialMap.resolve(host);
     if (mapped) {
       credential_backend = mapped.backend;
       credential_ref = mapped.ref;

--- a/src/tools/ssh-session-open.ts
+++ b/src/tools/ssh-session-open.ts
@@ -12,6 +12,7 @@ import type { SessionStore } from '../ssh/session-store.js';
 import { detectPasswordPrompt, detectPrompt } from '../ssh/prompt-detector.js';
 import { SSH_PTY_OPTIONS } from '../ssh/pty-options.js';
 import { resolveSshConfig } from '../ssh/ssh-config-reader.js';
+import { CredentialMap } from '../credentials/credential-map.js';
 
 export interface SshSessionOpenInput {
   host: string;
@@ -45,18 +46,32 @@ export async function sshSessionOpen(
   const {
     host,
     username,
-    credential_ref,
-    credential_backend,
     platform = 'auto',
     timeout_ms = 30_000,
     idle_timeout_ms,
     use_ssh_config = true,
   } = input;
+  let {
+    credential_ref,
+    credential_backend,
+  } = input;
 
   if (!host) throw new Error('host is required');
 
+  // Credential map fallback: if no explicit backend/ref, consult the map
+  let mappedUsername: string | undefined;
+  if (credential_backend === undefined && credential_ref === undefined) {
+    const credMap = new CredentialMap();
+    const mapped = credMap.resolve(host);
+    if (mapped) {
+      credential_backend = mapped.backend;
+      credential_ref = mapped.ref;
+      mappedUsername = mapped.username;
+    }
+  }
+
   // ── Resolve credentials ──────────────────────────────────────────────────
-  let resolvedUsername = username ?? '';
+  let resolvedUsername = username ?? mappedUsername ?? '';
   let passwordBuffer: Buffer = Buffer.alloc(0);
 
   if (credential_ref !== undefined) {

--- a/test/unit/credential-map.test.ts
+++ b/test/unit/credential-map.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for CredentialMap — host→credential resolution.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { CredentialMap } from '../../src/credentials/credential-map.js';
+
+describe('CredentialMap', () => {
+  let testDir: string;
+  let testFile: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `credmap-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(testDir, { recursive: true });
+    testFile = join(testDir, 'credential-map.json');
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  describe('defaultPath()', () => {
+    it('returns a path ending with credential-map.json', () => {
+      const path = CredentialMap.defaultPath();
+      expect(path).toMatch(/credential-map\.json$/);
+    });
+
+    it('returns platform-appropriate path', () => {
+      const path = CredentialMap.defaultPath();
+      if (process.platform === 'win32') {
+        expect(path).toContain('ai-ssh-toolkit');
+        // On Windows it should use APPDATA or AppData/Roaming
+      } else {
+        expect(path).toContain('.config/ai-ssh-toolkit');
+      }
+    });
+  });
+
+  describe('resolve() with glob patterns', () => {
+    it('matches exact hostname', () => {
+      writeFileSync(testFile, JSON.stringify({
+        rules: [{ match: 'server1.example.com', backend: 'bitwarden', ref: 'abc' }]
+      }));
+      const map = new CredentialMap(testFile);
+      const result = map.resolve('server1.example.com');
+      expect(result).not.toBeNull();
+      expect(result!.backend).toBe('bitwarden');
+      expect(result!.ref).toBe('abc');
+    });
+
+    it('matches wildcard pattern *.prod.example.com', () => {
+      writeFileSync(testFile, JSON.stringify({
+        rules: [{ match: '*.prod.example.com', backend: 'bitwarden', ref: 'prod-cred' }]
+      }));
+      const map = new CredentialMap(testFile);
+      expect(map.resolve('web1.prod.example.com')).not.toBeNull();
+      expect(map.resolve('db.prod.example.com')!.backend).toBe('bitwarden');
+    });
+
+    it('matches prefix wildcard pattern build-*', () => {
+      writeFileSync(testFile, JSON.stringify({
+        rules: [{ match: 'build-*', backend: 'ssh-agent' }]
+      }));
+      const map = new CredentialMap(testFile);
+      expect(map.resolve('build-123')).not.toBeNull();
+      expect(map.resolve('build-server.local')!.backend).toBe('ssh-agent');
+      expect(map.resolve('test-123')).toBeNull();
+    });
+
+    it('matches IP wildcard 10.218.191.*', () => {
+      writeFileSync(testFile, JSON.stringify({
+        rules: [{ match: '10.218.191.*', backend: 'env', ref: 'SW_USER:SW_PASS' }]
+      }));
+      const map = new CredentialMap(testFile);
+      expect(map.resolve('10.218.191.5')!.backend).toBe('env');
+      expect(map.resolve('10.218.192.5')).toBeNull();
+    });
+
+    it('matches catch-all * pattern', () => {
+      writeFileSync(testFile, JSON.stringify({
+        rules: [{ match: '*', backend: 'ssh-agent' }]
+      }));
+      const map = new CredentialMap(testFile);
+      expect(map.resolve('anything.example.com')!.backend).toBe('ssh-agent');
+    });
+
+    it('returns null when no rule matches', () => {
+      writeFileSync(testFile, JSON.stringify({
+        rules: [{ match: 'specific-host', backend: 'bitwarden', ref: 'x' }]
+      }));
+      const map = new CredentialMap(testFile);
+      expect(map.resolve('other-host')).toBeNull();
+    });
+
+    it('includes username when specified in rule', () => {
+      writeFileSync(testFile, JSON.stringify({
+        rules: [{ match: '*.prod.example.com', backend: 'bitwarden', ref: 'x', username: 'admin' }]
+      }));
+      const map = new CredentialMap(testFile);
+      const result = map.resolve('web.prod.example.com');
+      expect(result!.username).toBe('admin');
+    });
+  });
+
+  describe('first-match-wins semantics', () => {
+    it('returns the first matching rule', () => {
+      writeFileSync(testFile, JSON.stringify({
+        rules: [
+          { match: 'web1.prod.example.com', backend: 'bitwarden', ref: 'specific' },
+          { match: '*.prod.example.com', backend: 'env', ref: 'general' },
+          { match: '*', backend: 'ssh-agent' },
+        ]
+      }));
+      const map = new CredentialMap(testFile);
+
+      const r1 = map.resolve('web1.prod.example.com');
+      expect(r1!.backend).toBe('bitwarden');
+      expect(r1!.ref).toBe('specific');
+
+      const r2 = map.resolve('web2.prod.example.com');
+      expect(r2!.backend).toBe('env');
+      expect(r2!.ref).toBe('general');
+
+      const r3 = map.resolve('other.example.com');
+      expect(r3!.backend).toBe('ssh-agent');
+    });
+  });
+
+  describe('match_regex support', () => {
+    it('uses regex when match_regex is present', () => {
+      writeFileSync(testFile, JSON.stringify({
+        rules: [{ match: '*', match_regex: '^db-\\d+\\.internal$', backend: 'bitwarden', ref: 'db-cred' }]
+      }));
+      const map = new CredentialMap(testFile);
+      expect(map.resolve('db-42.internal')!.backend).toBe('bitwarden');
+      expect(map.resolve('db-abc.internal')).toBeNull();
+    });
+
+    it('handles invalid regex gracefully (no match)', () => {
+      writeFileSync(testFile, JSON.stringify({
+        rules: [{ match: '*', match_regex: '[invalid', backend: 'bitwarden', ref: 'x' }]
+      }));
+      const map = new CredentialMap(testFile);
+      expect(map.resolve('anything')).toBeNull();
+    });
+  });
+
+  describe('reload()', () => {
+    it('re-reads the file from disk', () => {
+      writeFileSync(testFile, JSON.stringify({
+        rules: [{ match: '*', backend: 'ssh-agent' }]
+      }));
+      const map = new CredentialMap(testFile);
+      expect(map.resolve('host1')!.backend).toBe('ssh-agent');
+
+      // Update the file
+      writeFileSync(testFile, JSON.stringify({
+        rules: [{ match: '*', backend: 'bitwarden', ref: 'new-ref' }]
+      }));
+      map.reload();
+      expect(map.resolve('host1')!.backend).toBe('bitwarden');
+      expect(map.resolve('host1')!.ref).toBe('new-ref');
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles missing file gracefully (no crash, resolve returns null)', () => {
+      const map = new CredentialMap('/nonexistent/path/credential-map.json');
+      expect(map.resolve('any-host')).toBeNull();
+    });
+
+    it('handles invalid JSON gracefully (no crash, resolve returns null)', () => {
+      writeFileSync(testFile, 'not valid json {{{}');
+      const map = new CredentialMap(testFile);
+      expect(map.resolve('any-host')).toBeNull();
+    });
+
+    it('handles JSON without rules array gracefully', () => {
+      writeFileSync(testFile, JSON.stringify({ something: 'else' }));
+      const map = new CredentialMap(testFile);
+      expect(map.resolve('any-host')).toBeNull();
+    });
+  });
+
+  describe('case insensitivity', () => {
+    it('matches patterns case-insensitively', () => {
+      writeFileSync(testFile, JSON.stringify({
+        rules: [{ match: '*.Example.COM', backend: 'bitwarden', ref: 'x' }]
+      }));
+      const map = new CredentialMap(testFile);
+      expect(map.resolve('host.example.com')).not.toBeNull();
+      expect(map.resolve('HOST.EXAMPLE.COM')).not.toBeNull();
+    });
+  });
+});

--- a/test/unit/ssh-multi-execute.test.ts
+++ b/test/unit/ssh-multi-execute.test.ts
@@ -140,7 +140,7 @@ describe("sshMultiExecute", () => {
       commands: ["show version"],
     };
 
-    const result = await sshMultiExecute(input, undefined, executor as typeof executeSingleHost);
+    const result = await sshMultiExecute(input, undefined, undefined, executor as typeof executeSingleHost);
 
     expect(result.total_hosts).toBe(3);
     expect(result.results).toHaveLength(3);
@@ -168,6 +168,7 @@ describe("sshMultiExecute", () => {
         username: "admin",
         commands: ["hostname"],
       },
+      undefined,
       undefined,
       executor as typeof executeSingleHost,
     );
@@ -198,6 +199,7 @@ describe("sshMultiExecute", () => {
         commands: ["uptime"],
         max_parallel: 5,
       },
+      undefined,
       undefined,
       executor as typeof executeSingleHost,
     );
@@ -233,6 +235,7 @@ describe("sshMultiExecute", () => {
         commands: ["hostname"],
       },
       undefined,
+      undefined,
       executor as typeof executeSingleHost,
     );
 
@@ -255,6 +258,7 @@ describe("sshMultiExecute", () => {
     const hosts = Array.from({ length: 25 }, (_, i) => `10.0.${Math.floor(i / 255)}.${(i % 255) + 1}`);
     await sshMultiExecute(
       { hosts, username: "admin", commands: ["uptime"] },
+      undefined,
       undefined,
       executor as typeof executeSingleHost,
     );
@@ -285,6 +289,7 @@ describe("sshMultiExecute", () => {
         username: "admin",
         commands: ["test"],
       },
+      undefined,
       undefined,
       executor as typeof executeSingleHost,
     );

--- a/test/unit/ssh-session-open.test.ts
+++ b/test/unit/ssh-session-open.test.ts
@@ -41,6 +41,7 @@ vi.mock('node-pty', () => {
 import { SessionStore } from '../../src/ssh/session-store.js';
 import { sshSessionOpen } from '../../src/tools/ssh-session-open.js';
 import type { CredentialRegistry } from '../../src/credentials/registry.js';
+import { CredentialMap } from '../../src/credentials/credential-map.js';
 
 function makeRegistry(overrides: Partial<CredentialRegistry> = {}): CredentialRegistry {
   return {
@@ -64,6 +65,9 @@ beforeEach(() => {
 });
 
 describe('sshSessionOpen', () => {
+  // Create a CredentialMap with no rules (non-existent file — silent no-op)
+  const credentialMap = new CredentialMap('/dev/null/nonexistent');
+
   it('returns a session_id and adds session to store on successful connect', async () => {
     const store = new SessionStore();
     const registry = makeRegistry();
@@ -73,7 +77,7 @@ describe('sshSessionOpen', () => {
       username: 'eric',
       platform: 'linux',
       timeout_ms: 5000,
-    });
+    }, credentialMap);
 
     // Let config resolution + dynamic import resolve
     await new Promise(r => setTimeout(r, 20));
@@ -104,7 +108,7 @@ describe('sshSessionOpen', () => {
       credential_backend: 'bitwarden',
       platform: 'linux',
       timeout_ms: 5000,
-    });
+    }, credentialMap);
 
     await new Promise(r => setTimeout(r, 20));
 
@@ -128,7 +132,7 @@ describe('sshSessionOpen', () => {
       username: 'eric',
       platform: 'linux',
       timeout_ms: 50,
-    });
+    }, credentialMap);
 
     // Never send a prompt — let it time out
     await expect(promise).rejects.toThrow(/timed out/i);
@@ -145,7 +149,7 @@ describe('sshSessionOpen', () => {
       username: 'eric',
       platform: 'linux',
       timeout_ms: 5000,
-    });
+    }, credentialMap);
 
     await new Promise(r => setTimeout(r, 20));
 


### PR DESCRIPTION
## Summary

Resolves #77

Adds a user-owned credential-map file (`~/.config/ai-ssh-toolkit/credential-map.json`) that maps host patterns to credential backends. Agents can call `ssh_execute(host=..., command=...)` with **no credential arguments** — the toolkit resolves the right backend+ref by matching the host against glob/regex rules.

## Changes

### New
- `src/credentials/credential-map.ts` — `CredentialMap` class with glob/regex matching, first-match-wins semantics, singleton via `index.ts` injection, schema validation on load, pre-compiled regexes (ReDoS mitigation)
- `src/tools/credential-diagnose.ts` — `credential_diagnose` tool showing which rule matched a host, including rule index
- `test/unit/credential-map.test.ts` — 17 unit tests

### Modified
- `src/tools/ssh-execute.ts` — credential map resolution when no backend/ref supplied; host validation before map lookup
- `src/tools/ssh-session-open.ts` — credential map resolution
- `src/tools/ssh-check.ts` — username resolution from map
- `src/tools/ssh-multi-execute.ts` — per-host credential map resolution
- `src/index.ts` — singleton `CredentialMap` injected into all tools; `credential_map_reload` tool registered
- `README.md` — Credential Map documentation section with example config

## Example credential-map.json

```json
{
  "rules": [
    { "match": "*.prod.example.com", "backend": "bitwarden", "ref": "af83b31a", "username": "admin" },
    { "match": "build-*", "backend": "ssh-agent" },
    { "match": "10.218.191.*", "backend": "env", "ref": "SWITCH_USER:SWITCH_PASS" },
    { "match": "*", "backend": "ssh-agent" }
  ]
}
```

## Acceptance Criteria

- [x] Map file loaded on startup; `credential_map_reload` tool refreshes without restart
- [x] `ssh_execute(host=..., command=...)` resolves credentials from map when no backend/ref supplied
- [x] First-match-wins semantics with glob patterns
- [x] `credential_diagnose` reports which rule matched a given host (with rule index)
- [x] Tool arguments always override the map
- [x] Documented with examples

## Test Results

```
Test Files  17 passed (17)
Tests       176 passed | 5 skipped (181)
```