### PR TITLE
feat: first-class ProxyJump jump_hosts parameter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ server.tool(
       .describe('Platform hint for prompt detection (default: auto)'),
     timeout_ms: z.number().int().positive().optional().describe('Connection + command timeout in milliseconds (default: 30000)'),
     use_ssh_config: z.boolean().optional().describe('When true (default), honor ~/.ssh/config for User, Port, IdentityFile, ProxyJump, etc. Set false to skip.'),
+    jump_hosts: z.array(z.string()).optional().describe('ProxyJump chain: list of bastion/jump hosts, e.g. ["bastion1.example.com","bastion2.internal"]. Translated to ssh -J flag.'),
   },
   async (input) => {
     try {
@@ -186,6 +187,7 @@ server.tool(
     timeout_ms: z.number().int().positive().optional().describe('Connection timeout in milliseconds (default: 5000)'),
     mode: z.enum(['tcp', 'banner', 'auth']).optional().describe("Check mode: 'tcp' (TCP connect only), 'banner' (TCP + SSH banner read, default), 'auth' (full ssh binary auth with BatchMode=yes)"),
     use_ssh_config: z.boolean().optional().describe('When true (default), honor ~/.ssh/config for User, Port, IdentityFile, ProxyJump, etc. Set false to skip.'),
+    jump_hosts: z.array(z.string()).optional().describe('ProxyJump chain: list of bastion/jump hosts. Used in auth mode to route through bastions. Translated to ssh -J flag.'),
   },
   async (input) => {
     try {
@@ -216,6 +218,7 @@ server.tool(
     timeout_ms: z.number().int().positive().optional().describe('Connect + initial prompt timeout in milliseconds (default: 30000)'),
     idle_timeout_ms: z.number().int().positive().optional().describe('Inactivity auto-close timeout in milliseconds (default: 300000)'),
     use_ssh_config: z.boolean().optional().describe('When true (default), honor ~/.ssh/config for User, Port, IdentityFile, ProxyJump, etc. Set false to skip.'),
+    jump_hosts: z.array(z.string()).optional().describe('ProxyJump chain: list of bastion/jump hosts, e.g. ["bastion1.example.com"]. Translated to ssh -J flag.'),
   },
   async (input) => {
     try {

--- a/src/ssh/pty-manager.ts
+++ b/src/ssh/pty-manager.ts
@@ -23,6 +23,8 @@ export interface PtySessionOptions {
   timeout_ms?: number;
   /** SSH port override. When omitted, resolved from ~/.ssh/config or defaults to 22. */
   port?: number;
+  /** ProxyJump chain — translated to `ssh -J host1,host2,...`. */
+  jump_hosts?: string[];
   /**
    * When true (default), resolve ~/.ssh/config for the given host alias using
    * `ssh -G <host>` and apply User, Port, IdentityFile, ProxyJump, etc. as
@@ -93,6 +95,9 @@ export async function runSshSession(opts: PtySessionOptions): Promise<PtySession
   ];
   if (resolvedPort !== undefined && resolvedPort !== 22) {
     sshArgs.push('-p', String(resolvedPort));
+  }
+  if (opts.jump_hosts && opts.jump_hosts.length > 0) {
+    sshArgs.push('-J', opts.jump_hosts.join(','));
   }
   sshArgs.push('--', `${resolvedUsername}@${host}`, command);
 

--- a/src/tools/ssh-check.ts
+++ b/src/tools/ssh-check.ts
@@ -45,6 +45,8 @@ export interface SshCheckInput {
    * Set to false to bypass ssh config lookup entirely.
    */
   use_ssh_config?: boolean;
+  /** ProxyJump chain — translated to `ssh -J host1,host2,...`. */
+  jump_hosts?: string[];
 }
 
 export interface SshCheckResult {
@@ -156,6 +158,7 @@ async function authProbe(
   port: number,
   username: string | undefined,
   timeoutMs: number,
+  jumpHosts?: string[],
 ): Promise<SshCheckResult> {
   const sshBin = await resolveSshBin();
   const timeoutSec = Math.max(1, Math.ceil(timeoutMs / 1000));
@@ -167,10 +170,11 @@ async function authProbe(
     '-o', `ConnectTimeout=${timeoutSec}`,
     '-o', 'StrictHostKeyChecking=accept-new',
     '-p', String(port),
-    '--',
-    target,
-    'exit',
   ];
+  if (jumpHosts && jumpHosts.length > 0) {
+    args.push('-J', jumpHosts.join(','));
+  }
+  args.push('--', target, 'exit');
 
   const start = Date.now();
   try {
@@ -220,6 +224,6 @@ export async function sshCheckHost(
     case 'banner':
       return tcpBannerProbe(host, resolvedPort, timeout_ms, true, socketFactory);
     case 'auth':
-      return authProbe(host, resolvedPort, username, timeout_ms);
+      return authProbe(host, resolvedPort, username, timeout_ms, input.jump_hosts);
   }
 }

--- a/src/tools/ssh-execute.ts
+++ b/src/tools/ssh-execute.ts
@@ -22,6 +22,8 @@ export interface SshExecuteInput {
    * Set to false to bypass ssh config lookup entirely.
    */
   use_ssh_config?: boolean;
+  /** ProxyJump chain — translated to `ssh -J host1,host2,...`. */
+  jump_hosts?: string[];
 }
 
 export interface SshExecuteResult {
@@ -106,6 +108,7 @@ export async function sshExecute(
       platform,
       timeout_ms,
       use_ssh_config: input.use_ssh_config ?? true,
+      jump_hosts: input.jump_hosts,
     });
     return result;
   } finally {

--- a/src/tools/ssh-session-open.ts
+++ b/src/tools/ssh-session-open.ts
@@ -29,6 +29,8 @@ export interface SshSessionOpenInput {
    * Set to false to bypass ssh config lookup entirely.
    */
   use_ssh_config?: boolean;
+  /** ProxyJump chain — translated to `ssh -J host1,host2,...`. */
+  jump_hosts?: string[];
 }
 
 export interface SshSessionOpenResult {
@@ -141,6 +143,9 @@ export async function sshSessionOpen(
   ];
   if (resolvedPort !== undefined && resolvedPort !== 22) {
     sshArgs.push('-p', String(resolvedPort));
+  }
+  if (input.jump_hosts && input.jump_hosts.length > 0) {
+    sshArgs.push('-J', input.jump_hosts.join(','));
   }
   sshArgs.push(`${resolvedUsername}@${host}`);
 

--- a/test/unit/jump-hosts.test.ts
+++ b/test/unit/jump-hosts.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Unit tests for jump_hosts (ProxyJump / -J) support across ssh_execute,
+ * ssh_session_open, and ssh_check_host.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { MockInstance } from 'vitest';
+
+// ── Shared mocks ─────────────────────────────────────────────────────────────
+
+vi.mock('../../src/ssh/ssh-config-reader.js', () => ({
+  resolveSshConfig: vi.fn().mockResolvedValue(null),
+}));
+
+// ── node-pty mock (used by pty-manager and ssh-session-open) ─────────────────
+
+let fakeOnData: ((data: string) => void) | null = null;
+let fakeOnExit: ((ev: { exitCode: number }) => void) | null = null;
+let fakeWrite: MockInstance;
+let fakeKill: MockInstance;
+let spawnMock: MockInstance;
+
+vi.mock('node-pty', () => {
+  fakeWrite = vi.fn();
+  fakeKill = vi.fn();
+  spawnMock = vi.fn(() => ({
+    onData: (cb: (data: string) => void) => {
+      fakeOnData = cb;
+      return { dispose: vi.fn(() => { fakeOnData = null; }) };
+    },
+    onExit: (cb: (ev: { exitCode: number }) => void) => {
+      fakeOnExit = cb;
+      return { dispose: vi.fn(() => { fakeOnExit = null; }) };
+    },
+    write: fakeWrite,
+    kill: fakeKill,
+  }));
+  return { default: { spawn: spawnMock } };
+});
+
+// ── ssh_check_host mocks (cli-resolver + child_process) ──────────────────────
+
+vi.mock('../../src/utils/cli-resolver.js', () => ({
+  resolveSshBin: vi.fn().mockResolvedValue('/usr/bin/ssh'),
+}));
+
+const execFileMock = vi.fn();
+vi.mock('child_process', () => {
+  const customSymbol = Symbol.for('nodejs.util.promisify.custom');
+  const fn = Object.assign(
+    (...args: unknown[]) => execFileMock(...args),
+    { [customSymbol]: (...args: unknown[]) => execFileMock(...args) },
+  );
+  return { execFile: fn };
+});
+
+// ── Imports (after mocks) ────────────────────────────────────────────────────
+
+const { runSshSession } = await import('../../src/ssh/pty-manager.js');
+import { sshSessionOpen } from '../../src/tools/ssh-session-open.js';
+import { sshCheckHost } from '../../src/tools/ssh-check.js';
+import { SessionStore } from '../../src/ssh/session-store.js';
+import { CredentialMap } from '../../src/credentials/credential-map.js';
+import type { CredentialRegistry } from '../../src/credentials/registry.js';
+
+function makeRegistry(): CredentialRegistry {
+  return {
+    getBackend: vi.fn().mockReturnValue({
+      isAvailable: vi.fn().mockResolvedValue(true),
+      getCredential: vi.fn().mockResolvedValue({
+        username: 'testuser',
+        password: Buffer.from('testpass'),
+      }),
+      cleanup: vi.fn().mockResolvedValue(undefined),
+    }),
+    register: vi.fn(),
+  } as unknown as CredentialRegistry;
+}
+
+const credentialMap = new CredentialMap('/dev/null/nonexistent');
+
+beforeEach(() => {
+  fakeOnData = null;
+  fakeOnExit = null;
+  vi.clearAllMocks();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// pty-manager (ssh_execute path)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('pty-manager jump_hosts', () => {
+  it('single jump host adds -J flag', async () => {
+    const promise = runSshSession({
+      host: 'target.example.com',
+      username: 'user',
+      command: 'echo hi',
+      jump_hosts: ['bastion.example.com'],
+      timeout_ms: 5000,
+    });
+    await new Promise(r => setTimeout(r, 20));
+    fakeOnData!('user@target:~$ ');
+    fakeOnExit!({ exitCode: 0 });
+    await promise;
+
+    const args: string[] = spawnMock.mock.calls[0][1];
+    expect(args).toContain('-J');
+    expect(args[args.indexOf('-J') + 1]).toBe('bastion.example.com');
+  });
+
+  it('chained jump hosts are comma-separated', async () => {
+    const promise = runSshSession({
+      host: 'target.internal',
+      username: 'user',
+      command: 'hostname',
+      jump_hosts: ['bastion1.example.com', 'bastion2.internal'],
+      timeout_ms: 5000,
+    });
+    await new Promise(r => setTimeout(r, 20));
+    fakeOnData!('user@target:~$ ');
+    fakeOnExit!({ exitCode: 0 });
+    await promise;
+
+    const args: string[] = spawnMock.mock.calls[0][1];
+    expect(args).toContain('-J');
+    expect(args[args.indexOf('-J') + 1]).toBe('bastion1.example.com,bastion2.internal');
+  });
+
+  it('no jump_hosts does not add -J flag (existing behavior)', async () => {
+    const promise = runSshSession({
+      host: 'target.example.com',
+      username: 'user',
+      command: 'ls',
+      timeout_ms: 5000,
+    });
+    await new Promise(r => setTimeout(r, 20));
+    fakeOnData!('user@target:~$ ');
+    fakeOnExit!({ exitCode: 0 });
+    await promise;
+
+    const args: string[] = spawnMock.mock.calls[0][1];
+    expect(args).not.toContain('-J');
+  });
+
+  it('empty jump_hosts array does not add -J flag', async () => {
+    const promise = runSshSession({
+      host: 'target.example.com',
+      username: 'user',
+      command: 'ls',
+      jump_hosts: [],
+      timeout_ms: 5000,
+    });
+    await new Promise(r => setTimeout(r, 20));
+    fakeOnData!('user@target:~$ ');
+    fakeOnExit!({ exitCode: 0 });
+    await promise;
+
+    const args: string[] = spawnMock.mock.calls[0][1];
+    expect(args).not.toContain('-J');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ssh_session_open
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('ssh_session_open jump_hosts', () => {
+  it('single jump host adds -J flag', async () => {
+    const store = new SessionStore();
+    const promise = sshSessionOpen(makeRegistry(), store, {
+      host: 'target.example.com',
+      username: 'user',
+      jump_hosts: ['bastion.example.com'],
+      timeout_ms: 5000,
+    }, credentialMap);
+    await new Promise(r => setTimeout(r, 20));
+    fakeOnData!('user@target:~$ ');
+    await promise;
+
+    const args: string[] = spawnMock.mock.calls[0][1];
+    expect(args).toContain('-J');
+    expect(args[args.indexOf('-J') + 1]).toBe('bastion.example.com');
+    store.destroy();
+  });
+
+  it('chained jump hosts are comma-separated', async () => {
+    const store = new SessionStore();
+    const promise = sshSessionOpen(makeRegistry(), store, {
+      host: 'target.internal',
+      username: 'user',
+      jump_hosts: ['b1.example.com', 'b2.internal'],
+      timeout_ms: 5000,
+    }, credentialMap);
+    await new Promise(r => setTimeout(r, 20));
+    fakeOnData!('user@target:~$ ');
+    await promise;
+
+    const args: string[] = spawnMock.mock.calls[0][1];
+    expect(args[args.indexOf('-J') + 1]).toBe('b1.example.com,b2.internal');
+    store.destroy();
+  });
+
+  it('no jump_hosts does not add -J flag', async () => {
+    const store = new SessionStore();
+    const promise = sshSessionOpen(makeRegistry(), store, {
+      host: 'target.example.com',
+      username: 'user',
+      timeout_ms: 5000,
+    }, credentialMap);
+    await new Promise(r => setTimeout(r, 20));
+    fakeOnData!('user@target:~$ ');
+    await promise;
+
+    const args: string[] = spawnMock.mock.calls[0][1];
+    expect(args).not.toContain('-J');
+    store.destroy();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ssh_check_host (auth mode only — tcp/banner don't use ssh binary)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('ssh_check_host jump_hosts', () => {
+  it('auth mode: single jump host adds -J to ssh args', async () => {
+    execFileMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    await sshCheckHost(
+      { host: 'target.example.com', mode: 'auth', use_ssh_config: false, jump_hosts: ['bastion.example.com'] },
+      credentialMap,
+    );
+
+    const args: string[] = execFileMock.mock.calls[0][1];
+    expect(args).toContain('-J');
+    expect(args[args.indexOf('-J') + 1]).toBe('bastion.example.com');
+  });
+
+  it('auth mode: chained jump hosts are comma-separated', async () => {
+    execFileMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    await sshCheckHost(
+      { host: 'target.internal', mode: 'auth', use_ssh_config: false, jump_hosts: ['b1.example.com', 'b2.internal'] },
+      credentialMap,
+    );
+
+    const args: string[] = execFileMock.mock.calls[0][1];
+    expect(args[args.indexOf('-J') + 1]).toBe('b1.example.com,b2.internal');
+  });
+
+  it('auth mode: no jump_hosts does not add -J', async () => {
+    execFileMock.mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    await sshCheckHost(
+      { host: 'target.example.com', mode: 'auth', use_ssh_config: false },
+      credentialMap,
+    );
+
+    const args: string[] = execFileMock.mock.calls[0][1];
+    expect(args).not.toContain('-J');
+  });
+});


### PR DESCRIPTION
Closes #84

## Summary

Adds `jump_hosts?: string[]` to `ssh_execute`, `ssh_session_open`, and `ssh_check_host`. No more `~/.ssh/config` workarounds for bastion chains.

## Usage
```json
{
  "host": "prod-db.internal",
  "command": "uptime",
  "jump_hosts": ["bastion1.example.com", "bastion2.internal"]
}
```
Translates to `-J bastion1.example.com,bastion2.internal`.

## Changes
- `src/tools/ssh-execute.ts` + `ssh-session-open.ts` + `ssh-check.ts` — `jump_hosts` param + `-J` arg construction
- `src/index.ts` — MCP schemas updated for all three tools
- `test/unit/jump-hosts.test.ts` — 10 new tests (single host, chained, empty array, backward compat)

## Tests
✅ 216 tests pass