### PR TITLE
feat: host key pinning and ssh_host_info recon tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,10 +27,15 @@ import { sshMultiExecute } from './tools/ssh-multi-execute.js';
 import { credentialGet } from './tools/credential-get.js';
 import { credentialListBackends } from './tools/credential-list.js';
 import { sshCheckHost } from './tools/ssh-check.js';
+import { sshHostInfo } from './tools/ssh-host-info.js';
+import { sshHostKeyTrust } from './tools/ssh-host-key-trust.js';
+import { sshHostKeyList } from './tools/ssh-host-key-list.js';
+import { sshHostKeyRemove } from './tools/ssh-host-key-remove.js';
 import { versionCheck } from './tools/version-check.js';
 import { credentialDiagnose } from './tools/credential-diagnose.js';
 import { CredentialRegistry } from './credentials/registry.js';
 import { CredentialMap } from './credentials/credential-map.js';
+import { HostKeyStore } from './security/host-key-store.js';
 import { BitwardenBackend } from './credentials/bitwarden.js';
 import { AzureKeyVaultBackend } from './credentials/azure-keyvault.js';
 import { EnvCredentialBackend } from './credentials/env.js';
@@ -68,6 +73,7 @@ registry.register(new SshAgentBackend());
 
 const sessionStore = new SessionStore();
 const credentialMap = new CredentialMap();
+const hostKeyStore = new HostKeyStore();
 
 // Graceful shutdown: destroy all sessions before exiting
 const shutdown = () => { sessionStore.destroy(); process.exit(0); };
@@ -94,7 +100,7 @@ server.tool(
   },
   async (input) => {
     try {
-      const result = await sshExecute(registry, input, credentialMap);
+      const result = await sshExecute(registry, input, credentialMap, hostKeyStore);
       return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
     } catch (err: unknown) {
       return {
@@ -219,7 +225,7 @@ server.tool(
   },
   async (input) => {
     try {
-      const result = await sshSessionOpen(registry, sessionStore, input, credentialMap);
+      const result = await sshSessionOpen(registry, sessionStore, input, credentialMap, hostKeyStore);
       return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
     } catch (err: unknown) {
       return {
@@ -320,6 +326,92 @@ server.tool(
   async () => {
     try {
       const result = await versionCheck();
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── ssh_host_info ────────────────────────────────────────────────────────────
+server.tool(
+  'ssh_host_info',
+  'Retrieve SSH host information (banner, OS hint, host key fingerprints) without authentication.',
+  {
+    host: z.string().describe('Hostname or IP address to probe'),
+    port: z.number().int().min(1).max(65535).optional().describe('SSH port (default: 22)'),
+    timeout_ms: z.number().int().positive().optional().describe('Timeout in milliseconds (default: 5000)'),
+    use_ssh_config: z.boolean().optional().describe('When true (default), honor ~/.ssh/config. Set false to skip.'),
+  },
+  async (input) => {
+    try {
+      const result = await sshHostInfo(input);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── ssh_host_key_trust ───────────────────────────────────────────────────────
+server.tool(
+  'ssh_host_key_trust',
+  'Pin or re-pin a host key fingerprint. If fingerprint is omitted, fetches live keys from the host.',
+  {
+    host: z.string().describe('Hostname or IP address to trust'),
+    port: z.number().int().min(1).max(65535).optional().describe('SSH port (default: 22)'),
+    fingerprint: z.string().optional().describe('SHA256 fingerprint to pin (e.g. "SHA256:abc..."). If omitted, fetches live keys.'),
+    key_type: z.string().optional().describe('Key type when pinning a specific fingerprint (e.g. "ssh-ed25519")'),
+    use_ssh_config: z.boolean().optional().describe('When true (default), honor ~/.ssh/config. Set false to skip.'),
+  },
+  async (input) => {
+    try {
+      const result = await sshHostKeyTrust(hostKeyStore, input);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── ssh_host_key_list ────────────────────────────────────────────────────────
+server.tool(
+  'ssh_host_key_list',
+  'List all pinned host key fingerprints.',
+  {},
+  async () => {
+    try {
+      const result = sshHostKeyList(hostKeyStore);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }] };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── ssh_host_key_remove ──────────────────────────────────────────────────────
+server.tool(
+  'ssh_host_key_remove',
+  'Remove a pinned host key, forgetting a previously trusted host.',
+  {
+    host: z.string().describe('Hostname or IP address to remove'),
+    port: z.number().int().min(1).max(65535).optional().describe('SSH port (default: 22)'),
+  },
+  async (input) => {
+    try {
+      const result = sshHostKeyRemove(hostKeyStore, input);
       return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
     } catch (err: unknown) {
       return {

--- a/src/security/host-key-scanner.ts
+++ b/src/security/host-key-scanner.ts
@@ -1,0 +1,138 @@
+/**
+ * SSH host key scanning utility — wraps ssh-keyscan + ssh-keygen to retrieve
+ * host key fingerprints without authentication.
+ */
+
+import { execFile, spawn } from 'child_process';
+import { promisify } from 'util';
+import { resolveCliPath } from '../utils/cli-resolver.js';
+import type { StoredFingerprint } from '../security/host-key-store.js';
+
+const execFileAsync = promisify(execFile);
+
+/** Raw key line from ssh-keyscan output (one per algorithm). */
+interface KeyScanLine {
+  host: string;
+  type: string;
+  public_key: string;
+}
+
+/**
+ * Parse ssh-keyscan stdout into structured key lines.
+ * Each non-comment line looks like: `hostname ssh-ed25519 AAAAC3Nza...`
+ */
+export function parseKeyscanOutput(stdout: string): KeyScanLine[] {
+  const lines: KeyScanLine[] = [];
+  for (const raw of stdout.split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const parts = line.split(/\s+/);
+    if (parts.length >= 3) {
+      lines.push({ host: parts[0], type: parts[1], public_key: parts[2] });
+    }
+  }
+  return lines;
+}
+
+/**
+ * Compute SHA-256 fingerprint of a single key line using ssh-keygen.
+ * Input is a full ssh-keyscan line: `host type base64key`
+ */
+async function fingerprintKeyLine(
+  sshKeygenBin: string,
+  keyLine: string,
+): Promise<string | null> {
+  return new Promise((resolve) => {
+    const proc = spawn(sshKeygenBin, ['-lf', '-'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000,
+    });
+
+    let stdout = '';
+    proc.stdout.on('data', (d: Buffer) => { stdout += d.toString(); });
+    proc.on('error', () => resolve(null));
+    proc.on('close', (code) => {
+      if (code !== 0) { resolve(null); return; }
+      // Output: "256 SHA256:abc... host (ED25519)"
+      const match = stdout.match(/SHA256:\S+/);
+      resolve(match ? match[0] : null);
+    });
+
+    proc.stdin.write(keyLine + '\n');
+    proc.stdin.end();
+  });
+}
+
+export interface ScanHostKeysOptions {
+  host: string;
+  port?: number;
+  timeoutSeconds?: number;
+}
+
+/**
+ * Scan a remote host for SSH host keys and return fingerprints.
+ * Does NOT require authentication — uses ssh-keyscan.
+ */
+export async function scanHostKeys(
+  opts: ScanHostKeysOptions,
+): Promise<StoredFingerprint[]> {
+  const { host, port = 22, timeoutSeconds = 5 } = opts;
+
+  const sshKeyscanBin = resolveCliPath('ssh-keyscan');
+  const sshKeygenBin = resolveCliPath('ssh-keygen');
+
+  const args = [
+    '-T', String(timeoutSeconds),
+    '-p', String(port),
+    '-t', 'ed25519,rsa,ecdsa',
+    '--',
+    host,
+  ];
+
+  const { stdout } = await execFileAsync(sshKeyscanBin, args, {
+    timeout: (timeoutSeconds + 2) * 1000,
+  });
+
+  const keyLines = parseKeyscanOutput(stdout);
+  const fingerprints: StoredFingerprint[] = [];
+
+  for (const kl of keyLines) {
+    const fullLine = `${kl.host} ${kl.type} ${kl.public_key}`;
+    const sha256 = await fingerprintKeyLine(sshKeygenBin, fullLine);
+    if (sha256) {
+      fingerprints.push({
+        type: kl.type,
+        sha256,
+        public_key: kl.public_key,
+      });
+    }
+  }
+
+  return fingerprints;
+}
+
+/**
+ * Detect OS family from an SSH banner string.
+ */
+export function detectOsHint(banner: string | undefined): string | null {
+  if (!banner) return null;
+  const lower = banner.toLowerCase();
+
+  if (lower.includes('ubuntu')) return 'Ubuntu';
+  if (lower.includes('debian')) return 'Debian';
+  if (lower.includes('redhat') || lower.includes('red hat')) return 'RedHat';
+  if (lower.includes('centos')) return 'CentOS';
+  if (lower.includes('fedora')) return 'Fedora';
+  if (lower.includes('freebsd')) return 'FreeBSD';
+  if (lower.includes('openbsd')) return 'OpenBSD';
+  if (lower.includes('windows')) return 'Windows';
+  if (lower.includes('cisco')) return 'Cisco';
+  if (lower.includes('junos')) return 'Juniper';
+  if (lower.includes('sonic')) return 'SONiC';
+  if (lower.includes('cumulus')) return 'Cumulus';
+  if (lower.includes('arista')) return 'Arista';
+  if (lower.includes('openssh')) return 'Linux/Unix';
+  if (lower.includes('dropbear')) return 'Embedded/Linux';
+
+  return null;
+}

--- a/src/security/host-key-store.ts
+++ b/src/security/host-key-store.ts
@@ -1,0 +1,156 @@
+/**
+ * Host key pin store — persists SSH host key fingerprints to
+ * ~/.ai-ssh-toolkit/known-keys.json for TOFU (Trust On First Use) pinning.
+ *
+ * On first connection the host keys are recorded.  On subsequent connections
+ * they are compared and a mismatch causes the connection to be refused.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync, renameSync } from 'fs';
+import { homedir } from 'os';
+import { join, dirname } from 'path';
+import { randomBytes } from 'crypto';
+
+// ── Public types ────────────────────────────────────────────────────────────
+
+export interface StoredFingerprint {
+  type: string;       // e.g. "ssh-ed25519", "ssh-rsa", "ecdsa-sha2-nistp256"
+  sha256: string;     // e.g. "SHA256:abc..."
+  public_key?: string; // base64-encoded raw key (allows known_hosts reconstruction)
+}
+
+export interface StoredHostEntry {
+  fingerprints: StoredFingerprint[];
+  first_seen: string;  // ISO-8601
+  last_seen: string;   // ISO-8601
+}
+
+export type VerifyResult = 'new' | 'match' | 'mismatch';
+
+export interface VerifyDetail {
+  result: VerifyResult;
+  expected?: StoredFingerprint[];
+  got?: StoredFingerprint[];
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Build a canonical store key in OpenSSH bracket notation. */
+export function hostKey(host: string, port: number = 22): string {
+  if (port === 22) return host;
+  return `[${host}]:${port}`;
+}
+
+// ── HostKeyStore ────────────────────────────────────────────────────────────
+
+export class HostKeyStore {
+  private data: Record<string, StoredHostEntry> = {};
+  private readonly filePath: string;
+
+  constructor(filePath?: string) {
+    this.filePath = filePath ?? join(homedir(), '.ai-ssh-toolkit', 'known-keys.json');
+    this.load();
+  }
+
+  /** (Re-)load from disk.  Missing / corrupt file → empty store. */
+  load(): void {
+    if (!existsSync(this.filePath)) {
+      this.data = {};
+      return;
+    }
+    try {
+      const raw = readFileSync(this.filePath, 'utf-8');
+      const parsed = JSON.parse(raw);
+      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+        this.data = parsed as Record<string, StoredHostEntry>;
+      } else {
+        this.data = {};
+      }
+    } catch {
+      this.data = {};
+    }
+  }
+
+  /** Atomically persist the store to disk. */
+  save(): void {
+    const dir = dirname(this.filePath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true, mode: 0o700 });
+    }
+    const tmp = this.filePath + '.' + randomBytes(6).toString('hex') + '.tmp';
+    writeFileSync(tmp, JSON.stringify(this.data, null, 2) + '\n', {
+      encoding: 'utf-8',
+      mode: 0o600,
+    });
+    renameSync(tmp, this.filePath);
+  }
+
+  /** Pin fingerprints for a host (overwrites any existing entry). */
+  pin(host: string, port: number, fingerprints: StoredFingerprint[]): void {
+    const key = hostKey(host, port);
+    const now = new Date().toISOString();
+    const existing = this.data[key];
+    this.data[key] = {
+      fingerprints,
+      first_seen: existing?.first_seen ?? now,
+      last_seen: now,
+    };
+    this.save();
+  }
+
+  /** Look up stored entry for a host. */
+  lookup(host: string, port: number = 22): StoredHostEntry | undefined {
+    return this.data[hostKey(host, port)];
+  }
+
+  /** Verify live fingerprints against stored pins. */
+  verify(host: string, port: number, liveFingerprints: StoredFingerprint[]): VerifyDetail {
+    const entry = this.lookup(host, port);
+    if (!entry) {
+      return { result: 'new', got: liveFingerprints };
+    }
+
+    // Build sets of sha256 values for comparison.
+    // A match requires at least one overlapping key type+fingerprint.
+    const storedSet = new Set(entry.fingerprints.map(f => `${f.type}:${f.sha256}`));
+    const liveSet = new Set(liveFingerprints.map(f => `${f.type}:${f.sha256}`));
+
+    // Check if any live fingerprint matches a stored one
+    for (const fp of liveSet) {
+      if (storedSet.has(fp)) {
+        // Update last_seen
+        const key = hostKey(host, port);
+        this.data[key].last_seen = new Date().toISOString();
+        this.save();
+        return { result: 'match', expected: entry.fingerprints, got: liveFingerprints };
+      }
+    }
+
+    return {
+      result: 'mismatch',
+      expected: entry.fingerprints,
+      got: liveFingerprints,
+    };
+  }
+
+  /** Remove a host from the store. */
+  remove(host: string, port: number = 22): boolean {
+    const key = hostKey(host, port);
+    if (this.data[key]) {
+      delete this.data[key];
+      this.save();
+      return true;
+    }
+    return false;
+  }
+
+  /** List all pinned hosts. */
+  list(): Record<string, StoredHostEntry> {
+    return { ...this.data };
+  }
+
+  /** Return the file path for diagnostics. */
+  getFilePath(): string {
+    return this.filePath;
+  }
+}

--- a/src/security/host-key-verify.ts
+++ b/src/security/host-key-verify.ts
@@ -1,0 +1,70 @@
+/**
+ * Host key verification helper — used by ssh_execute and ssh_session_open
+ * to enforce TOFU (Trust On First Use) host key pinning before connecting.
+ */
+
+import type { HostKeyStore } from '../security/host-key-store.js';
+import { scanHostKeys } from '../security/host-key-scanner.js';
+
+/**
+ * Verify host key for a connection target.  On first use, pins the key.
+ * On mismatch, throws an error that refuses the connection.
+ *
+ * If scanning fails and no pinned keys exist, the connection proceeds
+ * (we cannot TOFU without keys).  If scanning fails but pinned keys
+ * exist, the connection is refused (fail-closed).
+ */
+export async function verifyHostKey(
+  store: HostKeyStore,
+  host: string,
+  port: number = 22,
+): Promise<void> {
+  let liveFingerprints;
+  try {
+    liveFingerprints = await scanHostKeys({ host, port, timeoutSeconds: 5 });
+  } catch (err) {
+    const existing = store.lookup(host, port);
+    if (existing) {
+      // Fail closed: we have pinned keys but can't verify
+      throw new Error(
+        `Host key verification failed for ${host}:${port}: unable to scan live keys ` +
+        `(${err instanceof Error ? err.message : String(err)}). ` +
+        'Pinned keys exist — refusing connection for safety.',
+      );
+    }
+    // No pinned keys and can't scan → skip verification (first-use scenario
+    // where keyscan binary is unavailable or host doesn't respond to keyscan)
+    return;
+  }
+
+  if (liveFingerprints.length === 0) {
+    const existing = store.lookup(host, port);
+    if (existing) {
+      throw new Error(
+        `Host key verification failed for ${host}:${port}: ssh-keyscan returned no keys. ` +
+        'Pinned keys exist — refusing connection for safety.',
+      );
+    }
+    return;
+  }
+
+  const detail = store.verify(host, port, liveFingerprints);
+
+  switch (detail.result) {
+    case 'new':
+      // TOFU: pin on first use
+      store.pin(host, port, liveFingerprints);
+      break;
+    case 'match':
+      // All good
+      break;
+    case 'mismatch': {
+      const expected = detail.expected?.map(f => `${f.type} ${f.sha256}`).join(', ') ?? 'unknown';
+      const got = detail.got?.map(f => `${f.type} ${f.sha256}`).join(', ') ?? 'unknown';
+      throw new Error(
+        `Host key mismatch for ${host}:${port}: expected [${expected}], got [${got}]. ` +
+        'Use ssh_host_key_trust to re-pin.',
+      );
+    }
+  }
+}

--- a/src/security/host-key-verify.ts
+++ b/src/security/host-key-verify.ts
@@ -30,6 +30,7 @@ export async function verifyHostKey(
         `Host key verification failed for ${host}:${port}: unable to scan live keys ` +
         `(${err instanceof Error ? err.message : String(err)}). ` +
         'Pinned keys exist — refusing connection for safety.',
+        { cause: err },
       );
     }
     // No pinned keys and can't scan → skip verification (first-use scenario

--- a/src/tools/ssh-execute.ts
+++ b/src/tools/ssh-execute.ts
@@ -6,6 +6,8 @@ import type { PlatformHint } from '../ssh/prompt-detector.js';
 import type { CredentialRegistry } from '../credentials/registry.js';
 import { runSshSession } from '../ssh/pty-manager.js';
 import type { CredentialMap } from '../credentials/credential-map.js';
+import type { HostKeyStore } from '../security/host-key-store.js';
+import { verifyHostKey } from '../security/host-key-verify.js';
 
 export interface SshExecuteInput {
   host: string;
@@ -33,6 +35,7 @@ export async function sshExecute(
   registry: CredentialRegistry,
   input: SshExecuteInput,
   credentialMap: CredentialMap,
+  hostKeyStore?: HostKeyStore,
 ): Promise<SshExecuteResult> {
   let {
     credential_ref,
@@ -95,6 +98,11 @@ export async function sshExecute(
   // Don't throw here when resolvedUsername is empty — pty-manager will attempt
   // ssh config resolution first (if use_ssh_config is enabled) and throw with
   // a better error message if username resolution still fails.
+
+  // Host key verification (TOFU)
+  if (hostKeyStore) {
+    await verifyHostKey(hostKeyStore, host);
+  }
 
   // Run the PTY session
   try {

--- a/src/tools/ssh-host-info.ts
+++ b/src/tools/ssh-host-info.ts
@@ -1,0 +1,76 @@
+/**
+ * ssh_host_info tool handler — reconnaissance tool that retrieves SSH host
+ * information (banner, OS hint, host key fingerprints) without authentication.
+ */
+
+import { tcpBannerProbe } from './ssh-check.js';
+import { scanHostKeys, detectOsHint } from '../security/host-key-scanner.js';
+import { resolveSshConfig } from '../ssh/ssh-config-reader.js';
+import type { StoredFingerprint } from '../security/host-key-store.js';
+
+export interface SshHostInfoInput {
+  host: string;
+  port?: number;
+  timeout_ms?: number;
+  use_ssh_config?: boolean;
+}
+
+export interface SshHostInfoResult {
+  host: string;
+  port: number;
+  banner: string | null;
+  os_hint: string | null;
+  fingerprints: StoredFingerprint[];
+  keyscan_error?: string;
+  banner_error?: string;
+}
+
+export async function sshHostInfo(
+  input: SshHostInfoInput,
+): Promise<SshHostInfoResult> {
+  const { host, timeout_ms = 5000, use_ssh_config = true } = input;
+  let { port } = input;
+
+  if (!host) throw new Error('host is required');
+
+  // Resolve SSH config for the alias
+  if (use_ssh_config) {
+    const cfg = await resolveSshConfig(host);
+    if (cfg) {
+      port ??= cfg.port !== 22 ? cfg.port : undefined;
+    }
+  }
+
+  const resolvedPort = port ?? 22;
+  const timeoutSec = Math.max(1, Math.ceil(timeout_ms / 1000));
+
+  // Run banner probe and keyscan in parallel
+  const [bannerResult, keyscanResult] = await Promise.allSettled([
+    tcpBannerProbe(host, resolvedPort, timeout_ms, true),
+    scanHostKeys({ host, port: resolvedPort, timeoutSeconds: timeoutSec }),
+  ]);
+
+  const banner = bannerResult.status === 'fulfilled'
+    ? bannerResult.value.banner ?? null
+    : null;
+  const bannerError = bannerResult.status === 'rejected'
+    ? String((bannerResult.reason as Error).message ?? bannerResult.reason)
+    : undefined;
+
+  const fingerprints = keyscanResult.status === 'fulfilled'
+    ? keyscanResult.value
+    : [];
+  const keyscanError = keyscanResult.status === 'rejected'
+    ? String((keyscanResult.reason as Error).message ?? keyscanResult.reason)
+    : undefined;
+
+  return {
+    host,
+    port: resolvedPort,
+    banner,
+    os_hint: detectOsHint(banner ?? undefined),
+    fingerprints,
+    ...(keyscanError ? { keyscan_error: keyscanError } : {}),
+    ...(bannerError ? { banner_error: bannerError } : {}),
+  };
+}

--- a/src/tools/ssh-host-key-list.ts
+++ b/src/tools/ssh-host-key-list.ts
@@ -1,0 +1,21 @@
+/**
+ * ssh_host_key_list tool — list all pinned host key fingerprints.
+ */
+
+import type { HostKeyStore } from '../security/host-key-store.js';
+
+export interface SshHostKeyListResult {
+  hosts: Record<string, {
+    fingerprints: { type: string; sha256: string }[];
+    first_seen: string;
+    last_seen: string;
+  }>;
+  store_path: string;
+}
+
+export function sshHostKeyList(store: HostKeyStore): SshHostKeyListResult {
+  return {
+    hosts: store.list(),
+    store_path: store.getFilePath(),
+  };
+}

--- a/src/tools/ssh-host-key-remove.ts
+++ b/src/tools/ssh-host-key-remove.ts
@@ -1,0 +1,37 @@
+/**
+ * ssh_host_key_remove tool — forget a pinned host key.
+ */
+
+import type { HostKeyStore } from '../security/host-key-store.js';
+
+export interface SshHostKeyRemoveInput {
+  host: string;
+  port?: number;
+}
+
+export interface SshHostKeyRemoveResult {
+  host: string;
+  port: number;
+  removed: boolean;
+  message: string;
+}
+
+export function sshHostKeyRemove(
+  store: HostKeyStore,
+  input: SshHostKeyRemoveInput,
+): SshHostKeyRemoveResult {
+  const { host, port = 22 } = input;
+
+  if (!host) throw new Error('host is required');
+
+  const removed = store.remove(host, port);
+
+  return {
+    host,
+    port,
+    removed,
+    message: removed
+      ? `Host key for ${host}:${port} removed`
+      : `No pinned key found for ${host}:${port}`,
+  };
+}

--- a/src/tools/ssh-host-key-trust.ts
+++ b/src/tools/ssh-host-key-trust.ts
@@ -1,0 +1,72 @@
+/**
+ * ssh_host_key_trust tool — pin or re-pin a host key fingerprint.
+ *
+ * If fingerprint is provided, pins that specific fingerprint.
+ * If omitted, fetches live keys from the host via ssh-keyscan.
+ */
+
+import type { HostKeyStore, StoredFingerprint } from '../security/host-key-store.js';
+import { scanHostKeys } from '../security/host-key-scanner.js';
+import { resolveSshConfig } from '../ssh/ssh-config-reader.js';
+
+export interface SshHostKeyTrustInput {
+  host: string;
+  port?: number;
+  fingerprint?: string;
+  key_type?: string;
+  use_ssh_config?: boolean;
+}
+
+export interface SshHostKeyTrustResult {
+  host: string;
+  port: number;
+  pinned: StoredFingerprint[];
+  message: string;
+}
+
+export async function sshHostKeyTrust(
+  store: HostKeyStore,
+  input: SshHostKeyTrustInput,
+): Promise<SshHostKeyTrustResult> {
+  const { host, fingerprint, key_type, use_ssh_config = true } = input;
+  let { port } = input;
+
+  if (!host) throw new Error('host is required');
+
+  if (use_ssh_config) {
+    const cfg = await resolveSshConfig(host);
+    if (cfg) {
+      port ??= cfg.port !== 22 ? cfg.port : undefined;
+    }
+  }
+
+  const resolvedPort = port ?? 22;
+
+  let fingerprints: StoredFingerprint[];
+
+  if (fingerprint) {
+    // Pin a specific fingerprint provided by the user
+    const normalizedSha256 = fingerprint.startsWith('SHA256:')
+      ? fingerprint
+      : `SHA256:${fingerprint}`;
+    fingerprints = [{
+      type: key_type ?? 'unknown',
+      sha256: normalizedSha256,
+    }];
+  } else {
+    // Fetch live keys
+    fingerprints = await scanHostKeys({ host, port: resolvedPort });
+    if (fingerprints.length === 0) {
+      throw new Error(`No host keys retrieved from ${host}:${resolvedPort}. Is the host reachable?`);
+    }
+  }
+
+  store.pin(host, resolvedPort, fingerprints);
+
+  return {
+    host,
+    port: resolvedPort,
+    pinned: fingerprints,
+    message: `Host key(s) pinned for ${host}:${resolvedPort}`,
+  };
+}

--- a/src/tools/ssh-session-open.ts
+++ b/src/tools/ssh-session-open.ts
@@ -13,6 +13,8 @@ import { detectPasswordPrompt, detectPrompt } from '../ssh/prompt-detector.js';
 import { SSH_PTY_OPTIONS } from '../ssh/pty-options.js';
 import { resolveSshConfig } from '../ssh/ssh-config-reader.js';
 import type { CredentialMap } from '../credentials/credential-map.js';
+import type { HostKeyStore } from '../security/host-key-store.js';
+import { verifyHostKey } from '../security/host-key-verify.js';
 
 export interface SshSessionOpenInput {
   host: string;
@@ -43,6 +45,7 @@ export async function sshSessionOpen(
   sessionStore: SessionStore,
   input: SshSessionOpenInput,
   credentialMap: CredentialMap,
+  hostKeyStore?: HostKeyStore,
 ): Promise<SshSessionOpenResult> {
   const {
     host,
@@ -112,6 +115,11 @@ export async function sshSessionOpen(
       'username is required. Provide username, a credential_ref with a username, ' +
       'or add a User directive to ~/.ssh/config for this host.',
     );
+  }
+
+  // ── Host key verification (TOFU) ──────────────────────────────────────────
+  if (hostKeyStore) {
+    await verifyHostKey(hostKeyStore, host, resolvedPort ?? 22);
   }
 
   // ── Dynamic import (allows mocking in tests) ─────────────────────────────

--- a/test/unit/host-key-scanner.test.ts
+++ b/test/unit/host-key-scanner.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { parseKeyscanOutput, detectOsHint } from '../../src/security/host-key-scanner.js';
 
 // ── parseKeyscanOutput ──────────────────────────────────────────────────────

--- a/test/unit/host-key-scanner.test.ts
+++ b/test/unit/host-key-scanner.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { parseKeyscanOutput, detectOsHint } from '../../src/security/host-key-scanner.js';
+
+// ── parseKeyscanOutput ──────────────────────────────────────────────────────
+
+describe('parseKeyscanOutput', () => {
+  it('parses typical ssh-keyscan output', () => {
+    const stdout = [
+      '# example.com:22 SSH-2.0-OpenSSH_8.9',
+      'example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFakeKey1',
+      'example.com ssh-rsa AAAAB3NzaC1yc2EAAAAFakeKey2',
+      '',
+    ].join('\n');
+
+    const lines = parseKeyscanOutput(stdout);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toEqual({
+      host: 'example.com',
+      type: 'ssh-ed25519',
+      public_key: 'AAAAC3NzaC1lZDI1NTE5AAAAIFakeKey1',
+    });
+    expect(lines[1]).toEqual({
+      host: 'example.com',
+      type: 'ssh-rsa',
+      public_key: 'AAAAB3NzaC1yc2EAAAAFakeKey2',
+    });
+  });
+
+  it('skips comment lines', () => {
+    const stdout = '# comment\n# another comment\n';
+    expect(parseKeyscanOutput(stdout)).toHaveLength(0);
+  });
+
+  it('handles empty output', () => {
+    expect(parseKeyscanOutput('')).toHaveLength(0);
+  });
+
+  it('handles bracket-notation hosts', () => {
+    const stdout = '[example.com]:2222 ssh-ed25519 AAAAC3NzKey\n';
+    const lines = parseKeyscanOutput(stdout);
+    expect(lines).toHaveLength(1);
+    expect(lines[0].host).toBe('[example.com]:2222');
+  });
+});
+
+// ── detectOsHint ────────────────────────────────────────────────────────────
+
+describe('detectOsHint', () => {
+  it('detects Ubuntu', () => {
+    expect(detectOsHint('SSH-2.0-OpenSSH_8.9p1 Ubuntu-3ubuntu0.6')).toBe('Ubuntu');
+  });
+
+  it('detects Debian', () => {
+    expect(detectOsHint('SSH-2.0-OpenSSH_9.2p1 Debian-2+deb12u3')).toBe('Debian');
+  });
+
+  it('detects generic OpenSSH as Linux/Unix', () => {
+    expect(detectOsHint('SSH-2.0-OpenSSH_9.6')).toBe('Linux/Unix');
+  });
+
+  it('detects Cisco', () => {
+    expect(detectOsHint('SSH-2.0-Cisco-1.25')).toBe('Cisco');
+  });
+
+  it('detects Dropbear as Embedded/Linux', () => {
+    expect(detectOsHint('SSH-2.0-dropbear_2020.81')).toBe('Embedded/Linux');
+  });
+
+  it('returns null for undefined', () => {
+    expect(detectOsHint(undefined)).toBeNull();
+  });
+
+  it('returns null for unrecognized banner', () => {
+    expect(detectOsHint('SSH-2.0-libssh_0.9.6')).toBeNull();
+  });
+
+  it('is case insensitive', () => {
+    expect(detectOsHint('SSH-2.0-OPENSSH_9.0 UBUNTU')).toBe('Ubuntu');
+  });
+});

--- a/test/unit/host-key-store.test.ts
+++ b/test/unit/host-key-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
 import { tmpdir } from 'os';
 import {
   HostKeyStore,
@@ -206,9 +206,7 @@ describe('HostKeyStore', () => {
   // ── Corrupt file handling ─────────────────────────────────────────────────
 
   it('handles corrupt JSON file gracefully', () => {
-    const { writeFileSync, mkdirSync } = require('fs');
-    const { dirname } = require('path');
-    mkdirSync(dirname(storePath), { recursive: true });
+        mkdirSync(dirname(storePath), { recursive: true });
     writeFileSync(storePath, 'NOT VALID JSON!!!');
 
     const store = new HostKeyStore(storePath);

--- a/test/unit/host-key-store.test.ts
+++ b/test/unit/host-key-store.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  HostKeyStore,
+  hostKey,
+  type StoredFingerprint,
+} from '../../src/security/host-key-store.js';
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), 'hks-test-'));
+}
+
+function makeFingerprints(n: number = 1): StoredFingerprint[] {
+  const fps: StoredFingerprint[] = [];
+  const types = ['ssh-ed25519', 'ssh-rsa', 'ecdsa-sha2-nistp256'];
+  for (let i = 0; i < n; i++) {
+    fps.push({
+      type: types[i % types.length],
+      sha256: `SHA256:key${i}${Math.random().toString(36).slice(2, 10)}`,
+      public_key: `AAAA${i}`,
+    });
+  }
+  return fps;
+}
+
+describe('hostKey helper', () => {
+  it('returns host for port 22', () => {
+    expect(hostKey('example.com', 22)).toBe('example.com');
+  });
+
+  it('uses bracket notation for non-22 port', () => {
+    expect(hostKey('example.com', 2222)).toBe('[example.com]:2222');
+  });
+
+  it('defaults to port 22', () => {
+    expect(hostKey('example.com')).toBe('example.com');
+  });
+});
+
+describe('HostKeyStore', () => {
+  let tmpDir: string;
+  let storePath: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    storePath = join(tmpDir, 'known-keys.json');
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('starts empty when file does not exist', () => {
+    const store = new HostKeyStore(storePath);
+    expect(store.list()).toEqual({});
+  });
+
+  it('creates directory and file on first pin', () => {
+    const deepPath = join(tmpDir, 'subdir', 'known-keys.json');
+    const store = new HostKeyStore(deepPath);
+    const fps = makeFingerprints(1);
+
+    store.pin('host1.example.com', 22, fps);
+
+    expect(existsSync(deepPath)).toBe(true);
+    const raw = JSON.parse(readFileSync(deepPath, 'utf-8'));
+    expect(raw['host1.example.com']).toBeDefined();
+    expect(raw['host1.example.com'].fingerprints).toHaveLength(1);
+  });
+
+  // ── Pin / Lookup ──────────────────────────────────────────────────────────
+
+  it('pin stores fingerprints and lookup retrieves them', () => {
+    const store = new HostKeyStore(storePath);
+    const fps = makeFingerprints(2);
+
+    store.pin('server.test', 22, fps);
+
+    const entry = store.lookup('server.test', 22);
+    expect(entry).toBeDefined();
+    expect(entry!.fingerprints).toHaveLength(2);
+    expect(entry!.fingerprints[0].sha256).toBe(fps[0].sha256);
+    expect(entry!.first_seen).toBeTruthy();
+    expect(entry!.last_seen).toBeTruthy();
+  });
+
+  it('pin with non-default port stores under bracket key', () => {
+    const store = new HostKeyStore(storePath);
+    const fps = makeFingerprints(1);
+
+    store.pin('server.test', 2222, fps);
+
+    expect(store.lookup('server.test', 22)).toBeUndefined();
+    expect(store.lookup('server.test', 2222)).toBeDefined();
+  });
+
+  // ── Verify ────────────────────────────────────────────────────────────────
+
+  it('verify returns "new" for unknown host', () => {
+    const store = new HostKeyStore(storePath);
+    const fps = makeFingerprints(1);
+
+    const detail = store.verify('unknown.host', 22, fps);
+    expect(detail.result).toBe('new');
+    expect(detail.got).toEqual(fps);
+  });
+
+  it('verify returns "match" when live key matches stored key', () => {
+    const store = new HostKeyStore(storePath);
+    const fps = makeFingerprints(2);
+
+    store.pin('matched.host', 22, fps);
+
+    const detail = store.verify('matched.host', 22, fps);
+    expect(detail.result).toBe('match');
+  });
+
+  it('verify returns "match" when at least one key type overlaps', () => {
+    const store = new HostKeyStore(storePath);
+    const fps = makeFingerprints(2);
+
+    store.pin('partial.host', 22, fps);
+
+    // Only provide one of the two pinned keys
+    const detail = store.verify('partial.host', 22, [fps[0]]);
+    expect(detail.result).toBe('match');
+  });
+
+  it('verify returns "mismatch" when no keys overlap', () => {
+    const store = new HostKeyStore(storePath);
+    const pinned = makeFingerprints(1);
+
+    store.pin('mismatch.host', 22, pinned);
+
+    const different: StoredFingerprint[] = [{
+      type: 'ssh-ed25519',
+      sha256: 'SHA256:DIFFERENT_KEY',
+    }];
+
+    const detail = store.verify('mismatch.host', 22, different);
+    expect(detail.result).toBe('mismatch');
+    expect(detail.expected).toEqual(pinned);
+    expect(detail.got).toEqual(different);
+  });
+
+  // ── Remove ────────────────────────────────────────────────────────────────
+
+  it('remove deletes a pinned host and returns true', () => {
+    const store = new HostKeyStore(storePath);
+    store.pin('removeme.host', 22, makeFingerprints(1));
+
+    expect(store.remove('removeme.host', 22)).toBe(true);
+    expect(store.lookup('removeme.host', 22)).toBeUndefined();
+  });
+
+  it('remove returns false for non-existent host', () => {
+    const store = new HostKeyStore(storePath);
+    expect(store.remove('nope.host', 22)).toBe(false);
+  });
+
+  // ── List ──────────────────────────────────────────────────────────────────
+
+  it('list returns all pinned hosts', () => {
+    const store = new HostKeyStore(storePath);
+    store.pin('a.host', 22, makeFingerprints(1));
+    store.pin('b.host', 2222, makeFingerprints(1));
+
+    const all = store.list();
+    expect(Object.keys(all)).toHaveLength(2);
+    expect(all['a.host']).toBeDefined();
+    expect(all['[b.host]:2222']).toBeDefined();
+  });
+
+  // ── Persistence ───────────────────────────────────────────────────────────
+
+  it('data persists across HostKeyStore instances', () => {
+    const store1 = new HostKeyStore(storePath);
+    const fps = makeFingerprints(1);
+    store1.pin('persist.host', 22, fps);
+
+    const store2 = new HostKeyStore(storePath);
+    const entry = store2.lookup('persist.host', 22);
+    expect(entry).toBeDefined();
+    expect(entry!.fingerprints[0].sha256).toBe(fps[0].sha256);
+  });
+
+  it('re-pin updates last_seen but preserves first_seen', () => {
+    const store = new HostKeyStore(storePath);
+    const fps1 = makeFingerprints(1);
+    store.pin('repin.host', 22, fps1);
+
+    const first = store.lookup('repin.host', 22)!;
+    const firstSeen = first.first_seen;
+
+    // Small delay to ensure different timestamp
+    const fps2 = makeFingerprints(1);
+    store.pin('repin.host', 22, fps2);
+
+    const second = store.lookup('repin.host', 22)!;
+    expect(second.first_seen).toBe(firstSeen);
+    expect(second.fingerprints[0].sha256).toBe(fps2[0].sha256);
+  });
+
+  // ── Corrupt file handling ─────────────────────────────────────────────────
+
+  it('handles corrupt JSON file gracefully', () => {
+    const { writeFileSync, mkdirSync } = require('fs');
+    const { dirname } = require('path');
+    mkdirSync(dirname(storePath), { recursive: true });
+    writeFileSync(storePath, 'NOT VALID JSON!!!');
+
+    const store = new HostKeyStore(storePath);
+    expect(store.list()).toEqual({});
+  });
+});

--- a/test/unit/host-key-tools.test.ts
+++ b/test/unit/host-key-tools.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { HostKeyStore, type StoredFingerprint } from '../../src/security/host-key-store.js';
+import { sshHostKeyTrust } from '../../src/tools/ssh-host-key-trust.js';
+import { sshHostKeyList } from '../../src/tools/ssh-host-key-list.js';
+import { sshHostKeyRemove } from '../../src/tools/ssh-host-key-remove.js';
+
+// Mock SSH config and scanner
+vi.mock('../../src/ssh/ssh-config-reader.js', () => ({
+  resolveSshConfig: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../../src/security/host-key-scanner.js', () => ({
+  scanHostKeys: vi.fn(),
+}));
+
+import { scanHostKeys } from '../../src/security/host-key-scanner.js';
+const mockScanHostKeys = vi.mocked(scanHostKeys);
+
+function makeFingerprints(): StoredFingerprint[] {
+  return [
+    { type: 'ssh-ed25519', sha256: 'SHA256:testkey', public_key: 'AAAA1' },
+  ];
+}
+
+describe('ssh_host_key_trust', () => {
+  let tmpDir: string;
+  let store: HostKeyStore;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tmpDir = mkdtempSync(join(tmpdir(), 'trust-test-'));
+    store = new HostKeyStore(join(tmpDir, 'known-keys.json'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('pins live-fetched keys when fingerprint is omitted', async () => {
+    const fps = makeFingerprints();
+    mockScanHostKeys.mockResolvedValueOnce(fps);
+
+    const result = await sshHostKeyTrust(store, { host: 'trust.host', use_ssh_config: false });
+
+    expect(result.pinned).toHaveLength(1);
+    expect(result.pinned[0].sha256).toBe('SHA256:testkey');
+    expect(store.lookup('trust.host', 22)).toBeDefined();
+  });
+
+  it('pins explicit fingerprint when provided', async () => {
+    const result = await sshHostKeyTrust(store, {
+      host: 'explicit.host',
+      fingerprint: 'SHA256:manualpinned',
+      key_type: 'ssh-rsa',
+      use_ssh_config: false,
+    });
+
+    expect(result.pinned[0].sha256).toBe('SHA256:manualpinned');
+    expect(result.pinned[0].type).toBe('ssh-rsa');
+  });
+
+  it('normalizes fingerprint without SHA256: prefix', async () => {
+    const result = await sshHostKeyTrust(store, {
+      host: 'norm.host',
+      fingerprint: 'barebase64value',
+      use_ssh_config: false,
+    });
+
+    expect(result.pinned[0].sha256).toBe('SHA256:barebase64value');
+  });
+
+  it('re-pins overwrites previous fingerprint', async () => {
+    const fps1 = makeFingerprints();
+    mockScanHostKeys.mockResolvedValueOnce(fps1);
+    await sshHostKeyTrust(store, { host: 'repin.host', use_ssh_config: false });
+
+    const fps2: StoredFingerprint[] = [
+      { type: 'ssh-rsa', sha256: 'SHA256:newkey', public_key: 'BBBB' },
+    ];
+    mockScanHostKeys.mockResolvedValueOnce(fps2);
+    await sshHostKeyTrust(store, { host: 'repin.host', use_ssh_config: false });
+
+    const entry = store.lookup('repin.host', 22);
+    expect(entry!.fingerprints[0].sha256).toBe('SHA256:newkey');
+  });
+
+  it('throws when no keys are retrieved and fingerprint not provided', async () => {
+    mockScanHostKeys.mockResolvedValueOnce([]);
+
+    await expect(
+      sshHostKeyTrust(store, { host: 'empty.host', use_ssh_config: false }),
+    ).rejects.toThrow(/No host keys retrieved/);
+  });
+});
+
+describe('ssh_host_key_list', () => {
+  let tmpDir: string;
+  let store: HostKeyStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'list-test-'));
+    store = new HostKeyStore(join(tmpDir, 'known-keys.json'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns empty hosts when no keys are pinned', () => {
+    const result = sshHostKeyList(store);
+    expect(result.hosts).toEqual({});
+    expect(result.store_path).toContain('known-keys.json');
+  });
+
+  it('returns all pinned hosts', () => {
+    store.pin('a.host', 22, makeFingerprints());
+    store.pin('b.host', 2222, makeFingerprints());
+
+    const result = sshHostKeyList(store);
+    expect(Object.keys(result.hosts)).toHaveLength(2);
+  });
+});
+
+describe('ssh_host_key_remove', () => {
+  let tmpDir: string;
+  let store: HostKeyStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'remove-test-'));
+    store = new HostKeyStore(join(tmpDir, 'known-keys.json'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('removes a pinned host', () => {
+    store.pin('removeme.host', 22, makeFingerprints());
+    const result = sshHostKeyRemove(store, { host: 'removeme.host' });
+
+    expect(result.removed).toBe(true);
+    expect(store.lookup('removeme.host', 22)).toBeUndefined();
+  });
+
+  it('returns removed=false for non-existent host', () => {
+    const result = sshHostKeyRemove(store, { host: 'nope.host' });
+    expect(result.removed).toBe(false);
+  });
+
+  it('removes host on specific port', () => {
+    store.pin('porthost', 2222, makeFingerprints());
+
+    const result = sshHostKeyRemove(store, { host: 'porthost', port: 2222 });
+    expect(result.removed).toBe(true);
+  });
+});

--- a/test/unit/host-key-verify.test.ts
+++ b/test/unit/host-key-verify.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import {
+  HostKeyStore,
+  type StoredFingerprint,
+} from '../../src/security/host-key-store.js';
+import { verifyHostKey } from '../../src/security/host-key-verify.js';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// Mock the scanner so we never run real ssh-keyscan
+vi.mock('../../src/security/host-key-scanner.js', () => ({
+  scanHostKeys: vi.fn(),
+}));
+
+import { scanHostKeys } from '../../src/security/host-key-scanner.js';
+const mockScanHostKeys = vi.mocked(scanHostKeys);
+
+function makeFingerprints(): StoredFingerprint[] {
+  return [
+    { type: 'ssh-ed25519', sha256: 'SHA256:testkey1', public_key: 'AAAA1' },
+  ];
+}
+
+function makeDifferentFingerprints(): StoredFingerprint[] {
+  return [
+    { type: 'ssh-ed25519', sha256: 'SHA256:differentkey', public_key: 'BBBB1' },
+  ];
+}
+
+describe('verifyHostKey', () => {
+  let tmpDir: string;
+  let store: HostKeyStore;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tmpDir = mkdtempSync(join(tmpdir(), 'hkv-test-'));
+    store = new HostKeyStore(join(tmpDir, 'known-keys.json'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('pins on first connect (TOFU)', async () => {
+    const fps = makeFingerprints();
+    mockScanHostKeys.mockResolvedValueOnce(fps);
+
+    await verifyHostKey(store, 'new.host', 22);
+
+    const entry = store.lookup('new.host', 22);
+    expect(entry).toBeDefined();
+    expect(entry!.fingerprints[0].sha256).toBe('SHA256:testkey1');
+  });
+
+  it('allows connection when fingerprint matches', async () => {
+    const fps = makeFingerprints();
+    store.pin('known.host', 22, fps);
+
+    mockScanHostKeys.mockResolvedValueOnce(fps);
+
+    // Should not throw
+    await expect(verifyHostKey(store, 'known.host', 22)).resolves.toBeUndefined();
+  });
+
+  it('rejects connection on fingerprint mismatch', async () => {
+    const pinned = makeFingerprints();
+    store.pin('pinned.host', 22, pinned);
+
+    const different = makeDifferentFingerprints();
+    mockScanHostKeys.mockResolvedValueOnce(different);
+
+    await expect(verifyHostKey(store, 'pinned.host', 22))
+      .rejects
+      .toThrow(/Host key mismatch.*pinned\.host/);
+  });
+
+  it('mismatch error mentions ssh_host_key_trust', async () => {
+    const pinned = makeFingerprints();
+    store.pin('bad.host', 22, pinned);
+
+    mockScanHostKeys.mockResolvedValueOnce(makeDifferentFingerprints());
+
+    await expect(verifyHostKey(store, 'bad.host', 22))
+      .rejects
+      .toThrow(/ssh_host_key_trust/);
+  });
+
+  it('fails closed when scan fails and pinned keys exist', async () => {
+    store.pin('secure.host', 22, makeFingerprints());
+    mockScanHostKeys.mockRejectedValueOnce(new Error('Connection refused'));
+
+    await expect(verifyHostKey(store, 'secure.host', 22))
+      .rejects
+      .toThrow(/unable to scan live keys/);
+  });
+
+  it('skips verification when scan fails and no pinned keys exist', async () => {
+    mockScanHostKeys.mockRejectedValueOnce(new Error('ssh-keyscan not found'));
+
+    // Should not throw — no pinned keys, can't scan, skip
+    await expect(verifyHostKey(store, 'new.host', 22)).resolves.toBeUndefined();
+  });
+
+  it('skips verification when scan returns empty and no pinned keys exist', async () => {
+    mockScanHostKeys.mockResolvedValueOnce([]);
+
+    await expect(verifyHostKey(store, 'new.host', 22)).resolves.toBeUndefined();
+  });
+
+  it('fails closed when scan returns empty but pinned keys exist', async () => {
+    store.pin('existing.host', 22, makeFingerprints());
+    mockScanHostKeys.mockResolvedValueOnce([]);
+
+    await expect(verifyHostKey(store, 'existing.host', 22))
+      .rejects
+      .toThrow(/ssh-keyscan returned no keys/);
+  });
+});
+
+// Need afterEach import
+import { afterEach } from 'vitest';


### PR DESCRIPTION
Closes #94

## Summary

TOFU (Trust On First Use) host key pinning protects against MITM attacks on subsequent connections. Plus a new `ssh_host_info` tool for unauthenticated host reconnaissance.

## 4 new tools

| Tool | Description |
|------|-------------|
| `ssh_host_info` | Banner, OS hint, fingerprints — no auth required |
| `ssh_host_key_trust` | Pin or re-pin a host key |
| `ssh_host_key_list` | List all pinned keys |
| `ssh_host_key_remove` | Forget a host |

## ssh_host_info response
```json
{
  "host": "prod-web-1",
  "port": 22,
  "banner": "SSH-2.0-OpenSSH_8.9p1 Ubuntu-3ubuntu0.6",
  "os_hint": "Ubuntu",
  "fingerprints": [{ "type": "ED25519", "sha256": "SHA256:abc..." }]
}
```

## Pin store
- Persists to `~/.ai-ssh-toolkit/known-keys.json`
- Atomic writes (temp + rename), 0600 permissions
- First connect → auto-pin
- Subsequent connects → verify or **refuse** with clear error:
  `Host key mismatch for prod-web-1: expected SHA256:abc, got SHA256:xyz. Use ssh_host_key_trust to re-pin.`
- Scan failure with existing pins → fail-closed (refuse connection)

## Changes
- `src/security/host-key-store.ts` — pin store + TOFU logic
- `src/tools/ssh-host-info.ts` — recon tool
- `src/tools/ssh-host-key-*.ts` — 3 management tools
- `src/tools/ssh-execute.ts` + `ssh-session-open.ts` — pin/verify integrated
- `src/index.ts` — all 4 tools registered
- 47 new tests across 4 test files

## Tests
✅ 253 tests pass