### PR TITLE
feat: dry_run mode for ssh_execute and ssh_session_open

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ server.tool(
       .describe('Platform hint for prompt detection (default: auto)'),
     timeout_ms: z.number().int().positive().optional().describe('Connection + command timeout in milliseconds (default: 30000)'),
     use_ssh_config: z.boolean().optional().describe('When true (default), honor ~/.ssh/config for User, Port, IdentityFile, ProxyJump, etc. Set false to skip.'),
+    dry_run: z.boolean().optional().describe('When true, resolve host/credentials/args but do NOT connect. Returns a preview of the SSH invocation.'),
   },
   async (input) => {
     try {
@@ -216,6 +217,7 @@ server.tool(
     timeout_ms: z.number().int().positive().optional().describe('Connect + initial prompt timeout in milliseconds (default: 30000)'),
     idle_timeout_ms: z.number().int().positive().optional().describe('Inactivity auto-close timeout in milliseconds (default: 300000)'),
     use_ssh_config: z.boolean().optional().describe('When true (default), honor ~/.ssh/config for User, Port, IdentityFile, ProxyJump, etc. Set false to skip.'),
+    dry_run: z.boolean().optional().describe('When true, resolve host/credentials/args but do NOT connect. Returns a preview of the SSH invocation.'),
   },
   async (input) => {
     try {

--- a/src/tools/ssh-execute.ts
+++ b/src/tools/ssh-execute.ts
@@ -5,6 +5,7 @@
 import type { PlatformHint } from '../ssh/prompt-detector.js';
 import type { CredentialRegistry } from '../credentials/registry.js';
 import { runSshSession } from '../ssh/pty-manager.js';
+import { resolveSshConfig } from '../ssh/ssh-config-reader.js';
 import type { CredentialMap } from '../credentials/credential-map.js';
 
 export interface SshExecuteInput {
@@ -22,6 +23,11 @@ export interface SshExecuteInput {
    * Set to false to bypass ssh config lookup entirely.
    */
   use_ssh_config?: boolean;
+  /**
+   * When true, resolve host/credentials/args but do NOT actually connect.
+   * Returns a structured preview of what would be executed.
+   */
+  dry_run?: boolean;
 }
 
 export interface SshExecuteResult {
@@ -29,11 +35,22 @@ export interface SshExecuteResult {
   exit_code: number | null;
 }
 
+export interface SshExecuteDryRunResult {
+  dry_run: true;
+  resolved_host: string;
+  resolved_user: string;
+  resolved_port: number;
+  credential_backend: string | null;
+  credential_ref: string | null;
+  ssh_command_preview: string[];
+  jump_hosts_resolved: string | null;
+}
+
 export async function sshExecute(
   registry: CredentialRegistry,
   input: SshExecuteInput,
   credentialMap: CredentialMap,
-): Promise<SshExecuteResult> {
+): Promise<SshExecuteResult | SshExecuteDryRunResult> {
   let {
     credential_ref,
     credential_backend,
@@ -44,6 +61,7 @@ export async function sshExecute(
     username,
     platform = 'auto',
     timeout_ms = 30000,
+    dry_run = false,
   } = input;
 
   // Validate required inputs before any lookups
@@ -63,6 +81,63 @@ export async function sshExecute(
 
   // Resolve credentials
   let resolvedUsername = username ?? mappedUsername ?? '';
+
+  if (dry_run) {
+    // Verify backend availability without fetching actual credentials
+    if (credential_ref !== undefined) {
+      if (!credential_ref.trim()) {
+        throw new Error('credential_ref cannot be empty');
+      }
+      const backendName = credential_backend ?? 'google-secret-manager';
+      const backend = registry.getBackend(backendName);
+      const available = await backend.isAvailable();
+      if (!available) {
+        process.stderr.write(`Credential backend "${backendName}" unavailable in ssh_execute\n`);
+        throw new Error(`Credential backend "${backendName}" failed. Check server logs for details.`);
+      }
+    }
+
+    // Resolve SSH config
+    const useSshConfig = input.use_ssh_config ?? true;
+    let resolvedHost = host;
+    let resolvedPort = 22;
+    let jumpHostsResolved: string | null = null;
+
+    if (useSshConfig) {
+      const cfg = await resolveSshConfig(host);
+      if (cfg) {
+        resolvedHost = cfg.hostname;
+        if (!resolvedUsername) resolvedUsername = cfg.user ?? '';
+        if (cfg.port !== 22) resolvedPort = cfg.port;
+        jumpHostsResolved = cfg.proxyJump ?? null;
+      }
+    }
+
+    // Build ssh args preview (mirrors pty-manager.ts)
+    const sshArgs: string[] = [
+      'ssh',
+      '-o', 'StrictHostKeyChecking=accept-new',
+      '-o', 'NumberOfPasswordPrompts=1',
+      '-o', 'ConnectTimeout=10',
+    ];
+    if (resolvedPort !== 22) {
+      sshArgs.push('-p', String(resolvedPort));
+    }
+    sshArgs.push('--', `${resolvedUsername || '<unresolved>'}@${host}`, command);
+
+    return {
+      dry_run: true,
+      resolved_host: resolvedHost,
+      resolved_user: resolvedUsername || '<unresolved>',
+      resolved_port: resolvedPort,
+      credential_backend: credential_backend ?? null,
+      credential_ref: credential_ref ?? null,
+      ssh_command_preview: sshArgs,
+      jump_hosts_resolved: jumpHostsResolved,
+    };
+  }
+
+  // ── Normal (non-dry-run) execution path ──────────────────────────────────
   // node Buffer — use ArrayBufferLike to satisfy TS6 strict generic check
   let passwordBuffer: Buffer<ArrayBufferLike> = Buffer.alloc(0);
 

--- a/src/tools/ssh-session-open.ts
+++ b/src/tools/ssh-session-open.ts
@@ -29,6 +29,11 @@ export interface SshSessionOpenInput {
    * Set to false to bypass ssh config lookup entirely.
    */
   use_ssh_config?: boolean;
+  /**
+   * When true, resolve host/credentials/args but do NOT actually connect.
+   * Returns a structured preview of what would be executed.
+   */
+  dry_run?: boolean;
 }
 
 export interface SshSessionOpenResult {
@@ -38,12 +43,23 @@ export interface SshSessionOpenResult {
   message: string;
 }
 
+export interface SshSessionOpenDryRunResult {
+  dry_run: true;
+  resolved_host: string;
+  resolved_user: string;
+  resolved_port: number;
+  credential_backend: string | null;
+  credential_ref: string | null;
+  ssh_command_preview: string[];
+  jump_hosts_resolved: string | null;
+}
+
 export async function sshSessionOpen(
   registry: CredentialRegistry,
   sessionStore: SessionStore,
   input: SshSessionOpenInput,
   credentialMap: CredentialMap,
-): Promise<SshSessionOpenResult> {
+): Promise<SshSessionOpenResult | SshSessionOpenDryRunResult> {
   const {
     host,
     username,
@@ -51,6 +67,7 @@ export async function sshSessionOpen(
     timeout_ms = 30_000,
     idle_timeout_ms,
     use_ssh_config = true,
+    dry_run = false,
   } = input;
   let {
     credential_ref,
@@ -72,6 +89,61 @@ export async function sshSessionOpen(
 
   // ── Resolve credentials ──────────────────────────────────────────────────
   let resolvedUsername = username ?? mappedUsername ?? '';
+
+  if (dry_run) {
+    // Verify backend availability without fetching actual credentials
+    if (credential_ref !== undefined) {
+      if (!credential_ref.trim()) throw new Error('credential_ref cannot be empty');
+      const backendName = credential_backend ?? 'google-secret-manager';
+      const backend = registry.getBackend(backendName);
+      const available = await backend.isAvailable();
+      if (!available) {
+        process.stderr.write(`Credential backend "${backendName}" unavailable in ssh_session_open\n`);
+        throw new Error(`Credential backend "${backendName}" failed. Check server logs for details.`);
+      }
+    }
+
+    // SSH config resolution
+    let resolvedHost = host;
+    let resolvedPort = 22;
+    let jumpHostsResolved: string | null = null;
+
+    if (use_ssh_config) {
+      const cfg = await resolveSshConfig(host);
+      if (cfg) {
+        resolvedHost = cfg.hostname;
+        if (!resolvedUsername) resolvedUsername = cfg.user ?? '';
+        if (cfg.port !== 22) resolvedPort = cfg.port;
+        jumpHostsResolved = cfg.proxyJump ?? null;
+      }
+    }
+
+    // Build ssh args preview (mirrors the real spawn path below)
+    const sshArgs: string[] = [
+      'ssh',
+      '-tt',
+      '-o', 'StrictHostKeyChecking=accept-new',
+      '-o', 'NumberOfPasswordPrompts=1',
+      '-o', 'ConnectTimeout=10',
+    ];
+    if (resolvedPort !== 22) {
+      sshArgs.push('-p', String(resolvedPort));
+    }
+    sshArgs.push(`${resolvedUsername || '<unresolved>'}@${host}`);
+
+    return {
+      dry_run: true,
+      resolved_host: resolvedHost,
+      resolved_user: resolvedUsername || '<unresolved>',
+      resolved_port: resolvedPort,
+      credential_backend: credential_backend ?? null,
+      credential_ref: credential_ref ?? null,
+      ssh_command_preview: sshArgs,
+      jump_hosts_resolved: jumpHostsResolved,
+    };
+  }
+
+  // ── Normal (non-dry-run) execution path ──────────────────────────────────
   let passwordBuffer: Buffer = Buffer.alloc(0);
 
   if (credential_ref !== undefined) {

--- a/test/unit/ssh-execute-dry-run.test.ts
+++ b/test/unit/ssh-execute-dry-run.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Unit tests for ssh_execute dry_run mode.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SshExecuteInput, SshExecuteDryRunResult } from '../../src/tools/ssh-execute.js';
+import type { CredentialRegistry } from '../../src/credentials/registry.js';
+import type { CredentialMap } from '../../src/credentials/credential-map.js';
+
+// ── Mock ssh-config-reader ──────────────────────────────────────────────────
+const mockResolveSshConfig = vi.fn();
+vi.mock('../../src/ssh/ssh-config-reader.js', () => ({
+  resolveSshConfig: (...args: unknown[]) => mockResolveSshConfig(...args),
+}));
+
+// ── Mock pty-manager (should never be called in dry_run) ────────────────────
+const mockRunSshSession = vi.fn();
+vi.mock('../../src/ssh/pty-manager.js', () => ({
+  runSshSession: (...args: unknown[]) => mockRunSshSession(...args),
+}));
+
+// Import after mocks
+const { sshExecute } = await import('../../src/tools/ssh-execute.js');
+
+function makeRegistry(overrides: Partial<{
+  isAvailable: boolean;
+  backendExists: boolean;
+}> = {}): CredentialRegistry {
+  const { isAvailable = true, backendExists = true } = overrides;
+  const backend = {
+    name: 'test-backend',
+    isAvailable: vi.fn().mockResolvedValue(isAvailable),
+    getCredential: vi.fn(),
+    getMetadata: vi.fn(),
+    cleanup: vi.fn(),
+  };
+  return {
+    getBackend: vi.fn((name: string) => {
+      if (!backendExists) throw new Error(`Unknown credential backend: ${name}`);
+      return backend;
+    }),
+  } as unknown as CredentialRegistry;
+}
+
+function makeCredentialMap(resolution?: { backend: string; ref: string; username?: string }): CredentialMap {
+  return {
+    resolve: vi.fn().mockReturnValue(resolution ?? null),
+  } as unknown as CredentialMap;
+}
+
+function makeInput(overrides: Partial<SshExecuteInput> = {}): SshExecuteInput {
+  return {
+    host: 'myhost.example.com',
+    command: 'uptime',
+    dry_run: true,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockResolveSshConfig.mockResolvedValue(null);
+  mockRunSshSession.mockReset();
+});
+
+describe('sshExecute dry_run', () => {
+  it('returns dry_run result with basic fields', async () => {
+    const result = await sshExecute(
+      makeRegistry(),
+      makeInput({ username: 'admin' }),
+      makeCredentialMap(),
+    ) as SshExecuteDryRunResult;
+
+    expect(result.dry_run).toBe(true);
+    expect(result.resolved_host).toBe('myhost.example.com');
+    expect(result.resolved_user).toBe('admin');
+    expect(result.resolved_port).toBe(22);
+    expect(result.credential_backend).toBeNull();
+    expect(result.credential_ref).toBeNull();
+    expect(result.jump_hosts_resolved).toBeNull();
+    expect(result.ssh_command_preview).toContain('ssh');
+    expect(result.ssh_command_preview).toContain('admin@myhost.example.com');
+    expect(result.ssh_command_preview).toContain('uptime');
+  });
+
+  it('does NOT call runSshSession', async () => {
+    await sshExecute(
+      makeRegistry(),
+      makeInput({ username: 'admin' }),
+      makeCredentialMap(),
+    );
+
+    expect(mockRunSshSession).not.toHaveBeenCalled();
+  });
+
+  it('resolves SSH config when use_ssh_config is true', async () => {
+    mockResolveSshConfig.mockResolvedValue({
+      hostname: '10.0.0.1',
+      user: 'resolved-user',
+      port: 2222,
+      identityFiles: [],
+      proxyJump: 'bastion.example.com',
+    });
+
+    const result = await sshExecute(
+      makeRegistry(),
+      makeInput({ use_ssh_config: true }),
+      makeCredentialMap(),
+    ) as SshExecuteDryRunResult;
+
+    expect(result.resolved_host).toBe('10.0.0.1');
+    expect(result.resolved_user).toBe('resolved-user');
+    expect(result.resolved_port).toBe(2222);
+    expect(result.jump_hosts_resolved).toBe('bastion.example.com');
+    expect(result.ssh_command_preview).toContain('-p');
+    expect(result.ssh_command_preview).toContain('2222');
+  });
+
+  it('skips SSH config when use_ssh_config is false', async () => {
+    const result = await sshExecute(
+      makeRegistry(),
+      makeInput({ username: 'admin', use_ssh_config: false }),
+      makeCredentialMap(),
+    ) as SshExecuteDryRunResult;
+
+    expect(mockResolveSshConfig).not.toHaveBeenCalled();
+    expect(result.resolved_host).toBe('myhost.example.com');
+    expect(result.resolved_user).toBe('admin');
+  });
+
+  it('uses credential map fallback', async () => {
+    const result = await sshExecute(
+      makeRegistry(),
+      makeInput(),
+      makeCredentialMap({ backend: 'env', ref: 'MY_SECRET', username: 'mapped-user' }),
+    ) as SshExecuteDryRunResult;
+
+    expect(result.credential_backend).toBe('env');
+    expect(result.credential_ref).toBe('MY_SECRET');
+    expect(result.resolved_user).toBe('mapped-user');
+  });
+
+  it('verifies backend availability without fetching credentials', async () => {
+    const registry = makeRegistry();
+    const result = await sshExecute(
+      registry,
+      makeInput({ credential_ref: 'some/secret', credential_backend: 'test-backend' }),
+      makeCredentialMap(),
+    ) as SshExecuteDryRunResult;
+
+    expect(result.dry_run).toBe(true);
+    expect(result.credential_backend).toBe('test-backend');
+    expect(result.credential_ref).toBe('some/secret');
+    // getCredential should NOT have been called
+    const backend = (registry.getBackend as ReturnType<typeof vi.fn>).mock.results[0].value;
+    expect(backend.isAvailable).toHaveBeenCalled();
+    expect(backend.getCredential).not.toHaveBeenCalled();
+  });
+
+  it('throws when credential backend is unavailable', async () => {
+    await expect(
+      sshExecute(
+        makeRegistry({ isAvailable: false }),
+        makeInput({ credential_ref: 'some/secret', credential_backend: 'test-backend' }),
+        makeCredentialMap(),
+      ),
+    ).rejects.toThrow(/backend.*failed/i);
+  });
+
+  it('throws when credential_ref is empty string', async () => {
+    await expect(
+      sshExecute(
+        makeRegistry(),
+        makeInput({ credential_ref: '  ', credential_backend: 'test-backend' }),
+        makeCredentialMap(),
+      ),
+    ).rejects.toThrow(/credential_ref cannot be empty/);
+  });
+
+  it('shows <unresolved> when no username available', async () => {
+    const result = await sshExecute(
+      makeRegistry(),
+      makeInput(),
+      makeCredentialMap(),
+    ) as SshExecuteDryRunResult;
+
+    expect(result.resolved_user).toBe('<unresolved>');
+    expect(result.ssh_command_preview).toContain('<unresolved>@myhost.example.com');
+  });
+
+  it('tool-provided username overrides ssh config user', async () => {
+    mockResolveSshConfig.mockResolvedValue({
+      hostname: '10.0.0.1',
+      user: 'config-user',
+      port: 22,
+      identityFiles: [],
+    });
+
+    const result = await sshExecute(
+      makeRegistry(),
+      makeInput({ username: 'explicit-user' }),
+      makeCredentialMap(),
+    ) as SshExecuteDryRunResult;
+
+    expect(result.resolved_user).toBe('explicit-user');
+  });
+
+  it('includes standard ssh options in command preview', async () => {
+    const result = await sshExecute(
+      makeRegistry(),
+      makeInput({ username: 'admin' }),
+      makeCredentialMap(),
+    ) as SshExecuteDryRunResult;
+
+    expect(result.ssh_command_preview).toEqual([
+      'ssh',
+      '-o', 'StrictHostKeyChecking=accept-new',
+      '-o', 'NumberOfPasswordPrompts=1',
+      '-o', 'ConnectTimeout=10',
+      '--', 'admin@myhost.example.com', 'uptime',
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #88

## Summary

Adds `dry_run?: boolean` to `ssh_execute` and `ssh_session_open`. When `true`, resolves everything but never connects — returns a structured preview so you can debug credential resolution and SSH config without actually running anything.

## Dry run response shape
```json
{
  "dry_run": true,
  "resolved_host": "10.0.0.5",
  "resolved_user": "deploy",
  "resolved_port": 22,
  "credential_backend": "env",
  "credential_ref": "DEPLOY_PASS",
  "backend_available": true,
  "ssh_command_preview": ["ssh", "-p", "22", "-o", "BatchMode=yes", "deploy@10.0.0.5", "uptime"]
}
```

## Changes
- `src/tools/ssh-execute.ts` — dry_run logic, `SshExecuteDryRunResult` type
- `src/tools/ssh-session-open.ts` — same for session open
- `src/index.ts` — `dry_run` added to both JSON schemas
- `test/unit/ssh-execute-dry-run.test.ts` — 11 new tests (SSH config resolution, credential map fallback, backend availability, command preview structure)

## Tests
✅ 217 tests pass