### PR TITLE
fix: replace BatchMode=yes with TCP+banner probe in ssh_check_host

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,32 @@ No parameters required.
 
 ### `ssh_check_host`
 
-Check TCP reachability of a host with latency measurement.
+Check SSH host reachability via TCP connect, SSH banner probe, or full auth check.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `host` | string | ✅ | Hostname or IP |
 | `port` | number | ❌ | Port to check (default: 22) |
+| `username` | string | ❌ | SSH username for the check |
+| `timeout_ms` | number | ❌ | Connection timeout in ms (default: 5000) |
+| `mode` | string | ❌ | `'tcp'`, `'banner'` (default), or `'auth'` |
+| `use_ssh_config` | boolean | ❌ | Honor ~/.ssh/config (default: true) |
+
+**Modes:**
+
+- **`banner`** (default) — TCP connect + read SSH server banner. Works for password-auth hosts without false negatives.
+- **`tcp`** — TCP connect only (just checks the port is open).
+- **`auth`** — Full SSH auth attempt using `BatchMode=yes`. Returns `auth_succeeded` or `auth_failed`.
+
+**Response fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `reachable` | boolean | Whether the host was reachable |
+| `status` | string | `'tcp_unreachable'`, `'ssh_banner_received'`, `'auth_succeeded'`, or `'auth_failed'` |
+| `latency_ms` | number \| null | Round-trip latency (null if unreachable) |
+| `banner` | string? | SSH server banner (e.g. `'SSH-2.0-OpenSSH_8.9'`), only in banner mode |
+| `error` | string? | Error message when check fails |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Check SSH host reachability via TCP connect, SSH banner probe, or full auth chec
 **Modes:**
 
 - **`banner`** (default) — TCP connect + read SSH server banner. Works for password-auth hosts without false negatives.
-- **`tcp`** — TCP connect only (just checks the port is open).
+- **`tcp`** — TCP connect only (just checks the port is open). Returns `tcp_open` or `tcp_unreachable`.
 - **`auth`** — Full SSH auth attempt using `BatchMode=yes`. Returns `auth_succeeded` or `auth_failed`.
 
 **Response fields:**
@@ -100,7 +100,7 @@ Check SSH host reachability via TCP connect, SSH banner probe, or full auth chec
 | Field | Type | Description |
 |-------|------|-------------|
 | `reachable` | boolean | Whether the host was reachable |
-| `status` | string | `'tcp_unreachable'`, `'ssh_banner_received'`, `'auth_succeeded'`, or `'auth_failed'` |
+| `status` | string | `'tcp_unreachable'`, `'tcp_open'`, `'ssh_banner_received'`, `'auth_succeeded'`, or `'auth_failed'` |
 | `latency_ms` | number \| null | Round-trip latency (null if unreachable) |
 | `banner` | string? | SSH server banner (e.g. `'SSH-2.0-OpenSSH_8.9'`), only in banner mode |
 | `error` | string? | Error message when check fails |

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,12 +178,13 @@ server.tool(
 // ── ssh_check_host ───────────────────────────────────────────────────────────
 server.tool(
   'ssh_check_host',
-  'Verify SSH connectivity to a host without executing commands.',
+  'Verify SSH host reachability via TCP connect, SSH banner probe (default), or full auth check.',
   {
     host: z.string().describe('Hostname or IP address to check'),
     port: z.number().int().min(1).max(65535).optional().describe('SSH port (default: 22, or from ~/.ssh/config)'),
     username: z.string().optional().describe('SSH username for the connectivity check'),
     timeout_ms: z.number().int().positive().optional().describe('Connection timeout in milliseconds (default: 5000)'),
+    mode: z.enum(['tcp', 'banner', 'auth']).optional().describe("Check mode: 'tcp' (TCP connect only), 'banner' (TCP + SSH banner read, default), 'auth' (full ssh binary auth with BatchMode=yes)"),
     use_ssh_config: z.boolean().optional().describe('When true (default), honor ~/.ssh/config for User, Port, IdentityFile, ProxyJump, etc. Set false to skip.'),
   },
   async (input) => {

--- a/src/tools/ssh-check.ts
+++ b/src/tools/ssh-check.ts
@@ -1,21 +1,42 @@
 /**
- * ssh_check_host tool handler — verifies SSH connectivity to a host without
- * executing commands (uses ssh -q -o BatchMode=yes -o ConnectTimeout=5).
+ * ssh_check_host tool handler — verifies SSH host reachability via TCP + SSH
+ * banner probing (default) or optional full auth check.
+ *
+ * Modes:
+ *  - 'tcp'    — TCP connect only
+ *  - 'banner' — TCP connect + read SSH banner (default)
+ *  - 'auth'   — full ssh binary auth attempt (BatchMode=yes)
  */
 
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import * as net from 'net';
 import { resolveSshBin } from '../utils/cli-resolver.js';
 import { resolveSshConfig } from '../ssh/ssh-config-reader.js';
 import type { CredentialMap } from '../credentials/credential-map.js';
 
 const execFileAsync = promisify(execFile);
 
+export type SshCheckMode = 'tcp' | 'banner' | 'auth';
+
+export type SshCheckStatus =
+  | 'tcp_unreachable'
+  | 'ssh_banner_received'
+  | 'auth_succeeded'
+  | 'auth_failed';
+
 export interface SshCheckInput {
   host: string;
   port?: number;
   username?: string;
   timeout_ms?: number;
+  /**
+   * Check mode:
+   *  - 'tcp'    — TCP connect only
+   *  - 'banner' — TCP connect + read SSH banner (default)
+   *  - 'auth'   — full ssh binary auth attempt (BatchMode=yes)
+   */
+  mode?: SshCheckMode;
   /**
    * When true (default), resolve ~/.ssh/config for the given host alias so that
    * ssh_config(5) directives (HostName, User, Port, IdentityFile, ProxyJump, etc.)
@@ -27,12 +48,135 @@ export interface SshCheckInput {
 
 export interface SshCheckResult {
   reachable: boolean;
+  status: SshCheckStatus;
   latency_ms: number | null;
+  banner?: string;
   error?: string;
 }
 
+/**
+ * Perform a TCP connect + optional SSH banner read using Node.js net.Socket.
+ * Exported for testing (allows injecting a socket factory).
+ */
+export async function tcpBannerProbe(
+  host: string,
+  port: number,
+  timeoutMs: number,
+  readBanner: boolean,
+  socketFactory: () => net.Socket = () => new net.Socket(),
+): Promise<SshCheckResult> {
+  const start = Date.now();
+
+  return new Promise<SshCheckResult>((resolve) => {
+    const socket = socketFactory();
+    let settled = false;
+
+    const finish = (result: SshCheckResult) => {
+      if (settled) return;
+      settled = true;
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(result);
+    };
+
+    socket.setTimeout(timeoutMs);
+
+    socket.on('timeout', () => {
+      finish({
+        reachable: false,
+        status: 'tcp_unreachable',
+        latency_ms: null,
+        error: `TCP connection to ${host}:${port} timed out after ${timeoutMs}ms`,
+      });
+    });
+
+    socket.on('error', (err: Error) => {
+      finish({
+        reachable: false,
+        status: 'tcp_unreachable',
+        latency_ms: null,
+        error: err.message,
+      });
+    });
+
+    socket.connect(port, host, () => {
+      const latency = Date.now() - start;
+
+      if (!readBanner) {
+        finish({
+          reachable: true,
+          status: 'ssh_banner_received',
+          latency_ms: latency,
+        });
+        return;
+      }
+
+      // Wait for the SSH banner (first chunk of data)
+      socket.once('data', (data: Buffer) => {
+        const raw = data.toString('utf-8').trim();
+        const banner = raw.startsWith('SSH-') ? raw.split('\n')[0].trim() : undefined;
+        finish({
+          reachable: true,
+          status: 'ssh_banner_received',
+          latency_ms: latency,
+          banner,
+        });
+      });
+
+      // If no data arrives within a reasonable window, still report reachable
+      setTimeout(() => {
+        finish({
+          reachable: true,
+          status: 'ssh_banner_received',
+          latency_ms: latency,
+        });
+      }, Math.min(timeoutMs, 3000));
+    });
+  });
+}
+
+/**
+ * Perform an auth-level SSH check using the ssh binary with BatchMode=yes.
+ */
+async function authProbe(
+  host: string,
+  port: number,
+  username: string | undefined,
+  timeoutMs: number,
+): Promise<SshCheckResult> {
+  const sshBin = await resolveSshBin();
+  const timeoutSec = Math.max(1, Math.ceil(timeoutMs / 1000));
+
+  const target = username ? `${username}@${host}` : host;
+  const args = [
+    '-q',
+    '-o', 'BatchMode=yes',
+    '-o', `ConnectTimeout=${timeoutSec}`,
+    '-o', 'StrictHostKeyChecking=accept-new',
+    '-p', String(port),
+    '--',
+    target,
+    'exit',
+  ];
+
+  const start = Date.now();
+  try {
+    await execFileAsync(sshBin, args, { timeout: timeoutMs + 1000 });
+    return { reachable: true, status: 'auth_succeeded', latency_ms: Date.now() - start };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const error = err as NodeJS.ErrnoException & { code?: number | string; status?: number };
+    const code = typeof error.code === 'number' ? error.code : error.status;
+    if (code === 1) {
+      // Connected — remote shell returned non-zero, but auth succeeded
+      return { reachable: true, status: 'auth_succeeded', latency_ms: Date.now() - start };
+    }
+    return { reachable: false, status: 'auth_failed', latency_ms: null, error: msg };
+  }
+}
+
 export async function sshCheckHost(input: SshCheckInput, credentialMap: CredentialMap): Promise<SshCheckResult> {
-  const { host, timeout_ms = 5000, use_ssh_config = true } = input;
+  const { host, timeout_ms = 5000, use_ssh_config = true, mode = 'banner' } = input;
   let { port, username } = input;
 
   // Credential map fallback for username resolution
@@ -53,37 +197,12 @@ export async function sshCheckHost(input: SshCheckInput, credentialMap: Credenti
 
   const resolvedPort = port ?? 22;
 
-  const sshBin = await resolveSshBin();
-  const timeoutSec = Math.max(1, Math.ceil(timeout_ms / 1000));
-
-  const target = username ? `${username}@${host}` : host;
-  const args = [
-    '-q',
-    '-o', 'BatchMode=yes',
-    '-o', `ConnectTimeout=${timeoutSec}`,
-    '-o', 'StrictHostKeyChecking=accept-new',
-    '-p', String(resolvedPort),
-    '--',
-    target,
-    'exit',
-  ];
-
-  const start = Date.now();
-  try {
-    await execFileAsync(sshBin, args, { timeout: timeout_ms + 1000 });
-    return { reachable: true, latency_ms: Date.now() - start };
-  } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
-    // Exit code 255 = ssh-level connection failure (host unreachable, refused, etc.)
-    // Exit code 0 = connected and exited cleanly
-    // Exit code 1 = connected but "exit" command returned non-zero (still means reachable)
-    // execFile exposes child exit code on err.code (number); err.status is a fallback
-    const error = err as NodeJS.ErrnoException & { code?: number | string; status?: number };
-    const code = typeof error.code === 'number' ? error.code : error.status;
-    if (code === 1) {
-      // Connected — the remote shell returned non-zero, but host is reachable
-      return { reachable: true, latency_ms: Date.now() - start };
-    }
-    return { reachable: false, latency_ms: null, error: msg };
+  switch (mode) {
+    case 'tcp':
+      return tcpBannerProbe(host, resolvedPort, timeout_ms, false);
+    case 'banner':
+      return tcpBannerProbe(host, resolvedPort, timeout_ms, true);
+    case 'auth':
+      return authProbe(host, resolvedPort, username, timeout_ms);
   }
 }

--- a/src/tools/ssh-check.ts
+++ b/src/tools/ssh-check.ts
@@ -188,7 +188,11 @@ async function authProbe(
   }
 }
 
-export async function sshCheckHost(input: SshCheckInput, credentialMap: CredentialMap): Promise<SshCheckResult> {
+export async function sshCheckHost(
+  input: SshCheckInput,
+  credentialMap: CredentialMap,
+  socketFactory?: () => net.Socket,
+): Promise<SshCheckResult> {
   const { host, timeout_ms = 5000, use_ssh_config = true, mode = 'banner' } = input;
   let { port, username } = input;
 
@@ -212,9 +216,9 @@ export async function sshCheckHost(input: SshCheckInput, credentialMap: Credenti
 
   switch (mode) {
     case 'tcp':
-      return tcpBannerProbe(host, resolvedPort, timeout_ms, false);
+      return tcpBannerProbe(host, resolvedPort, timeout_ms, false, socketFactory);
     case 'banner':
-      return tcpBannerProbe(host, resolvedPort, timeout_ms, true);
+      return tcpBannerProbe(host, resolvedPort, timeout_ms, true, socketFactory);
     case 'auth':
       return authProbe(host, resolvedPort, username, timeout_ms);
   }

--- a/src/tools/ssh-check.ts
+++ b/src/tools/ssh-check.ts
@@ -21,6 +21,7 @@ export type SshCheckMode = 'tcp' | 'banner' | 'auth';
 
 export type SshCheckStatus =
   | 'tcp_unreachable'
+  | 'tcp_open'
   | 'ssh_banner_received'
   | 'auth_succeeded'
   | 'auth_failed';
@@ -71,9 +72,12 @@ export async function tcpBannerProbe(
     const socket = socketFactory();
     let settled = false;
 
+    let bannerTimer: ReturnType<typeof setTimeout> | undefined;
+
     const finish = (result: SshCheckResult) => {
       if (settled) return;
       settled = true;
+      if (bannerTimer !== undefined) clearTimeout(bannerTimer);
       socket.removeAllListeners();
       socket.destroy();
       resolve(result);
@@ -105,7 +109,7 @@ export async function tcpBannerProbe(
       if (!readBanner) {
         finish({
           reachable: true,
-          status: 'ssh_banner_received',
+          status: 'tcp_open',
           latency_ms: latency,
         });
         return;
@@ -123,8 +127,17 @@ export async function tcpBannerProbe(
         });
       });
 
+      // If the connection closes before we get data, still report reachable
+      socket.on('close', () => {
+        finish({
+          reachable: true,
+          status: 'ssh_banner_received',
+          latency_ms: latency,
+        });
+      });
+
       // If no data arrives within a reasonable window, still report reachable
-      setTimeout(() => {
+      bannerTimer = setTimeout(() => {
         finish({
           reachable: true,
           status: 'ssh_banner_received',

--- a/test/unit/ssh-check.test.ts
+++ b/test/unit/ssh-check.test.ts
@@ -37,9 +37,16 @@ vi.mock('../../src/utils/cli-resolver.js', () => ({
 }));
 
 const execFileMock = vi.fn();
-vi.mock('child_process', () => ({
-  execFile: (...args: unknown[]) => execFileMock(...args),
-}));
+vi.mock('child_process', () => {
+  // Use the well-known promisify custom symbol so that
+  // promisify(execFile) delegates directly to execFileMock (returns Promises).
+  const customSymbol = Symbol.for('nodejs.util.promisify.custom');
+  const fn = Object.assign(
+    (...args: unknown[]) => execFileMock(...args),
+    { [customSymbol]: (...args: unknown[]) => execFileMock(...args) },
+  );
+  return { execFile: fn };
+});
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -111,7 +118,7 @@ describe('ssh_check_host', () => {
       const result = await tcpBannerProbe('tcp.example.com', 2222, 5000, false, () => sock as unknown as net.Socket);
 
       expect(result.reachable).toBe(true);
-      expect(result.status).toBe('ssh_banner_received');
+      expect(result.status).toBe('tcp_open');
       expect(result.latency_ms).toBeTypeOf('number');
     });
 
@@ -161,11 +168,7 @@ describe('ssh_check_host', () => {
     });
 
     it('mode=auth: auth_succeeded when ssh exits 0', async () => {
-      execFileMock.mockImplementation(
-        (_cmd: string, _args: string[], _opts: unknown, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
-          cb(null, { stdout: '', stderr: '' });
-        },
-      );
+      execFileMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
 
       const result = await sshCheckHost(
         { host: 'auth-ok.example.com', mode: 'auth', use_ssh_config: false },
@@ -178,13 +181,8 @@ describe('ssh_check_host', () => {
     });
 
     it('mode=auth: auth_failed when ssh exits 255', async () => {
-      execFileMock.mockImplementation(
-        (_cmd: string, _args: string[], _opts: unknown, cb: (err: Error & { code?: number }) => void) => {
-          const err = new Error('Permission denied') as Error & { code?: number };
-          err.code = 255;
-          cb(err);
-        },
-      );
+      const err = Object.assign(new Error('Permission denied'), { code: 255 });
+      execFileMock.mockRejectedValueOnce(err);
 
       const result = await sshCheckHost(
         { host: 'auth-fail.example.com', mode: 'auth', use_ssh_config: false },
@@ -197,13 +195,8 @@ describe('ssh_check_host', () => {
     });
 
     it('mode=auth: auth_succeeded when ssh exits 1 (connected but exit returned non-zero)', async () => {
-      execFileMock.mockImplementation(
-        (_cmd: string, _args: string[], _opts: unknown, cb: (err: Error & { code?: number }) => void) => {
-          const err = new Error('exit code 1') as Error & { code?: number };
-          err.code = 1;
-          cb(err);
-        },
-      );
+      const err = Object.assign(new Error('exit code 1'), { code: 1 });
+      execFileMock.mockRejectedValueOnce(err);
 
       const result = await sshCheckHost(
         { host: 'exit1.example.com', mode: 'auth', use_ssh_config: false },

--- a/test/unit/ssh-check.test.ts
+++ b/test/unit/ssh-check.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+import type * as net from 'net';
+import { sshCheckHost, tcpBannerProbe } from '../../src/tools/ssh-check.js';
+import { CredentialMap } from '../../src/credentials/credential-map.js';
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+/** Fake net.Socket built on EventEmitter with the methods tcpBannerProbe uses. */
+class FakeSocket extends EventEmitter {
+  destroyed = false;
+  connect = vi.fn((_port: number, _host: string, cb?: () => void) => {
+    // default: connect succeeds immediately
+    if (cb) setImmediate(cb);
+    return this;
+  });
+  setTimeout = vi.fn();
+  destroy = vi.fn(() => { this.destroyed = true; });
+  removeAllListeners = vi.fn(() => this);
+}
+
+function makeCredentialMap(): CredentialMap {
+  // Construct with a non-existent path so no real file is loaded
+  return new CredentialMap('/dev/null/no-such-credential-map.json');
+}
+
+// Mock resolveSshConfig so it never touches the real filesystem
+vi.mock('../../src/ssh/ssh-config-reader.js', () => ({
+  resolveSshConfig: vi.fn().mockResolvedValue(null),
+}));
+
+// Mock resolveSshBin / execFile for auth mode tests
+vi.mock('../../src/utils/cli-resolver.js', () => ({
+  resolveSshBin: vi.fn().mockResolvedValue('/usr/bin/ssh'),
+}));
+
+const execFileMock = vi.fn();
+vi.mock('child_process', () => ({
+  execFile: (...args: unknown[]) => execFileMock(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ssh_check_host', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── tcpBannerProbe direct tests ────────────────────────────────────────
+
+  describe('tcpBannerProbe', () => {
+    it('mode=banner: returns SSH banner when server sends one', async () => {
+      const sock = new FakeSocket();
+      sock.connect = vi.fn((_p: number, _h: string, cb?: () => void) => {
+        setImmediate(() => {
+          cb?.();
+          setImmediate(() => sock.emit('data', Buffer.from('SSH-2.0-OpenSSH_8.9\r\n')));
+        });
+        return sock;
+      });
+
+      const result = await tcpBannerProbe('example.com', 22, 5000, true, () => sock as unknown as net.Socket);
+
+      expect(result.reachable).toBe(true);
+      expect(result.status).toBe('ssh_banner_received');
+      expect(result.banner).toBe('SSH-2.0-OpenSSH_8.9');
+      expect(result.latency_ms).toBeTypeOf('number');
+    });
+
+    it('mode=banner: TCP connect fails → unreachable', async () => {
+      const sock = new FakeSocket();
+      sock.connect = vi.fn(() => {
+        setImmediate(() => sock.emit('error', new Error('ECONNREFUSED')));
+        return sock;
+      });
+
+      const result = await tcpBannerProbe('down.example.com', 22, 5000, true, () => sock as unknown as net.Socket);
+
+      expect(result.reachable).toBe(false);
+      expect(result.status).toBe('tcp_unreachable');
+      expect(result.error).toContain('ECONNREFUSED');
+      expect(result.latency_ms).toBeNull();
+    });
+
+    it('mode=banner: TCP connects but no SSH banner → still reachable', async () => {
+      const sock = new FakeSocket();
+      // connect succeeds but no data event fires (the setTimeout fallback triggers)
+      sock.connect = vi.fn((_p: number, _h: string, cb?: () => void) => {
+        setImmediate(() => cb?.());
+        return sock;
+      });
+
+      const result = await tcpBannerProbe('silent.example.com', 22, 500, true, () => sock as unknown as net.Socket);
+
+      expect(result.reachable).toBe(true);
+      expect(result.status).toBe('ssh_banner_received');
+      expect(result.banner).toBeUndefined();
+    });
+
+    it('mode=tcp: just checks TCP open', async () => {
+      const sock = new FakeSocket();
+      sock.connect = vi.fn((_p: number, _h: string, cb?: () => void) => {
+        setImmediate(() => cb?.());
+        return sock;
+      });
+
+      const result = await tcpBannerProbe('tcp.example.com', 2222, 5000, false, () => sock as unknown as net.Socket);
+
+      expect(result.reachable).toBe(true);
+      expect(result.status).toBe('ssh_banner_received');
+      expect(result.latency_ms).toBeTypeOf('number');
+    });
+
+    it('timeout fires → tcp_unreachable', async () => {
+      const sock = new FakeSocket();
+      sock.connect = vi.fn(() => {
+        // Simulate timeout after socket.setTimeout fires
+        setImmediate(() => sock.emit('timeout'));
+        return sock;
+      });
+
+      const result = await tcpBannerProbe('slow.example.com', 22, 100, true, () => sock as unknown as net.Socket);
+
+      expect(result.reachable).toBe(false);
+      expect(result.status).toBe('tcp_unreachable');
+      expect(result.error).toContain('timed out');
+    });
+  });
+
+  // ── sshCheckHost integration-level tests ──────────────────────────────
+
+  describe('sshCheckHost', () => {
+    it('default mode is banner', async () => {
+      const sock = new FakeSocket();
+      sock.connect = vi.fn((_p: number, _h: string, cb?: () => void) => {
+        setImmediate(() => {
+          cb?.();
+          setImmediate(() => sock.emit('data', Buffer.from('SSH-2.0-Test\r\n')));
+        });
+        return sock;
+      });
+
+      // We test via tcpBannerProbe since sshCheckHost creates a real socket;
+      // for the default-mode assertion we verify that mode defaults to 'banner'
+      // by calling sshCheckHost with no mode and checking the result shape.
+      // But since we can't inject sockets into sshCheckHost directly, we
+      // verify indirectly that the mode field defaults correctly.
+      const input = { host: 'example.com', mode: undefined as undefined };
+      // sshCheckHost will try a real TCP connection which will fail in CI,
+      // but we can still verify it chose the right code path by checking
+      // the result status is tcp_unreachable (not auth_failed).
+      const result = await sshCheckHost(input, makeCredentialMap());
+      // In a test env with no real SSH server, TCP will fail
+      expect(['tcp_unreachable', 'ssh_banner_received']).toContain(result.status);
+      expect(result.status).not.toBe('auth_failed');
+      expect(result.status).not.toBe('auth_succeeded');
+    });
+
+    it('mode=auth: auth_succeeded when ssh exits 0', async () => {
+      execFileMock.mockImplementation(
+        (_cmd: string, _args: string[], _opts: unknown, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+          cb(null, { stdout: '', stderr: '' });
+        },
+      );
+
+      const result = await sshCheckHost(
+        { host: 'auth-ok.example.com', mode: 'auth', use_ssh_config: false },
+        makeCredentialMap(),
+      );
+
+      expect(result.reachable).toBe(true);
+      expect(result.status).toBe('auth_succeeded');
+      expect(result.latency_ms).toBeTypeOf('number');
+    });
+
+    it('mode=auth: auth_failed when ssh exits 255', async () => {
+      execFileMock.mockImplementation(
+        (_cmd: string, _args: string[], _opts: unknown, cb: (err: Error & { code?: number }) => void) => {
+          const err = new Error('Permission denied') as Error & { code?: number };
+          err.code = 255;
+          cb(err);
+        },
+      );
+
+      const result = await sshCheckHost(
+        { host: 'auth-fail.example.com', mode: 'auth', use_ssh_config: false },
+        makeCredentialMap(),
+      );
+
+      expect(result.reachable).toBe(false);
+      expect(result.status).toBe('auth_failed');
+      expect(result.error).toContain('Permission denied');
+    });
+
+    it('mode=auth: auth_succeeded when ssh exits 1 (connected but exit returned non-zero)', async () => {
+      execFileMock.mockImplementation(
+        (_cmd: string, _args: string[], _opts: unknown, cb: (err: Error & { code?: number }) => void) => {
+          const err = new Error('exit code 1') as Error & { code?: number };
+          err.code = 1;
+          cb(err);
+        },
+      );
+
+      const result = await sshCheckHost(
+        { host: 'exit1.example.com', mode: 'auth', use_ssh_config: false },
+        makeCredentialMap(),
+      );
+
+      expect(result.reachable).toBe(true);
+      expect(result.status).toBe('auth_succeeded');
+    });
+
+    it('ssh config resolution works with use_ssh_config=true', async () => {
+      const { resolveSshConfig } = await import('../../src/ssh/ssh-config-reader.js');
+      const mockResolve = vi.mocked(resolveSshConfig);
+      mockResolve.mockResolvedValueOnce({
+        hostname: 'real-host.example.com',
+        user: 'sshuser',
+        port: 2222,
+        identityFiles: [],
+      });
+
+      // This will attempt a real TCP connection (which will fail), but we
+      // verify ssh config was consulted
+      const result = await sshCheckHost(
+        { host: 'alias', use_ssh_config: true },
+        makeCredentialMap(),
+      );
+
+      expect(mockResolve).toHaveBeenCalledWith('alias');
+      // TCP will likely fail in CI
+      expect(result).toHaveProperty('status');
+      expect(result).toHaveProperty('reachable');
+    });
+  });
+});

--- a/test/unit/ssh-check.test.ts
+++ b/test/unit/ssh-check.test.ts
@@ -151,18 +151,16 @@ describe('ssh_check_host', () => {
         return sock;
       });
 
-      // We test via tcpBannerProbe since sshCheckHost creates a real socket;
-      // for the default-mode assertion we verify that mode defaults to 'banner'
-      // by calling sshCheckHost with no mode and checking the result shape.
-      // But since we can't inject sockets into sshCheckHost directly, we
-      // verify indirectly that the mode field defaults correctly.
-      const input = { host: 'example.com', mode: undefined as undefined };
-      // sshCheckHost will try a real TCP connection which will fail in CI,
-      // but we can still verify it chose the right code path by checking
-      // the result status is tcp_unreachable (not auth_failed).
-      const result = await sshCheckHost(input, makeCredentialMap());
-      // In a test env with no real SSH server, TCP will fail
-      expect(['tcp_unreachable', 'ssh_banner_received']).toContain(result.status);
+      // Inject the fake socket factory so sshCheckHost never opens a real connection.
+      const result = await sshCheckHost(
+        { host: 'example.com' },
+        makeCredentialMap(),
+        () => sock as unknown as import('net').Socket,
+      );
+
+      expect(result.reachable).toBe(true);
+      expect(result.status).toBe('ssh_banner_received');
+      expect(result.banner).toBe('SSH-2.0-Test');
       expect(result.status).not.toBe('auth_failed');
       expect(result.status).not.toBe('auth_succeeded');
     });


### PR DESCRIPTION
## Summary

Resolves #79

`ssh_check_host` used `BatchMode=yes` which fails for password-auth hosts even when they're fully reachable. Replaced with a TCP+SSH banner probe by default.

## Changes

### `src/tools/ssh-check.ts` — full rewrite
- **`mode: 'banner'` (default)** — TCP connect + SSH banner read via `net.Socket`. No ssh binary, no false negatives. Returns `ssh_banner_received` on success.
- **`mode: 'tcp'`** — TCP connect only. Returns `tcp_open`.
- **`mode: 'auth'`** — original `BatchMode=yes` ssh approach for explicit auth verification.
- New structured `status` field: `tcp_unreachable | tcp_open | ssh_banner_received | auth_succeeded | auth_failed`
- New `banner?` field — SSH server banner string (e.g. `SSH-2.0-OpenSSH_9.3`)
- `reachable` field preserved for backward compat
- Timer properly cleared to prevent resource leaks; socket `close` event handled

### `test/unit/ssh-check.test.ts` — new (10 tests)
Covers all three modes, banner parsing, TCP timeout, connection refused, no-banner data, auth success/failure.

### `src/index.ts` — added `mode` parameter to tool schema

### `README.md` — updated docs

## Acceptance Criteria

- [x] Default `ssh_check_host` returns success for any host with port 22 open speaking SSH, regardless of auth method
- [x] Structured `status` field
- [x] `mode: 'auth'` opts into BatchMode behavior
- [x] Documented in README

## Test Results

```
Test Files  18 passed (18)
Tests       206 passed | 5 skipped (211)
```