### PR TITLE
feat: cleaner env credential ref format with named keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,11 +285,19 @@ credential_ref: "my-vault/my-secret"
 
 ### Environment Variables
 
-Read credentials from environment variables. Reference by variable name prefix.
+Read credentials from environment variables. Three ref formats are supported:
 
 ```text
 credential_backend: "env"
-credential_ref: "MY_SWITCH"  → reads MY_SWITCH_USERNAME and MY_SWITCH_PASSWORD
+
+# Password-only (username from the tool's username arg):
+credential_ref: "SWITCH_PASS"
+
+# Named keys (recommended):
+credential_ref: "user=SWITCH_USER,pass=SWITCH_PASS"
+
+# Legacy colon format (backwards compatible):
+credential_ref: "SWITCH_USER:SWITCH_PASS"
 ```
 
 ### SSH Agent

--- a/src/credentials/env.ts
+++ b/src/credentials/env.ts
@@ -7,8 +7,11 @@ import {
 /**
  * Environment variable credential backend.
  *
- * ref format: "ENV_USER:ENV_PASS" — two env var names separated by colon.
- * Example: "SWITCH_USER:SWITCH_PASS"
+ * Supported ref formats (in order of preference):
+ *
+ * 1. "PASS_VAR"                      — password-only; username from tool arg
+ * 2. "user=USER_VAR,pass=PASS_VAR"   — explicit named keys (recommended)
+ * 3. "USER_VAR:PASS_VAR"             — legacy colon format (backwards compat)
  *
  * Always available — no external CLI required.
  */
@@ -22,8 +25,8 @@ export class EnvCredentialBackend implements CredentialBackend {
   async getCredential(ref: string): Promise<CredentialResult> {
     const { userVar, passVar } = this.parseRef(ref);
 
-    const username = process.env[userVar];
-    if (!username) {
+    const username = userVar ? (process.env[userVar] ?? "") : "";
+    if (userVar && !username) {
       throw new Error(`Environment variable not set: ${userVar}`);
     }
 
@@ -41,11 +44,11 @@ export class EnvCredentialBackend implements CredentialBackend {
   async getMetadata(ref: string): Promise<CredentialMetadata> {
     const { userVar, passVar } = this.parseRef(ref);
 
-    const username = process.env[userVar];
+    const username = userVar ? (process.env[userVar] ?? "") : "";
     const hasPassword = !!process.env[passVar];
 
     return {
-      username: username ?? "",
+      username,
       has_password: hasPassword,
       backend: this.name,
     };
@@ -55,13 +58,75 @@ export class EnvCredentialBackend implements CredentialBackend {
     // No staged secrets to wipe — reads env vars on demand
   }
 
-  private parseRef(ref: string): { userVar: string; passVar: string } {
-    const parts = ref.split(":");
-    if (parts.length !== 2 || !parts[0] || !parts[1]) {
+  /**
+   * Parse a credential ref into optional userVar and required passVar.
+   *
+   * Formats:
+   *   "PASS_VAR"                     → { userVar: undefined, passVar: "PASS_VAR" }
+   *   "user=U,pass=P"               → { userVar: "U",       passVar: "P" }
+   *   "USER_VAR:PASS_VAR"           → { userVar: "USER_VAR", passVar: "PASS_VAR" }
+   */
+  parseRef(ref: string): { userVar: string | undefined; passVar: string } {
+    const trimmed = ref.trim();
+    if (!trimmed) {
       throw new Error(
-        `Invalid env ref format: "${ref}". Expected "USER_VAR:PASS_VAR"`,
+        `Invalid env ref: empty string. ` +
+          `Expected "PASS_VAR" or "user=USER_VAR,pass=PASS_VAR"`,
       );
     }
-    return { userVar: parts[0], passVar: parts[1] };
+
+    // Named-key format: "user=X,pass=Y" or "pass=Y,user=X" or "pass=Y"
+    if (trimmed.includes("=")) {
+      const keys = new Map<string, string>();
+      for (const segment of trimmed.split(",")) {
+        const eqIdx = segment.indexOf("=");
+        if (eqIdx === -1) {
+          throw new Error(
+            `Invalid env ref: "${ref}". Each segment must be key=value. ` +
+              `Expected "user=USER_VAR,pass=PASS_VAR"`,
+          );
+        }
+        const key = segment.slice(0, eqIdx).trim().toLowerCase();
+        const value = segment.slice(eqIdx + 1).trim();
+        if (!key || !value) {
+          throw new Error(
+            `Invalid env ref: "${ref}". Empty key or value in "${segment}". ` +
+              `Expected "user=USER_VAR,pass=PASS_VAR"`,
+          );
+        }
+        if (key !== "user" && key !== "pass") {
+          throw new Error(
+            `Invalid env ref: "${ref}". Unknown key "${key}". ` +
+              `Allowed keys: user, pass`,
+          );
+        }
+        keys.set(key, value);
+      }
+      const passVar = keys.get("pass");
+      if (!passVar) {
+        throw new Error(
+          `Invalid env ref: "${ref}". Missing required "pass" key. ` +
+            `Expected "user=USER_VAR,pass=PASS_VAR"`,
+        );
+      }
+      return { userVar: keys.get("user"), passVar };
+    }
+
+    // Legacy colon format: "USER_VAR:PASS_VAR"
+    if (trimmed.includes(":")) {
+      const colonIdx = trimmed.indexOf(":");
+      const userVar = trimmed.slice(0, colonIdx);
+      const passVar = trimmed.slice(colonIdx + 1);
+      if (!userVar || !passVar) {
+        throw new Error(
+          `Invalid env ref: "${ref}". Colon format requires both parts. ` +
+            `Expected "USER_VAR:PASS_VAR" or use "user=USER_VAR,pass=PASS_VAR"`,
+        );
+      }
+      return { userVar, passVar };
+    }
+
+    // Single variable: password-only, username comes from tool arg
+    return { userVar: undefined, passVar: trimmed };
   }
 }

--- a/test/unit/env-backend.test.ts
+++ b/test/unit/env-backend.test.ts
@@ -38,11 +38,118 @@ describe("EnvCredentialBackend", () => {
     });
   });
 
+  describe("parseRef", () => {
+    describe("single variable (password-only)", () => {
+      it("should parse a bare variable name", () => {
+        const result = backend.parseRef("TEST_PASS");
+        expect(result).toEqual({ userVar: undefined, passVar: "TEST_PASS" });
+      });
+
+      it("should trim whitespace", () => {
+        const result = backend.parseRef("  TEST_PASS  ");
+        expect(result).toEqual({ userVar: undefined, passVar: "TEST_PASS" });
+      });
+    });
+
+    describe("named-key format", () => {
+      it("should parse user=X,pass=Y", () => {
+        const result = backend.parseRef("user=TEST_USER,pass=TEST_PASS");
+        expect(result).toEqual({ userVar: "TEST_USER", passVar: "TEST_PASS" });
+      });
+
+      it("should parse pass=Y,user=X (reversed order)", () => {
+        const result = backend.parseRef("pass=TEST_PASS,user=TEST_USER");
+        expect(result).toEqual({ userVar: "TEST_USER", passVar: "TEST_PASS" });
+      });
+
+      it("should parse pass=Y alone (no user key)", () => {
+        const result = backend.parseRef("pass=TEST_PASS");
+        expect(result).toEqual({ userVar: undefined, passVar: "TEST_PASS" });
+      });
+
+      it("should be case-insensitive for keys", () => {
+        const result = backend.parseRef("User=TEST_USER,Pass=TEST_PASS");
+        expect(result).toEqual({ userVar: "TEST_USER", passVar: "TEST_PASS" });
+      });
+
+      it("should throw on missing pass key", () => {
+        expect(() => backend.parseRef("user=TEST_USER")).toThrow(
+          'Missing required "pass" key',
+        );
+      });
+
+      it("should throw on unknown key", () => {
+        expect(() => backend.parseRef("pass=P,host=H")).toThrow(
+          'Unknown key "host"',
+        );
+      });
+
+      it("should throw on empty value", () => {
+        expect(() => backend.parseRef("user=,pass=TEST_PASS")).toThrow(
+          "Empty key or value",
+        );
+      });
+
+      it("should throw on segment without =", () => {
+        expect(() => backend.parseRef("user=TEST_USER,PASS")).toThrow(
+          "Each segment must be key=value",
+        );
+      });
+    });
+
+    describe("legacy colon format", () => {
+      it("should parse USER:PASS", () => {
+        const result = backend.parseRef("TEST_USER:TEST_PASS");
+        expect(result).toEqual({ userVar: "TEST_USER", passVar: "TEST_PASS" });
+      });
+
+      it("should throw on empty left side", () => {
+        expect(() => backend.parseRef(":TEST_PASS")).toThrow(
+          "Colon format requires both parts",
+        );
+      });
+
+      it("should throw on empty right side", () => {
+        expect(() => backend.parseRef("TEST_USER:")).toThrow(
+          "Colon format requires both parts",
+        );
+      });
+    });
+
+    describe("error cases", () => {
+      it("should throw on empty string", () => {
+        expect(() => backend.parseRef("")).toThrow("Invalid env ref: empty string");
+      });
+
+      it("should throw on whitespace-only string", () => {
+        expect(() => backend.parseRef("   ")).toThrow("Invalid env ref: empty string");
+      });
+    });
+  });
+
   describe("getCredential", () => {
-    it("should return username and password from env vars", async () => {
+    it("should return username and password from legacy colon format", async () => {
       const result = await backend.getCredential("TEST_USER:TEST_PASS");
       expect(result.username).toBe("admin");
       expect(Buffer.isBuffer(result.password)).toBe(true);
+      expect(result.password.toString("utf-8")).toBe("s3cret!");
+    });
+
+    it("should return username and password from named-key format", async () => {
+      const result = await backend.getCredential("user=TEST_USER,pass=TEST_PASS");
+      expect(result.username).toBe("admin");
+      expect(result.password.toString("utf-8")).toBe("s3cret!");
+    });
+
+    it("should return empty username from single-var format", async () => {
+      const result = await backend.getCredential("TEST_PASS");
+      expect(result.username).toBe("");
+      expect(result.password.toString("utf-8")).toBe("s3cret!");
+    });
+
+    it("should return empty username from named-key format without user", async () => {
+      const result = await backend.getCredential("pass=TEST_PASS");
+      expect(result.username).toBe("");
       expect(result.password.toString("utf-8")).toBe("s3cret!");
     });
 
@@ -65,19 +172,11 @@ describe("EnvCredentialBackend", () => {
       ).rejects.toThrow("Environment variable not set: TEST_PASS");
     });
 
-    it("should throw on invalid ref format (no colon)", async () => {
-      await expect(backend.getCredential("SINGLE_VAR")).rejects.toThrow(
-        'Invalid env ref format',
-      );
-    });
-
-    it("should throw on invalid ref format (empty parts)", async () => {
-      await expect(backend.getCredential(":TEST_PASS")).rejects.toThrow(
-        'Invalid env ref format',
-      );
-      await expect(backend.getCredential("TEST_USER:")).rejects.toThrow(
-        'Invalid env ref format',
-      );
+    it("should throw if password env var is not set (single-var)", async () => {
+      delete process.env["TEST_PASS"];
+      await expect(
+        backend.getCredential("TEST_PASS"),
+      ).rejects.toThrow("Environment variable not set: TEST_PASS");
     });
 
     it("should handle special characters in password", async () => {
@@ -102,6 +201,18 @@ describe("EnvCredentialBackend", () => {
       expect(meta.has_password).toBe(true);
       expect(meta.backend).toBe("env");
       expect((meta as Record<string, unknown>)["password"]).toBeUndefined();
+    });
+
+    it("should return metadata from named-key format", async () => {
+      const meta = await backend.getMetadata("user=TEST_USER,pass=TEST_PASS");
+      expect(meta.username).toBe("admin");
+      expect(meta.has_password).toBe(true);
+    });
+
+    it("should return empty username from single-var format", async () => {
+      const meta = await backend.getMetadata("TEST_PASS");
+      expect(meta.username).toBe("");
+      expect(meta.has_password).toBe(true);
     });
 
     it("should return has_password false if pass var missing", async () => {


### PR DESCRIPTION
Closes #87

## Summary

The env backend `credential_ref` now accepts three formats:

| Format | Example | When to use |
|--------|---------|-------------|
| Single var (new) | `PASS_VAR` | Password only; username from tool arg |
| Named keys (recommended) | `user=USER_VAR,pass=PASS_VAR` | Explicit, self-documenting |
| Legacy colon (compat) | `USER_VAR:PASS_VAR` | Backwards compatible, still works |

## Changes
- `src/credentials/env.ts` — `parseRef` handles all three formats; `userVar` now optional
- `test/unit/env-backend.test.ts` — 15 → 34 tests covering all parse variants and edge cases
- `README.md` — updated env backend docs to show all three formats

## Tests
✅ 225 tests pass