### PR TITLE
feat: actionable diagnostics for credential backends

### DIFF
--- a/src/credentials/azure-keyvault.ts
+++ b/src/credentials/azure-keyvault.ts
@@ -3,6 +3,7 @@ import {
   CredentialBackend,
   CredentialResult,
   CredentialMetadata,
+  HealthCheckResult,
 } from "./backend.js";
 import { resolveCliPath } from "../utils/cli-resolver.js";
 
@@ -39,14 +40,24 @@ export class AzureKeyVaultBackend implements CredentialBackend {
   private stagedBuffers: Buffer[] = [];
 
   async isAvailable(): Promise<boolean> {
+    const health = await this.checkHealth();
+    return health.available;
+  }
+
+  async checkHealth(): Promise<HealthCheckResult> {
     try {
       this.cliPath = resolveCliPath("az");
+    } catch {
+      return { available: false, reason: 'Azure CLI (az) not found in PATH' };
+    }
+
+    try {
       await execFileAsync(this.cliPath, ["account", "show"], {
         timeout: 10000,
       });
-      return true;
-    } catch {
-      return false;
+      return { available: true };
+    } catch (err) {
+      return { available: false, reason: `Azure CLI not authenticated — run 'az login' first: ${err instanceof Error ? err.message : String(err)}` };
     }
   }
 

--- a/src/credentials/backend.ts
+++ b/src/credentials/backend.ts
@@ -17,11 +17,24 @@ export interface CredentialMetadata {
   backend: string;
 }
 
+export interface HealthCheckResult {
+  available: boolean;
+  /** Human-readable reason when unavailable — never contains credential material */
+  reason?: string;
+}
+
 export interface CredentialBackend {
   readonly name: string;
 
   /** Check if this backend's prerequisites are met */
   isAvailable(): Promise<boolean>;
+
+  /**
+   * Structured health check with diagnostic reason on failure.
+   * Reason text must never contain credential material — only
+   * infrastructure status (CLI missing, env var unset, auth expired, etc.).
+   */
+  checkHealth(): Promise<HealthCheckResult>;
 
   /** Retrieve credential — password as Buffer, zero-fill after use */
   getCredential(ref: string): Promise<CredentialResult>;

--- a/src/credentials/bitwarden.ts
+++ b/src/credentials/bitwarden.ts
@@ -3,6 +3,7 @@ import {
   CredentialBackend,
   CredentialResult,
   CredentialMetadata,
+  HealthCheckResult,
 } from "./backend.js";
 import { resolveCliPath } from "../utils/cli-resolver.js";
 
@@ -38,8 +39,18 @@ export class BitwardenBackend implements CredentialBackend {
   private stagedBuffers: Buffer[] = [];
 
   async isAvailable(): Promise<boolean> {
+    const health = await this.checkHealth();
+    return health.available;
+  }
+
+  async checkHealth(): Promise<HealthCheckResult> {
     try {
       this.cliPath = resolveCliPath("bw");
+    } catch {
+      return { available: false, reason: 'Bitwarden CLI (bw) not found in PATH' };
+    }
+
+    try {
       this.hydrateSessionKeyFromEnv();
       const args = this.sessionKey ? ["status", "--session", this.sessionKey] : ["status"];
       const { stdout } = await execFileAsync(this.cliPath, args, {
@@ -47,11 +58,11 @@ export class BitwardenBackend implements CredentialBackend {
       });
       const status = JSON.parse(stdout);
       if (status.status === "unlocked") {
-        return true;
+        return { available: true };
       }
-      return false;
-    } catch {
-      return false;
+      return { available: false, reason: `Bitwarden vault is ${status.status ?? 'not unlocked'} — run 'bw unlock' first` };
+    } catch (err) {
+      return { available: false, reason: `Bitwarden status check failed: ${err instanceof Error ? err.message : String(err)}` };
     }
   }
 

--- a/src/credentials/env.ts
+++ b/src/credentials/env.ts
@@ -2,6 +2,7 @@ import {
   CredentialBackend,
   CredentialResult,
   CredentialMetadata,
+  HealthCheckResult,
 } from "./backend.js";
 
 /**
@@ -17,6 +18,10 @@ export class EnvCredentialBackend implements CredentialBackend {
 
   async isAvailable(): Promise<boolean> {
     return true;
+  }
+
+  async checkHealth(): Promise<HealthCheckResult> {
+    return { available: true };
   }
 
   async getCredential(ref: string): Promise<CredentialResult> {

--- a/src/credentials/google-secret-manager.ts
+++ b/src/credentials/google-secret-manager.ts
@@ -20,7 +20,7 @@
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { resolve } from 'path';
-import type { CredentialBackend, CredentialMetadata, CredentialResult } from './backend.js';
+import type { CredentialBackend, CredentialMetadata, CredentialResult, HealthCheckResult } from './backend.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -62,15 +62,25 @@ export class GoogleSecretManagerBackend implements CredentialBackend {
   }
 
   async isAvailable(): Promise<boolean> {
+    const health = await this.checkHealth();
+    return health.available;
+  }
+
+  async checkHealth(): Promise<HealthCheckResult> {
+    let gcloud: string;
     try {
-      const gcloud = await this.resolveGcloud();
-      // Check auth state
+      gcloud = await this.resolveGcloud();
+    } catch {
+      return { available: false, reason: 'gcloud CLI not found in PATH — install Google Cloud SDK' };
+    }
+
+    try {
       await execFileAsync(gcloud, ['auth', 'print-access-token'], {
         env: { ...process.env },
       });
-      return true;
-    } catch {
-      return false;
+      return { available: true };
+    } catch (err) {
+      return { available: false, reason: `gcloud not authenticated — run 'gcloud auth login': ${err instanceof Error ? err.message : String(err)}` };
     }
   }
 

--- a/src/credentials/registry.ts
+++ b/src/credentials/registry.ts
@@ -1,4 +1,4 @@
-import type { CredentialBackend, CredentialMetadata, CredentialResult, HealthCheckResult } from './backend.js';
+import type { CredentialBackend, CredentialMetadata, CredentialResult } from './backend.js';
 
 export type { HealthCheckResult } from './backend.js';
 

--- a/src/credentials/registry.ts
+++ b/src/credentials/registry.ts
@@ -1,8 +1,11 @@
-import type { CredentialBackend, CredentialMetadata, CredentialResult } from './backend.js';
+import type { CredentialBackend, CredentialMetadata, CredentialResult, HealthCheckResult } from './backend.js';
+
+export type { HealthCheckResult } from './backend.js';
 
 export interface BackendStatus {
   name: string;
   available: boolean;
+  reason?: string;
 }
 
 /**
@@ -14,6 +17,7 @@ export interface BackendStatus {
 export class CredentialRegistry {
   private backends: Map<string, CredentialBackend> = new Map();
   private availability: Map<string, boolean> = new Map();
+  private diagnostics: Map<string, string | undefined> = new Map();
 
   /** Register a backend instance */
   register(backend: CredentialBackend): void {
@@ -30,12 +34,17 @@ export class CredentialRegistry {
     const results = await Promise.all(
       entries.map(async ([name, backend]): Promise<BackendStatus> => {
         try {
-          const available = await backend.isAvailable();
-          this.availability.set(name, available);
-          return { name, available };
-        } catch {
+          const health = await backend.checkHealth();
+          this.availability.set(name, health.available);
+          this.diagnostics.set(name, health.reason);
+          const status: BackendStatus = { name, available: health.available };
+          if (health.reason) status.reason = health.reason;
+          return status;
+        } catch (err) {
+          const reason = `Health check threw: ${err instanceof Error ? err.message : String(err)}`;
           this.availability.set(name, false);
-          return { name, available: false };
+          this.diagnostics.set(name, reason);
+          return { name, available: false, reason };
         }
       })
     );
@@ -45,10 +54,15 @@ export class CredentialRegistry {
 
   /** List all backends with cached availability status */
   listBackends(): BackendStatus[] {
-    return Array.from(this.backends.keys()).map((name) => ({
-      name,
-      available: this.availability.get(name) ?? false,
-    }));
+    return Array.from(this.backends.keys()).map((name) => {
+      const status: BackendStatus = {
+        name,
+        available: this.availability.get(name) ?? false,
+      };
+      const reason = this.diagnostics.get(name);
+      if (reason) status.reason = reason;
+      return status;
+    });
   }
 
   /** Get a credential from a specific backend */
@@ -82,6 +96,11 @@ export class CredentialRegistry {
   /** Check if a specific backend is available */
   isAvailable(name: string): boolean {
     return this.availability.get(name) ?? false;
+  }
+
+  /** Get cached diagnostic reason for a backend (if any) */
+  getDiagnostic(name: string): string | undefined {
+    return this.diagnostics.get(name);
   }
 
   /** Number of registered backends */

--- a/src/credentials/ssh-agent.ts
+++ b/src/credentials/ssh-agent.ts
@@ -4,6 +4,7 @@ import {
   CredentialBackend,
   CredentialResult,
   CredentialMetadata,
+  HealthCheckResult,
 } from "./backend.js";
 
 const execFileAsync = promisify(execFile);
@@ -26,23 +27,31 @@ export class SshAgentBackend implements CredentialBackend {
   private static readonly WINDOWS_PIPE = "\\\\.\\pipe\\openssh-ssh-agent";
 
   async isAvailable(): Promise<boolean> {
-    // Check SSH_AUTH_SOCK is set (or Windows named pipe exists)
-    const sock = this.getAgentSocket();
-    if (!sock) return false;
+    const health = await this.checkHealth();
+    return health.available;
+  }
 
-    // Probe the agent with ssh-add -l to verify it is reachable and has keys
+  async checkHealth(): Promise<HealthCheckResult> {
+    const sock = this.getAgentSocket();
+    if (!sock) {
+      return { available: false, reason: 'SSH_AUTH_SOCK is not set and no agent socket found' };
+    }
+
     try {
       const { stdout } = await execFileAsync("ssh-add", ["-l"], {
         timeout: 5000,
         env: { ...process.env, SSH_AUTH_SOCK: sock },
       });
-      // ssh-add -l exits 0 when identities are present
-      // Output contains lines like: "2048 SHA256:... comment (RSA)"
-      return stdout.trim().length > 0;
-    } catch {
-      // Exit code 1 = agent reachable but no identities
-      // Exit code 2 = agent not reachable
-      return false;
+      if (stdout.trim().length > 0) {
+        return { available: true };
+      }
+      return { available: false, reason: 'ssh-agent is running but has no identities loaded — run \'ssh-add\' to add keys' };
+    } catch (err: unknown) {
+      const exitCode = (err as { code?: number }).code;
+      if (exitCode === 1) {
+        return { available: false, reason: 'ssh-agent is running but has no identities loaded — run \'ssh-add\' to add keys' };
+      }
+      return { available: false, reason: 'ssh-agent is not reachable — is the agent daemon running?' };
     }
   }
 

--- a/src/tools/credential-diagnose.ts
+++ b/src/tools/credential-diagnose.ts
@@ -21,6 +21,7 @@ export interface CredentialDiagnoseResult {
   } | null;
   matched_rule_index: number | null;
   backend_available: boolean;
+  backend_diagnostic?: string;
 }
 
 export async function credentialDiagnose(
@@ -43,14 +44,17 @@ export async function credentialDiagnose(
   }
 
   let backendAvailable = false;
+  let backendDiagnostic: string | undefined;
   try {
     const backend = registry.getBackend(resolved.backend);
-    backendAvailable = await backend.isAvailable();
+    const health = await backend.checkHealth();
+    backendAvailable = health.available;
+    backendDiagnostic = health.reason;
   } catch {
     // backend not found or unavailable
   }
 
-  return {
+  const result: CredentialDiagnoseResult = {
     host,
     matched_rule: {
       match: resolved.matched_rule.match,
@@ -62,4 +66,6 @@ export async function credentialDiagnose(
     matched_rule_index: resolved.matched_rule_index ?? null,
     backend_available: backendAvailable,
   };
+  if (backendDiagnostic) result.backend_diagnostic = backendDiagnostic;
+  return result;
 }

--- a/src/tools/ssh-execute.ts
+++ b/src/tools/ssh-execute.ts
@@ -75,8 +75,9 @@ export async function sshExecute(
     try {
       const available = await backend.isAvailable();
       if (!available) {
-        process.stderr.write(`Credential backend "${backendName}" unavailable in ssh_execute\n`);
-        throw new Error(`Credential backend "${backendName}" failed. Check server logs for details.`);
+        const health = await backend.checkHealth();
+        const diagnostic = health.reason ?? 'unknown reason';
+        throw new Error(`Credential backend "${backendName}" is not available: ${diagnostic}`);
       }
       const cred = await backend.getCredential(credential_ref);
       resolvedUsername = cred.username || resolvedUsername;

--- a/test/unit/azure-keyvault-backend.test.ts
+++ b/test/unit/azure-keyvault-backend.test.ts
@@ -77,6 +77,31 @@ describe("AzureKeyVaultBackend", () => {
     });
   });
 
+  describe("checkHealth", () => {
+    it("should return available when az CLI is authenticated", async () => {
+      mockExecFile(JSON.stringify({ name: "my-sub", state: "Enabled" }));
+      const health = await backend.checkHealth();
+      expect(health.available).toBe(true);
+      expect(health.reason).toBeUndefined();
+    });
+
+    it("should return diagnostic when az CLI not found", async () => {
+      vi.mocked(resolveCliPath).mockImplementation(() => {
+        throw new Error("CLI tool not found: az");
+      });
+      const health = await backend.checkHealth();
+      expect(health.available).toBe(false);
+      expect(health.reason).toBe("Azure CLI (az) not found in PATH");
+    });
+
+    it("should return diagnostic when az not authenticated", async () => {
+      mockExecFileError("Please run az login");
+      const health = await backend.checkHealth();
+      expect(health.available).toBe(false);
+      expect(health.reason).toContain("az login");
+    });
+  });
+
   describe("ref format validation", () => {
     it("should throw on ref without slash", async () => {
       await expect(backend.getCredential("no-slash")).rejects.toThrow(

--- a/test/unit/bitwarden-backend.test.ts
+++ b/test/unit/bitwarden-backend.test.ts
@@ -107,6 +107,38 @@ describe("BitwardenBackend", () => {
     });
   });
 
+  describe("checkHealth", () => {
+    it("should return available with no reason when vault is unlocked", async () => {
+      mockExecFile(JSON.stringify({ status: "unlocked" }));
+      const health = await backend.checkHealth();
+      expect(health.available).toBe(true);
+      expect(health.reason).toBeUndefined();
+    });
+
+    it("should return diagnostic when bw CLI not found", async () => {
+      vi.mocked(resolveCliPath).mockImplementation(() => {
+        throw new Error("CLI tool not found: bw");
+      });
+      const health = await backend.checkHealth();
+      expect(health.available).toBe(false);
+      expect(health.reason).toBe("Bitwarden CLI (bw) not found in PATH");
+    });
+
+    it("should return diagnostic when vault is locked", async () => {
+      mockExecFile(JSON.stringify({ status: "locked" }));
+      const health = await backend.checkHealth();
+      expect(health.available).toBe(false);
+      expect(health.reason).toContain("locked");
+    });
+
+    it("should return diagnostic when status check fails", async () => {
+      mockExecFileError("Connection refused");
+      const health = await backend.checkHealth();
+      expect(health.available).toBe(false);
+      expect(health.reason).toContain("status check failed");
+    });
+  });
+
   describe("getCredential", () => {
     it("should return username and password Buffer from BW item", async () => {
       const bwItem = {

--- a/test/unit/env-backend.test.ts
+++ b/test/unit/env-backend.test.ts
@@ -38,6 +38,14 @@ describe("EnvCredentialBackend", () => {
     });
   });
 
+  describe("checkHealth", () => {
+    it("should return available: true with no reason", async () => {
+      const health = await backend.checkHealth();
+      expect(health.available).toBe(true);
+      expect(health.reason).toBeUndefined();
+    });
+  });
+
   describe("getCredential", () => {
     it("should return username and password from env vars", async () => {
       const result = await backend.getCredential("TEST_USER:TEST_PASS");

--- a/test/unit/google-secret-manager-backend.test.ts
+++ b/test/unit/google-secret-manager-backend.test.ts
@@ -75,6 +75,30 @@ describe('GoogleSecretManagerBackend', () => {
     });
   });
 
+  describe('checkHealth', () => {
+    it('returns available when gcloud is authenticated', async () => {
+      setupMock({ 'auth print-access-token': 'ya29.token' });
+      const health = await backend.checkHealth();
+      expect(health.available).toBe(true);
+      expect(health.reason).toBeUndefined();
+    });
+
+    it('returns diagnostic when gcloud CLI not found', async () => {
+      mockExecFileAsync.mockRejectedValue(new Error('gcloud not found'));
+      const health = await backend.checkHealth();
+      expect(health.available).toBe(false);
+      expect(health.reason).toContain('gcloud CLI not found');
+    });
+
+    it('returns diagnostic when gcloud not authenticated', async () => {
+      // which gcloud succeeds, but auth fails
+      setupMock({ 'auth print-access-token': new Error('not authenticated') });
+      const health = await backend.checkHealth();
+      expect(health.available).toBe(false);
+      expect(health.reason).toContain('gcloud auth login');
+    });
+  });
+
   // ── getCredential - base64 decode ────────────────────────────────────────
 
   describe('getCredential - base64 decode', () => {

--- a/test/unit/registry.test.ts
+++ b/test/unit/registry.test.ts
@@ -4,16 +4,22 @@ import type {
   CredentialBackend,
   CredentialResult,
   CredentialMetadata,
+  HealthCheckResult,
 } from "../../src/credentials/backend.js";
 
 /** Create a mock backend for testing */
 function createMockBackend(
   name: string,
   available: boolean = true,
+  reason?: string,
 ): CredentialBackend {
   return {
     name,
     isAvailable: vi.fn(async () => available),
+    checkHealth: vi.fn(async (): Promise<HealthCheckResult> => {
+      if (available) return { available: true };
+      return { available: false, reason: reason ?? `${name} is not available` };
+    }),
     getCredential: vi.fn(async (): Promise<CredentialResult> => ({
       username: `${name}-user`,
       password: Buffer.from(`${name}-pass`),
@@ -61,20 +67,41 @@ describe("CredentialRegistry", () => {
   describe("discoverAvailability", () => {
     it("should probe all backends and return status", async () => {
       registry.register(createMockBackend("env", true));
-      registry.register(createMockBackend("bitwarden", false));
+      registry.register(createMockBackend("bitwarden", false, "bw CLI not found"));
 
       const results = await registry.discoverAvailability();
       expect(results).toEqual([
         { name: "env", available: true },
-        { name: "bitwarden", available: false },
+        { name: "bitwarden", available: false, reason: "bw CLI not found" },
       ]);
     });
 
-    it("should handle isAvailable() throwing as unavailable", async () => {
+    it("should include reason in status when backend is unavailable", async () => {
+      registry.register(createMockBackend("azure", false, "Azure CLI (az) not found in PATH"));
+
+      const results = await registry.discoverAvailability();
+      expect(results).toHaveLength(1);
+      expect(results[0].available).toBe(false);
+      expect(results[0].reason).toBe("Azure CLI (az) not found in PATH");
+    });
+
+    it("should not include reason when backend is available", async () => {
+      registry.register(createMockBackend("env", true));
+
+      const results = await registry.discoverAvailability();
+      expect(results).toHaveLength(1);
+      expect(results[0].available).toBe(true);
+      expect(results[0].reason).toBeUndefined();
+    });
+
+    it("should handle checkHealth() throwing as unavailable with reason", async () => {
       const broken: CredentialBackend = {
         name: "broken",
         isAvailable: vi.fn(async () => {
           throw new Error("crash");
+        }),
+        checkHealth: vi.fn(async () => {
+          throw new Error("health check exploded");
         }),
         getCredential: vi.fn(),
         getMetadata: vi.fn(),
@@ -83,26 +110,32 @@ describe("CredentialRegistry", () => {
       registry.register(broken);
 
       const results = await registry.discoverAvailability();
-      expect(results).toEqual([{ name: "broken", available: false }]);
+      expect(results).toEqual([
+        { name: "broken", available: false, reason: "Health check threw: health check exploded" },
+      ]);
     });
 
-    it("should cache availability results", async () => {
+    it("should cache availability and diagnostic results", async () => {
       registry.register(createMockBackend("env", true));
+      registry.register(createMockBackend("bw", false, "vault locked"));
       await registry.discoverAvailability();
       expect(registry.isAvailable("env")).toBe(true);
+      expect(registry.isAvailable("bw")).toBe(false);
+      expect(registry.getDiagnostic("env")).toBeUndefined();
+      expect(registry.getDiagnostic("bw")).toBe("vault locked");
     });
   });
 
   describe("listBackends", () => {
     it("should list all registered backends with availability", async () => {
       registry.register(createMockBackend("env", true));
-      registry.register(createMockBackend("bitwarden", false));
+      registry.register(createMockBackend("bitwarden", false, "bw not found"));
       await registry.discoverAvailability();
 
       const list = registry.listBackends();
       expect(list).toEqual([
         { name: "env", available: true },
-        { name: "bitwarden", available: false },
+        { name: "bitwarden", available: false, reason: "bw not found" },
       ]);
     });
 
@@ -186,6 +219,24 @@ describe("CredentialRegistry", () => {
 
       expect(registry.isAvailable("env")).toBe(true);
       expect(registry.isAvailable("bw")).toBe(false);
+    });
+  });
+
+  describe("getDiagnostic", () => {
+    it("should return undefined for unregistered backend", () => {
+      expect(registry.getDiagnostic("ghost")).toBeUndefined();
+    });
+
+    it("should return undefined for available backend", async () => {
+      registry.register(createMockBackend("env", true));
+      await registry.discoverAvailability();
+      expect(registry.getDiagnostic("env")).toBeUndefined();
+    });
+
+    it("should return reason for unavailable backend", async () => {
+      registry.register(createMockBackend("bw", false, "vault is locked"));
+      await registry.discoverAvailability();
+      expect(registry.getDiagnostic("bw")).toBe("vault is locked");
     });
   });
 });

--- a/test/unit/ssh-agent.test.ts
+++ b/test/unit/ssh-agent.test.ts
@@ -109,6 +109,52 @@ describe("SshAgentBackend", () => {
     });
   });
 
+  describe("checkHealth", () => {
+    it("should return available when agent has identities", async () => {
+      process.env.SSH_AUTH_SOCK = "/tmp/ssh-agent.sock";
+      (mockExecFile as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+        stdout: "2048 SHA256:abc123def456 user@host (RSA)\n",
+        stderr: "",
+      });
+
+      const health = await backend.checkHealth();
+      expect(health.available).toBe(true);
+      expect(health.reason).toBeUndefined();
+    });
+
+    it("should return diagnostic when SSH_AUTH_SOCK not set", async () => {
+      delete process.env.SSH_AUTH_SOCK;
+      Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+
+      const health = await backend.checkHealth();
+      expect(health.available).toBe(false);
+      expect(health.reason).toContain("SSH_AUTH_SOCK");
+    });
+
+    it("should return diagnostic when agent has no identities", async () => {
+      process.env.SSH_AUTH_SOCK = "/tmp/ssh-agent.sock";
+      (mockExecFile as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+        stdout: "",
+        stderr: "",
+      });
+
+      const health = await backend.checkHealth();
+      expect(health.available).toBe(false);
+      expect(health.reason).toContain("no identities");
+    });
+
+    it("should return diagnostic when agent is not reachable", async () => {
+      process.env.SSH_AUTH_SOCK = "/tmp/ssh-agent.sock";
+      (mockExecFile as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+        Object.assign(new Error("agent not running"), { code: 2 }),
+      );
+
+      const health = await backend.checkHealth();
+      expect(health.available).toBe(false);
+      expect(health.reason).toContain("not reachable");
+    });
+  });
+
   describe("getCredential", () => {
     it("should return username from ref and empty password Buffer", async () => {
       const result = await backend.getCredential("admin");


### PR DESCRIPTION
Closes #78

## Summary

`credential_list_backends` now tells you **why** a backend is unavailable instead of just `available: false`. `ssh_execute` errors include the diagnostic inline instead of "check server logs".

## Backend diagnostics added

| Backend | Example diagnostic |
|---------|-------------------|
| bitwarden | `CLI (bw) not found in PATH` / `vault is locked` |
| ssh-agent | `SSH_AUTH_SOCK is not set` / `no identities loaded` |
| azure-keyvault | `CLI (az) not found in PATH` / `not authenticated — run 'az login'` |
| google-secret-manager | `gcloud CLI not found` / `not authenticated — run 'gcloud auth login'` |

## Changes
- `src/credentials/backend.ts` — `HealthCheckResult` type + `checkHealth()` added to interface
- 5 backends updated with specific diagnostics
- Registry: `BackendStatus` now includes optional `reason`; `listBackends()` surfaces it
- `src/tools/ssh-execute.ts` — error message now includes diagnostic
- 40+ new test cases, 226 total passing

## Tests
✅ 226 tests pass