### PR TITLE
feat: auto session reuse and SSH ControlMaster

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import { AzureKeyVaultBackend } from './credentials/azure-keyvault.js';
 import { EnvCredentialBackend } from './credentials/env.js';
 import { GoogleSecretManagerBackend } from './credentials/google-secret-manager.js';
 import { SshAgentBackend } from './credentials/ssh-agent.js';
+import { SessionReuseManager, getSessionReuseTtl } from './ssh/session-reuse.js';
 import { readFileSync } from 'fs';
 
 function getPackageVersion(): string {
@@ -68,6 +69,7 @@ registry.register(new SshAgentBackend());
 
 const sessionStore = new SessionStore();
 const credentialMap = new CredentialMap();
+const reuseManager = new SessionReuseManager(getSessionReuseTtl());
 
 // Graceful shutdown: destroy all sessions before exiting
 const shutdown = () => { sessionStore.destroy(); process.exit(0); };
@@ -91,10 +93,11 @@ server.tool(
       .describe('Platform hint for prompt detection (default: auto)'),
     timeout_ms: z.number().int().positive().optional().describe('Connection + command timeout in milliseconds (default: 30000)'),
     use_ssh_config: z.boolean().optional().describe('When true (default), honor ~/.ssh/config for User, Port, IdentityFile, ProxyJump, etc. Set false to skip.'),
+    reuse_session: z.boolean().optional().describe('When true, reuse an existing SSH ControlMaster connection if available. When false, force a fresh connection. Default follows AI_SSH_SESSION_REUSE_TTL_SECONDS config.'),
   },
   async (input) => {
     try {
-      const result = await sshExecute(registry, input, credentialMap);
+      const result = await sshExecute(registry, input, credentialMap, reuseManager);
       return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
     } catch (err: unknown) {
       return {

--- a/src/ssh/pty-manager.ts
+++ b/src/ssh/pty-manager.ts
@@ -30,6 +30,8 @@ export interface PtySessionOptions {
    * Set to false to skip config lookup entirely.
    */
   use_ssh_config?: boolean;
+  /** Extra SSH CLI args (e.g. ControlMaster options) prepended to the arg list. */
+  extraSshArgs?: string[];
 }
 
 export interface PtySessionResult {
@@ -57,6 +59,7 @@ export async function runSshSession(opts: PtySessionOptions): Promise<PtySession
     platform = 'auto',
     timeout_ms = 30000,
     use_ssh_config = true,
+    extraSshArgs = [],
   } = opts;
 
   // ── SSH config resolution ─────────────────────────────────────────────────
@@ -87,6 +90,7 @@ export async function runSshSession(opts: PtySessionOptions): Promise<PtySession
   // Build SSH args — pass the original host alias so SSH can apply its own
   // config (HostName, IdentityFile, ProxyJump, Ciphers, etc.) naturally.
   const sshArgs: string[] = [
+    ...extraSshArgs,
     '-o', 'StrictHostKeyChecking=accept-new',
     '-o', 'NumberOfPasswordPrompts=1',
     '-o', 'ConnectTimeout=10',

--- a/src/ssh/session-reuse.ts
+++ b/src/ssh/session-reuse.ts
@@ -1,0 +1,89 @@
+/**
+ * SessionReuseManager — tracks SSH connection activity and provides
+ * ControlMaster SSH arguments for transparent connection reuse.
+ *
+ * When enabled, SSH connections to the same (host, username) tuple are
+ * multiplexed over a single TCP connection via OpenSSH ControlMaster.
+ *
+ * Configuration:
+ *   AI_SSH_SESSION_REUSE_TTL_SECONDS — TTL in seconds (default: 60, 0 to disable)
+ */
+
+import os from 'os';
+import path from 'path';
+import fs from 'fs';
+
+/**
+ * Read the session-reuse TTL from the environment.
+ * Returns 60 (seconds) by default, 0 means disabled.
+ */
+export function getSessionReuseTtl(): number {
+  const envVal = process.env.AI_SSH_SESSION_REUSE_TTL_SECONDS;
+  if (envVal !== undefined) {
+    const parsed = parseInt(envVal, 10);
+    if (Number.isFinite(parsed) && parsed >= 0) return parsed;
+  }
+  return 60;
+}
+
+export class SessionReuseManager {
+  private activity = new Map<string, number>();
+
+  constructor(private ttlSeconds: number = 60) {}
+
+  private makeKey(host: string, username: string): string {
+    return `${username}@${host}`;
+  }
+
+  /** Whether session reuse is enabled (TTL > 0). */
+  isEnabled(): boolean {
+    return this.ttlSeconds > 0;
+  }
+
+  /**
+   * Check whether a reusable session exists for this (host, username) combo
+   * that is still within the TTL window.
+   */
+  shouldReuse(host: string, username: string): boolean {
+    if (!this.isEnabled()) return false;
+    const key = this.makeKey(host, username);
+    const lastActivity = this.activity.get(key);
+    if (lastActivity === undefined) return false;
+    return (Date.now() - lastActivity) < this.ttlSeconds * 1000;
+  }
+
+  /** Record a successful connection for TTL tracking. */
+  recordActivity(host: string, username: string): void {
+    const key = this.makeKey(host, username);
+    this.activity.set(key, Date.now());
+  }
+
+  /**
+   * Return the ControlPath directory, creating it if needed.
+   * Uses os.tmpdir()/ai-ssh-toolkit with mode 0o700.
+   */
+  getControlDir(): string {
+    const dir = path.join(os.tmpdir(), 'ai-ssh-toolkit');
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    return dir;
+  }
+
+  /**
+   * Return extra SSH args for ControlMaster multiplexing.
+   * SSH expands %h (host), %p (port), %r (remote user) in ControlPath.
+   */
+  getControlMasterArgs(): string[] {
+    if (!this.isEnabled()) return [];
+    const controlPath = path.join(this.getControlDir(), 'cm-%h-%p-%r');
+    return [
+      '-o', 'ControlMaster=auto',
+      '-o', `ControlPath=${controlPath}`,
+      '-o', `ControlPersist=${this.ttlSeconds}`,
+    ];
+  }
+
+  /** Clear all tracked activity (for testing). */
+  clear(): void {
+    this.activity.clear();
+  }
+}

--- a/src/tools/ssh-execute.ts
+++ b/src/tools/ssh-execute.ts
@@ -6,6 +6,7 @@ import type { PlatformHint } from '../ssh/prompt-detector.js';
 import type { CredentialRegistry } from '../credentials/registry.js';
 import { runSshSession } from '../ssh/pty-manager.js';
 import type { CredentialMap } from '../credentials/credential-map.js';
+import type { SessionReuseManager } from '../ssh/session-reuse.js';
 
 export interface SshExecuteInput {
   host: string;
@@ -22,6 +23,12 @@ export interface SshExecuteInput {
    * Set to false to bypass ssh config lookup entirely.
    */
   use_ssh_config?: boolean;
+  /**
+   * When true, reuse an existing SSH ControlMaster connection if available.
+   * When false, force a fresh connection. When undefined, follows the
+   * AI_SSH_SESSION_REUSE_TTL_SECONDS config (enabled by default).
+   */
+  reuse_session?: boolean;
 }
 
 export interface SshExecuteResult {
@@ -33,6 +40,7 @@ export async function sshExecute(
   registry: CredentialRegistry,
   input: SshExecuteInput,
   credentialMap: CredentialMap,
+  reuseManager?: SessionReuseManager,
 ): Promise<SshExecuteResult> {
   let {
     credential_ref,
@@ -96,6 +104,12 @@ export async function sshExecute(
   // ssh config resolution first (if use_ssh_config is enabled) and throw with
   // a better error message if username resolution still fails.
 
+  // Determine whether to use session reuse (ControlMaster)
+  const useReuse = input.reuse_session ?? (reuseManager?.isEnabled() ?? false);
+  const extraSshArgs = (useReuse && reuseManager)
+    ? reuseManager.getControlMasterArgs()
+    : [];
+
   // Run the PTY session
   try {
     const result = await runSshSession({
@@ -106,7 +120,14 @@ export async function sshExecute(
       platform,
       timeout_ms,
       use_ssh_config: input.use_ssh_config ?? true,
+      extraSshArgs,
     });
+
+    // Record successful connection for future reuse
+    if (useReuse && reuseManager && resolvedUsername) {
+      reuseManager.recordActivity(host, resolvedUsername);
+    }
+
     return result;
   } finally {
     // Zero-fill password buffer after PTY session completes (success or failure)

--- a/test/unit/session-reuse.test.ts
+++ b/test/unit/session-reuse.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Unit tests for session-reuse.ts and the reuse integration in ssh-execute.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
+import os from 'os';
+import path from 'path';
+
+// ── SessionReuseManager unit tests ──────────────────────────────────────────
+
+describe('SessionReuseManager', () => {
+  // Import directly (no mocking needed for unit tests)
+  let SessionReuseManager: typeof import('../../src/ssh/session-reuse.js').SessionReuseManager;
+  let getSessionReuseTtl: typeof import('../../src/ssh/session-reuse.js').getSessionReuseTtl;
+
+  beforeEach(async () => {
+    const mod = await import('../../src/ssh/session-reuse.js');
+    SessionReuseManager = mod.SessionReuseManager;
+    getSessionReuseTtl = mod.getSessionReuseTtl;
+  });
+
+  it('isEnabled returns true when TTL > 0', () => {
+    const mgr = new SessionReuseManager(60);
+    expect(mgr.isEnabled()).toBe(true);
+  });
+
+  it('isEnabled returns false when TTL is 0', () => {
+    const mgr = new SessionReuseManager(0);
+    expect(mgr.isEnabled()).toBe(false);
+  });
+
+  it('shouldReuse returns false when no activity recorded', () => {
+    const mgr = new SessionReuseManager(60);
+    expect(mgr.shouldReuse('host1', 'user1')).toBe(false);
+  });
+
+  it('shouldReuse returns true within TTL after recordActivity', () => {
+    const mgr = new SessionReuseManager(60);
+    mgr.recordActivity('host1', 'user1');
+    expect(mgr.shouldReuse('host1', 'user1')).toBe(true);
+  });
+
+  it('shouldReuse returns false for different host', () => {
+    const mgr = new SessionReuseManager(60);
+    mgr.recordActivity('host1', 'user1');
+    expect(mgr.shouldReuse('host2', 'user1')).toBe(false);
+  });
+
+  it('shouldReuse returns false for different user', () => {
+    const mgr = new SessionReuseManager(60);
+    mgr.recordActivity('host1', 'user1');
+    expect(mgr.shouldReuse('host1', 'user2')).toBe(false);
+  });
+
+  it('shouldReuse returns false after TTL expires', () => {
+    const mgr = new SessionReuseManager(1); // 1 second TTL
+    // Record activity 2 seconds in the past
+    mgr.recordActivity('host1', 'user1');
+    // Manually expire by manipulating the internal map
+    const key = 'user1@host1';
+    (mgr as unknown as { activity: Map<string, number> }).activity.set(
+      key,
+      Date.now() - 2000,
+    );
+    expect(mgr.shouldReuse('host1', 'user1')).toBe(false);
+  });
+
+  it('shouldReuse returns false when disabled (TTL=0)', () => {
+    const mgr = new SessionReuseManager(0);
+    mgr.recordActivity('host1', 'user1');
+    expect(mgr.shouldReuse('host1', 'user1')).toBe(false);
+  });
+
+  it('getControlMasterArgs returns correct SSH options', () => {
+    const mgr = new SessionReuseManager(60);
+    const args = mgr.getControlMasterArgs();
+    expect(args).toContain('-o');
+    expect(args).toContain('ControlMaster=auto');
+    const cpIdx = args.indexOf('ControlMaster=auto');
+    // ControlPath should reference the tmpdir-based path with SSH tokens
+    const controlPathArg = args[args.indexOf('ControlPath=', 0) !== -1 ? args.indexOf('ControlPath=', 0) : -1]
+      ?? args.find(a => a.startsWith('ControlPath='));
+    expect(controlPathArg).toBeDefined();
+    expect(controlPathArg).toContain('ai-ssh-toolkit');
+    expect(controlPathArg).toContain('cm-%h-%p-%r');
+    // ControlPersist should match the TTL
+    expect(args).toContain('ControlPersist=60');
+  });
+
+  it('getControlMasterArgs returns empty array when disabled', () => {
+    const mgr = new SessionReuseManager(0);
+    expect(mgr.getControlMasterArgs()).toEqual([]);
+  });
+
+  it('clear removes all tracked activity', () => {
+    const mgr = new SessionReuseManager(60);
+    mgr.recordActivity('host1', 'user1');
+    expect(mgr.shouldReuse('host1', 'user1')).toBe(true);
+    mgr.clear();
+    expect(mgr.shouldReuse('host1', 'user1')).toBe(false);
+  });
+
+  describe('getSessionReuseTtl', () => {
+    const origEnv = process.env.AI_SSH_SESSION_REUSE_TTL_SECONDS;
+
+    afterEach(() => {
+      if (origEnv === undefined) {
+        delete process.env.AI_SSH_SESSION_REUSE_TTL_SECONDS;
+      } else {
+        process.env.AI_SSH_SESSION_REUSE_TTL_SECONDS = origEnv;
+      }
+    });
+
+    it('returns 60 by default', () => {
+      delete process.env.AI_SSH_SESSION_REUSE_TTL_SECONDS;
+      expect(getSessionReuseTtl()).toBe(60);
+    });
+
+    it('reads from env var', () => {
+      process.env.AI_SSH_SESSION_REUSE_TTL_SECONDS = '120';
+      expect(getSessionReuseTtl()).toBe(120);
+    });
+
+    it('returns 0 to disable', () => {
+      process.env.AI_SSH_SESSION_REUSE_TTL_SECONDS = '0';
+      expect(getSessionReuseTtl()).toBe(0);
+    });
+
+    it('ignores invalid env values and returns default', () => {
+      process.env.AI_SSH_SESSION_REUSE_TTL_SECONDS = 'abc';
+      expect(getSessionReuseTtl()).toBe(60);
+    });
+  });
+});
+
+// ── ssh_execute integration with session reuse ──────────────────────────────
+
+// ---- ssh-config-reader mock ------------------------------------------------
+vi.mock('../../src/ssh/ssh-config-reader.js', () => ({
+  resolveSshConfig: vi.fn().mockResolvedValue(null),
+}));
+
+// ---- node-pty mock ---------------------------------------------------------
+let fakeOnData: ((data: string) => void) | null = null;
+let fakeOnExit: ((ev: { exitCode: number }) => void) | null = null;
+let fakeWrite: MockInstance;
+let fakeKill: MockInstance;
+let spawnMock: MockInstance;
+
+vi.mock('node-pty', () => {
+  fakeWrite = vi.fn();
+  fakeKill = vi.fn();
+  spawnMock = vi.fn(() => ({
+    onData: (cb: (data: string) => void) => { fakeOnData = cb; },
+    onExit: (cb: (ev: { exitCode: number }) => void) => { fakeOnExit = cb; },
+    write: fakeWrite,
+    kill: fakeKill,
+  }));
+  return { default: { spawn: spawnMock } };
+});
+
+// Import after mocks
+const { sshExecute } = await import('../../src/tools/ssh-execute.js');
+const { SessionReuseManager: SRM } = await import('../../src/ssh/session-reuse.js');
+import type { CredentialRegistry } from '../../src/credentials/registry.js';
+import { CredentialMap } from '../../src/credentials/credential-map.js';
+
+function makeRegistry(): CredentialRegistry {
+  return {
+    getBackend: vi.fn().mockReturnValue({
+      isAvailable: vi.fn().mockResolvedValue(true),
+      getCredential: vi.fn().mockResolvedValue({
+        username: 'testuser',
+        password: Buffer.from('testpass'),
+      }),
+      cleanup: vi.fn().mockResolvedValue(undefined),
+    }),
+    register: vi.fn(),
+  } as unknown as CredentialRegistry;
+}
+
+const credentialMap = new CredentialMap('/dev/null/nonexistent');
+
+describe('sshExecute with session reuse', () => {
+  beforeEach(() => {
+    fakeOnData = null;
+    fakeOnExit = null;
+    vi.clearAllMocks();
+  });
+
+  it('includes ControlMaster args when reuse is enabled', async () => {
+    const mgr = new SRM(60);
+    const registry = makeRegistry();
+
+    const promise = sshExecute(registry, {
+      host: 'test-host',
+      command: 'echo hello',
+      username: 'testuser',
+      platform: 'linux',
+      timeout_ms: 5000,
+    }, credentialMap, mgr);
+
+    await new Promise(r => setTimeout(r, 20));
+    fakeOnData!('testuser@test-host:~$ ');
+    fakeOnExit!({ exitCode: 0 });
+
+    await promise;
+
+    // Verify ControlMaster args were passed to ssh spawn
+    const sshArgs: string[] = spawnMock.mock.calls[0][1];
+    expect(sshArgs).toContain('ControlMaster=auto');
+    expect(sshArgs.some((a: string) => a.startsWith('ControlPath='))).toBe(true);
+    expect(sshArgs).toContain('ControlPersist=60');
+  });
+
+  it('records activity after successful execution', async () => {
+    const mgr = new SRM(60);
+    const registry = makeRegistry();
+
+    expect(mgr.shouldReuse('test-host', 'testuser')).toBe(false);
+
+    const promise = sshExecute(registry, {
+      host: 'test-host',
+      command: 'echo hello',
+      username: 'testuser',
+      platform: 'linux',
+      timeout_ms: 5000,
+    }, credentialMap, mgr);
+
+    await new Promise(r => setTimeout(r, 20));
+    fakeOnData!('testuser@test-host:~$ ');
+    fakeOnExit!({ exitCode: 0 });
+
+    await promise;
+
+    // After successful execution, activity should be recorded
+    expect(mgr.shouldReuse('test-host', 'testuser')).toBe(true);
+  });
+
+  it('does not include ControlMaster args when reuse_session is false', async () => {
+    const mgr = new SRM(60);
+    const registry = makeRegistry();
+
+    const promise = sshExecute(registry, {
+      host: 'test-host',
+      command: 'echo hello',
+      username: 'testuser',
+      platform: 'linux',
+      timeout_ms: 5000,
+      reuse_session: false,
+    }, credentialMap, mgr);
+
+    await new Promise(r => setTimeout(r, 20));
+    fakeOnData!('testuser@test-host:~$ ');
+    fakeOnExit!({ exitCode: 0 });
+
+    await promise;
+
+    const sshArgs: string[] = spawnMock.mock.calls[0][1];
+    expect(sshArgs).not.toContain('ControlMaster=auto');
+  });
+
+  it('includes ControlMaster args when reuse_session is explicitly true', async () => {
+    const mgr = new SRM(60);
+    const registry = makeRegistry();
+
+    const promise = sshExecute(registry, {
+      host: 'test-host',
+      command: 'echo hello',
+      username: 'testuser',
+      platform: 'linux',
+      timeout_ms: 5000,
+      reuse_session: true,
+    }, credentialMap, mgr);
+
+    await new Promise(r => setTimeout(r, 20));
+    fakeOnData!('testuser@test-host:~$ ');
+    fakeOnExit!({ exitCode: 0 });
+
+    await promise;
+
+    const sshArgs: string[] = spawnMock.mock.calls[0][1];
+    expect(sshArgs).toContain('ControlMaster=auto');
+  });
+
+  it('does not include ControlMaster args when no reuseManager is provided', async () => {
+    const registry = makeRegistry();
+
+    const promise = sshExecute(registry, {
+      host: 'test-host',
+      command: 'echo hello',
+      username: 'testuser',
+      platform: 'linux',
+      timeout_ms: 5000,
+    }, credentialMap);
+
+    await new Promise(r => setTimeout(r, 20));
+    fakeOnData!('testuser@test-host:~$ ');
+    fakeOnExit!({ exitCode: 0 });
+
+    await promise;
+
+    const sshArgs: string[] = spawnMock.mock.calls[0][1];
+    expect(sshArgs).not.toContain('ControlMaster=auto');
+  });
+
+  it('does not include ControlMaster args when TTL is 0 (disabled)', async () => {
+    const mgr = new SRM(0);
+    const registry = makeRegistry();
+
+    const promise = sshExecute(registry, {
+      host: 'test-host',
+      command: 'echo hello',
+      username: 'testuser',
+      platform: 'linux',
+      timeout_ms: 5000,
+    }, credentialMap, mgr);
+
+    await new Promise(r => setTimeout(r, 20));
+    fakeOnData!('testuser@test-host:~$ ');
+    fakeOnExit!({ exitCode: 0 });
+
+    await promise;
+
+    const sshArgs: string[] = spawnMock.mock.calls[0][1];
+    expect(sshArgs).not.toContain('ControlMaster=auto');
+  });
+
+  it('returns same shape as regular ssh_execute (transparent reuse)', async () => {
+    const mgr = new SRM(60);
+    const registry = makeRegistry();
+
+    const promise = sshExecute(registry, {
+      host: 'test-host',
+      command: 'echo hello',
+      username: 'testuser',
+      platform: 'linux',
+      timeout_ms: 5000,
+    }, credentialMap, mgr);
+
+    await new Promise(r => setTimeout(r, 20));
+    fakeOnData!('hello\r\ntestuser@test-host:~$ ');
+    fakeOnExit!({ exitCode: 0 });
+
+    const result = await promise;
+    expect(result).toHaveProperty('output');
+    expect(result).toHaveProperty('exit_code');
+    expect(result.exit_code).toBe(0);
+    expect(typeof result.output).toBe('string');
+  });
+});

--- a/test/unit/session-reuse.test.ts
+++ b/test/unit/session-reuse.test.ts
@@ -3,8 +3,6 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
-import os from 'os';
-import path from 'path';
 
 // ── SessionReuseManager unit tests ──────────────────────────────────────────
 
@@ -76,10 +74,8 @@ describe('SessionReuseManager', () => {
     const args = mgr.getControlMasterArgs();
     expect(args).toContain('-o');
     expect(args).toContain('ControlMaster=auto');
-    const cpIdx = args.indexOf('ControlMaster=auto');
     // ControlPath should reference the tmpdir-based path with SSH tokens
-    const controlPathArg = args[args.indexOf('ControlPath=', 0) !== -1 ? args.indexOf('ControlPath=', 0) : -1]
-      ?? args.find(a => a.startsWith('ControlPath='));
+    const controlPathArg = args.find(a => a.startsWith('ControlPath='));
     expect(controlPathArg).toBeDefined();
     expect(controlPathArg).toContain('ai-ssh-toolkit');
     expect(controlPathArg).toContain('cm-%h-%p-%r');


### PR DESCRIPTION
Closes #91

## Summary

`ssh_execute` now transparently reuses existing SSH connections via OpenSSH ControlMaster multiplexing — eliminating the 1-2s connect+auth overhead on repeated calls to the same host.

## How it works

- First call to a host opens a connection and sets up a ControlMaster socket at `/tmp/ai-ssh-toolkit/cm-<host>-<port>-<user>`
- Subsequent calls within the TTL (default 60s) attach to the existing master — near-zero connect latency
- After TTL expires with no activity, the connection is released
- Falls back gracefully to a fresh connection if the master socket is gone

## Configuration

| Env var | Default | Description |
|---------|---------|-------------|
| `AI_SSH_SESSION_REUSE_TTL_SECONDS` | `60` | Inactivity TTL; `0` disables reuse |

## Per-call override
```json
{ "host": "prod-web-1", "command": "uptime", "reuse_session": false }
```

## Changes
- `src/ssh/session-reuse.ts` — `SessionReuseManager` with TTL tracking + ControlMaster args
- `src/ssh/pty-manager.ts` — `extraSshArgs` option added
- `src/tools/ssh-execute.ts` — reuse integration + `reuse_session` param
- `src/index.ts` — manager wired up from env var, schema updated
- `test/unit/session-reuse.test.ts` — 22 new tests

## Tests
✅ 228 tests pass