### PR TITLE
chore: group typescript-eslint and eslint dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,15 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
+          - "typescript-eslint"
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Problem

Dependabot was opening separate PRs for `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser`, and `typescript-eslint`. Since they're tightly coupled peer dependencies, bumping one without the others causes `npm ci` to fail with ERESOLVE errors (as seen in PR #104).

## Fix

Add Dependabot groups so all `@typescript-eslint/*` and `typescript-eslint` packages bump together in a single PR. Same for `eslint` and `eslint-*` plugins.

## After this merges

Close the broken PRs #104, #106, #107 — Dependabot will re-open them as a single grouped PR on next schedule.