### PR TITLE
feat: output size limits and output_to_file overflow

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,8 @@ server.tool(
       .describe('Platform hint for prompt detection (default: auto)'),
     timeout_ms: z.number().int().positive().optional().describe('Connection + command timeout in milliseconds (default: 30000)'),
     use_ssh_config: z.boolean().optional().describe('When true (default), honor ~/.ssh/config for User, Port, IdentityFile, ProxyJump, etc. Set false to skip.'),
+    max_output_bytes: z.number().int().positive().optional().describe('Maximum output size in bytes before truncation (default: 65536 = 64 KB). Output exceeding this limit is saved to a file and a head/tail preview is returned inline.'),
+    output_to_file: z.string().optional().describe('If provided, always write full output to this file path (plus return head/tail inline).'),
   },
   async (input) => {
     try {
@@ -238,6 +240,8 @@ server.tool(
     session_id: z.string().describe('Session ID returned by ssh_session_open'),
     command: z.string().describe('Command to execute in the session'),
     timeout_ms: z.number().int().positive().optional().describe('Command timeout in milliseconds (default: 30000)'),
+    max_output_bytes: z.number().int().positive().optional().describe('Maximum output size in bytes before truncation (default: 65536 = 64 KB). Output exceeding this limit is saved to a file and a head/tail preview is returned inline.'),
+    output_to_file: z.string().optional().describe('If provided, always write full output to this file path (plus return head/tail inline).'),
   },
   async (input) => {
     try {

--- a/src/tools/ssh-execute.ts
+++ b/src/tools/ssh-execute.ts
@@ -6,6 +6,7 @@ import type { PlatformHint } from '../ssh/prompt-detector.js';
 import type { CredentialRegistry } from '../credentials/registry.js';
 import { runSshSession } from '../ssh/pty-manager.js';
 import type { CredentialMap } from '../credentials/credential-map.js';
+import { applyOutputLimit } from '../utils/output-limiter.js';
 
 export interface SshExecuteInput {
   host: string;
@@ -22,11 +23,20 @@ export interface SshExecuteInput {
    * Set to false to bypass ssh config lookup entirely.
    */
   use_ssh_config?: boolean;
+  /** Maximum output bytes before truncation (default: 65 536 = 64 KB). */
+  max_output_bytes?: number;
+  /** If provided, always write full output to this file path. */
+  output_to_file?: string;
 }
 
 export interface SshExecuteResult {
   output: string;
   exit_code: number | null;
+  truncated?: boolean;
+  total_bytes?: number;
+  head?: string;
+  tail?: string;
+  saved_path?: string;
 }
 
 export async function sshExecute(
@@ -107,7 +117,14 @@ export async function sshExecute(
       timeout_ms,
       use_ssh_config: input.use_ssh_config ?? true,
     });
-    return result;
+
+    // Apply output limiting
+    const limited = await applyOutputLimit(result.output, {
+      max_output_bytes: input.max_output_bytes,
+      output_to_file: input.output_to_file,
+    });
+
+    return { ...result, ...limited };
   } finally {
     // Zero-fill password buffer after PTY session completes (success or failure)
     passwordBuffer.fill(0);

--- a/src/tools/ssh-session-execute.ts
+++ b/src/tools/ssh-session-execute.ts
@@ -9,17 +9,27 @@ import type { SessionStore, ManagedSession } from '../ssh/session-store.js';
 import type { IDisposable } from 'node-pty';
 import { detectPrompt } from '../ssh/prompt-detector.js';
 import { scrubOutput } from '../ssh/output-scrubber.js';
+import { applyOutputLimit } from '../utils/output-limiter.js';
 
 export interface SshSessionExecuteInput {
   session_id: string;
   command: string;
   timeout_ms?: number; // default 30000
+  /** Maximum output bytes before truncation (default: 65 536 = 64 KB). */
+  max_output_bytes?: number;
+  /** If provided, always write full output to this file path. */
+  output_to_file?: string;
 }
 
 export interface SshSessionExecuteResult {
   output: string;
   exit_code: number | null; // null for interactive sessions
   session_id: string;
+  truncated?: boolean;
+  total_bytes?: number;
+  head?: string;
+  tail?: string;
+  saved_path?: string;
 }
 
 export async function sshSessionExecute(
@@ -52,7 +62,7 @@ export async function sshSessionExecute(
 
   const sess = session; // capture for closure — TypeScript narrowing guard
 
-  return new Promise<SshSessionExecuteResult>((resolve, reject) => {
+  const base = await new Promise<SshSessionExecuteResult>((resolve, reject) => {
     let captureBuffer = '';
     let settled = false;
     let dataDisposable: IDisposable | undefined;
@@ -128,4 +138,12 @@ export async function sshSessionExecute(
       fail(new Error(`Failed to write to PTY: ${String(err)}`));
     }
   });
+
+  // Apply output limiting after PTY interaction completes
+  const limited = await applyOutputLimit(base.output, {
+    max_output_bytes: input.max_output_bytes,
+    output_to_file: input.output_to_file,
+  });
+
+  return { ...base, ...limited };
 }

--- a/src/utils/output-limiter.ts
+++ b/src/utils/output-limiter.ts
@@ -1,0 +1,140 @@
+/**
+ * Output size limiter — caps SSH command output to protect the agent context
+ * window.  When output exceeds the configured byte limit (or `output_to_file`
+ * is set), the full output is written to disk and an inline head/tail preview
+ * is returned instead.
+ */
+
+import { mkdir, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { randomUUID } from 'crypto';
+
+/** Default cap: 64 KB */
+export const DEFAULT_MAX_OUTPUT_BYTES = 65_536;
+
+/** Max bytes for each inline preview segment (head / tail). */
+const MAX_PREVIEW_BYTES = 8_192;
+
+const HEAD_LINES = 50;
+const TAIL_LINES = 20;
+
+export interface OutputLimitOptions {
+  max_output_bytes?: number;
+  output_to_file?: string;
+}
+
+export interface OutputLimitResult {
+  /** Inline output — full text when under limit, or head+tail preview when truncated. */
+  output: string;
+  truncated?: boolean;
+  total_bytes?: number;
+  head?: string;
+  tail?: string;
+  saved_path?: string;
+}
+
+/**
+ * Returns the base directory for overflow files.
+ * Uses `os.tmpdir()` for portability; override via `AI_SSH_TOOLKIT_OUTPUT_DIR`.
+ */
+function getOutputDir(): string {
+  return process.env.AI_SSH_TOOLKIT_OUTPUT_DIR ?? join(tmpdir(), 'ai-ssh-toolkit');
+}
+
+/**
+ * Slice a string so its UTF-8 byte length does not exceed `maxBytes`.
+ * Avoids splitting multi-byte characters.
+ */
+function byteSafeSlice(str: string, maxBytes: number): string {
+  const buf = Buffer.from(str, 'utf-8');
+  if (buf.length <= maxBytes) return str;
+  // Walk back from maxBytes to avoid splitting a multi-byte char
+  let end = maxBytes;
+  // eslint-disable-next-line no-bitwise
+  while (end > 0 && (buf[end]! & 0xc0) === 0x80) end--;
+  return buf.subarray(0, end).toString('utf-8');
+}
+
+/**
+ * Build an inline preview (head + tail) of `output`, byte-capped.
+ */
+function buildPreview(output: string): { head: string; tail: string } {
+  const lines = output.split('\n');
+  const headLines = lines.slice(0, HEAD_LINES).join('\n');
+  const tailLines = lines.slice(-TAIL_LINES).join('\n');
+  return {
+    head: byteSafeSlice(headLines, MAX_PREVIEW_BYTES),
+    tail: byteSafeSlice(tailLines, MAX_PREVIEW_BYTES),
+  };
+}
+
+/**
+ * Write `content` to a file. Creates parent directory with 0o700.
+ * Generated overflow files use `wx` flag to never overwrite.
+ */
+async function writeOutputFile(
+  filePath: string,
+  content: string,
+  isGenerated: boolean,
+): Promise<void> {
+  const dir = join(filePath, '..');
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+  await writeFile(filePath, content, {
+    encoding: 'utf-8',
+    mode: 0o600,
+    flag: isGenerated ? 'wx' : 'w',
+  });
+}
+
+/**
+ * Apply output limiting.
+ *
+ * - If `output_to_file` is set, always write full output there and return
+ *   head/tail inline.
+ * - If output exceeds `max_output_bytes`, write to a generated overflow file
+ *   and return head/tail inline.
+ * - Otherwise return the full output unchanged.
+ */
+export async function applyOutputLimit(
+  output: string,
+  options: OutputLimitOptions = {},
+): Promise<OutputLimitResult> {
+  const maxBytes = options.max_output_bytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+  const totalBytes = Buffer.byteLength(output, 'utf-8');
+  const outputToFile = options.output_to_file;
+
+  // Case 1: caller explicitly requested output_to_file
+  if (outputToFile) {
+    await writeOutputFile(outputToFile, output, false);
+    const { head, tail } = buildPreview(output);
+    return {
+      output: `[Full output saved to ${outputToFile}]\n\n--- head (first ${HEAD_LINES} lines) ---\n${head}\n\n--- tail (last ${TAIL_LINES} lines) ---\n${tail}`,
+      truncated: totalBytes > maxBytes,
+      total_bytes: totalBytes,
+      head,
+      tail,
+      saved_path: outputToFile,
+    };
+  }
+
+  // Case 2: output is within the byte limit — return unchanged
+  if (totalBytes <= maxBytes) {
+    return { output };
+  }
+
+  // Case 3: output exceeds byte limit — overflow to generated file
+  const outputDir = getOutputDir();
+  const savedPath = join(outputDir, `${randomUUID()}.txt`);
+  await writeOutputFile(savedPath, output, true);
+
+  const { head, tail } = buildPreview(output);
+  return {
+    output: `[Output truncated: ${totalBytes} bytes exceeds ${maxBytes} byte limit. Full output saved to ${savedPath}]\n\n--- head (first ${HEAD_LINES} lines) ---\n${head}\n\n--- tail (last ${TAIL_LINES} lines) ---\n${tail}`,
+    truncated: true,
+    total_bytes: totalBytes,
+    head,
+    tail,
+    saved_path: savedPath,
+  };
+}

--- a/src/utils/output-limiter.ts
+++ b/src/utils/output-limiter.ts
@@ -51,7 +51,6 @@ function byteSafeSlice(str: string, maxBytes: number): string {
   if (buf.length <= maxBytes) return str;
   // Walk back from maxBytes to avoid splitting a multi-byte char
   let end = maxBytes;
-  // eslint-disable-next-line no-bitwise
   while (end > 0 && (buf[end]! & 0xc0) === 0x80) end--;
   return buf.subarray(0, end).toString('utf-8');
 }

--- a/test/unit/output-limiter.test.ts
+++ b/test/unit/output-limiter.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, existsSync, readFileSync, rmSync } from 'fs';
+import { existsSync, readFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { applyOutputLimit, DEFAULT_MAX_OUTPUT_BYTES } from '../../src/utils/output-limiter.js';

--- a/test/unit/output-limiter.test.ts
+++ b/test/unit/output-limiter.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Unit tests for the output-limiter utility.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, existsSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { applyOutputLimit, DEFAULT_MAX_OUTPUT_BYTES } from '../../src/utils/output-limiter.js';
+
+const TEST_OUTPUT_DIR = join(tmpdir(), 'ai-ssh-toolkit-test-' + process.pid);
+
+beforeEach(() => {
+  process.env.AI_SSH_TOOLKIT_OUTPUT_DIR = TEST_OUTPUT_DIR;
+});
+
+afterEach(() => {
+  delete process.env.AI_SSH_TOOLKIT_OUTPUT_DIR;
+  if (existsSync(TEST_OUTPUT_DIR)) {
+    rmSync(TEST_OUTPUT_DIR, { recursive: true, force: true });
+  }
+});
+
+describe('applyOutputLimit', () => {
+  it('returns output unchanged when under default limit', async () => {
+    const output = 'Hello, world!\nLine 2\n';
+    const result = await applyOutputLimit(output);
+
+    expect(result.output).toBe(output);
+    expect(result.truncated).toBeUndefined();
+    expect(result.saved_path).toBeUndefined();
+    expect(result.head).toBeUndefined();
+    expect(result.tail).toBeUndefined();
+  });
+
+  it('returns output unchanged when exactly at limit', async () => {
+    // Build a string that is exactly DEFAULT_MAX_OUTPUT_BYTES in UTF-8
+    const output = 'A'.repeat(DEFAULT_MAX_OUTPUT_BYTES);
+    const result = await applyOutputLimit(output);
+
+    expect(result.output).toBe(output);
+    expect(result.truncated).toBeUndefined();
+  });
+
+  it('truncates output exceeding the default limit', async () => {
+    const lineCount = 200;
+    const lines = Array.from({ length: lineCount }, (_, i) => `Line ${i + 1}: ${'x'.repeat(500)}`);
+    const output = lines.join('\n');
+    expect(Buffer.byteLength(output, 'utf-8')).toBeGreaterThan(DEFAULT_MAX_OUTPUT_BYTES);
+
+    const result = await applyOutputLimit(output);
+
+    expect(result.truncated).toBe(true);
+    expect(result.total_bytes).toBe(Buffer.byteLength(output, 'utf-8'));
+    expect(result.head).toBeDefined();
+    expect(result.tail).toBeDefined();
+    expect(result.saved_path).toBeDefined();
+    expect(result.output).toContain('Output truncated');
+    expect(result.output).toContain('head');
+    expect(result.output).toContain('tail');
+
+    // Verify overflow file was written with full content
+    expect(existsSync(result.saved_path!)).toBe(true);
+    const savedContent = readFileSync(result.saved_path!, 'utf-8');
+    expect(savedContent).toBe(output);
+  });
+
+  it('respects custom max_output_bytes', async () => {
+    const output = 'A'.repeat(100);
+    const result = await applyOutputLimit(output, { max_output_bytes: 50 });
+
+    expect(result.truncated).toBe(true);
+    expect(result.total_bytes).toBe(100);
+    expect(result.saved_path).toBeDefined();
+    expect(existsSync(result.saved_path!)).toBe(true);
+  });
+
+  it('head contains first 50 lines', async () => {
+    const lines = Array.from({ length: 100 }, (_, i) => `Line ${i + 1}`);
+    const output = lines.join('\n');
+
+    const result = await applyOutputLimit(output, { max_output_bytes: 10 });
+
+    expect(result.head).toBeDefined();
+    expect(result.head!).toContain('Line 1');
+    expect(result.head!).toContain('Line 50');
+    expect(result.head!).not.toContain('Line 51');
+  });
+
+  it('tail contains last 20 lines', async () => {
+    const lines = Array.from({ length: 100 }, (_, i) => `Line ${i + 1}`);
+    const output = lines.join('\n');
+
+    const result = await applyOutputLimit(output, { max_output_bytes: 10 });
+
+    expect(result.tail).toBeDefined();
+    expect(result.tail!).toContain('Line 81');
+    expect(result.tail!).toContain('Line 100');
+  });
+
+  it('handles empty output without truncation', async () => {
+    const result = await applyOutputLimit('');
+
+    expect(result.output).toBe('');
+    expect(result.truncated).toBeUndefined();
+  });
+
+  describe('output_to_file', () => {
+    it('writes full output to specified file and returns head/tail', async () => {
+      const filePath = join(TEST_OUTPUT_DIR, 'explicit-output.txt');
+      const output = 'Small output for file';
+
+      const result = await applyOutputLimit(output, { output_to_file: filePath });
+
+      expect(result.saved_path).toBe(filePath);
+      expect(result.head).toBeDefined();
+      expect(result.tail).toBeDefined();
+      expect(result.output).toContain('Full output saved to');
+      expect(existsSync(filePath)).toBe(true);
+      expect(readFileSync(filePath, 'utf-8')).toBe(output);
+    });
+
+    it('sets truncated=false when output_to_file is used with small output', async () => {
+      const filePath = join(TEST_OUTPUT_DIR, 'small.txt');
+      const output = 'tiny';
+
+      const result = await applyOutputLimit(output, { output_to_file: filePath });
+
+      expect(result.truncated).toBe(false);
+      expect(result.total_bytes).toBe(4);
+    });
+
+    it('sets truncated=true when output_to_file is used with large output', async () => {
+      const filePath = join(TEST_OUTPUT_DIR, 'large.txt');
+      const output = 'A'.repeat(DEFAULT_MAX_OUTPUT_BYTES + 1);
+
+      const result = await applyOutputLimit(output, { output_to_file: filePath });
+
+      expect(result.truncated).toBe(true);
+      expect(result.saved_path).toBe(filePath);
+    });
+  });
+
+  describe('byte-safe preview', () => {
+    it('caps head preview to avoid very long single-line output', async () => {
+      // Single very long line — head should be byte-capped
+      const output = 'X'.repeat(100_000);
+
+      const result = await applyOutputLimit(output, { max_output_bytes: 10 });
+
+      expect(result.head).toBeDefined();
+      expect(Buffer.byteLength(result.head!, 'utf-8')).toBeLessThanOrEqual(8192);
+    });
+
+    it('handles multibyte UTF-8 characters without splitting', async () => {
+      // Each emoji is 4 bytes in UTF-8
+      const emoji = '😀';
+      const output = emoji.repeat(30_000); // ~120KB — over default limit
+
+      const result = await applyOutputLimit(output);
+
+      expect(result.truncated).toBe(true);
+      expect(result.head).toBeDefined();
+      // Head should be valid UTF-8 — no replacement chars
+      expect(result.head!).not.toContain('\uFFFD');
+      // Full output saved correctly
+      const saved = readFileSync(result.saved_path!, 'utf-8');
+      expect(saved).toBe(output);
+    });
+  });
+});


### PR DESCRIPTION
Closes #90

## Summary

`ssh_execute` and `ssh_session_execute` now cap output at 64KB by default. When exceeded, the full output is saved to a temp file and a head+tail preview is returned inline — no more context window blowouts from `journalctl --no-pager` or `show tech-support`.

## New parameters

| Parameter | Default | Description |
|-----------|---------|-------------|
| `max_output_bytes` | 65536 (64KB) | Cap per call |
| `output_to_file` | _(none)_ | Always write to this path |

## Truncated response shape
```json
{
  "truncated": true,
  "total_bytes": 12345678,
  "head": "first 50 lines...",
  "tail": "last 20 lines...",
  "saved_path": "/tmp/ai-ssh-toolkit/abc123.txt"
}
```

## Changes
- `src/utils/output-limiter.ts` — new utility, byte-safe UTF-8 slicing, UUID-named temp files
- `src/tools/ssh-execute.ts` + `ssh-session-execute.ts` — integrated
- `src/index.ts` — MCP schemas updated
- `test/unit/output-limiter.test.ts` — 12 new tests

## Tests
✅ 218 tests pass