### PR TITLE
feat: additional credential backends (1Password, Vault, AWS, macOS, Windows)

### DIFF
--- a/src/credentials/aws-secretsmanager.ts
+++ b/src/credentials/aws-secretsmanager.ts
@@ -1,0 +1,160 @@
+import { execFile } from "child_process";
+import {
+  CredentialBackend,
+  CredentialResult,
+  CredentialMetadata,
+} from "./backend.js";
+import { resolveCliPath } from "../utils/cli-resolver.js";
+
+/** Promisified execFile wrapper */
+function execFileAsync(
+  cmd: string,
+  args: string[],
+  opts: { timeout?: number; env?: NodeJS.ProcessEnv } = {},
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(cmd, args, opts, (error, stdout, stderr) => {
+      if (error) reject(error);
+      else resolve({ stdout: stdout as string, stderr: stderr as string });
+    });
+  });
+}
+
+/**
+ * AWS Secrets Manager credential backend.
+ *
+ * ref format:
+ *   "secret-name#username_key:password_key"
+ *   "arn:aws:secretsmanager:...:secret:name#username_key:password_key"
+ *
+ * Uses `aws` CLI to retrieve secrets. Requires AWS CLI installed and configured.
+ *
+ * Security:
+ * - Passwords returned as Buffer, zero-filled by caller
+ * - CLI resolved to absolute path
+ */
+export class AwsSecretsManagerBackend implements CredentialBackend {
+  readonly name = "aws-secretsmanager";
+  private cliPath: string | null = null;
+  private stagedBuffers: Buffer[] = [];
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      this.cliPath = resolveCliPath("aws");
+      await execFileAsync(this.cliPath, ["sts", "get-caller-identity"], {
+        timeout: 10000,
+        env: { ...process.env },
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getCredential(ref: string): Promise<CredentialResult> {
+    const cli = await this.resolveCli();
+    const { secretId, usernameKey, passwordKey } = this.parseRef(ref);
+
+    const { stdout } = await execFileAsync(
+      cli,
+      [
+        "secretsmanager",
+        "get-secret-value",
+        "--secret-id",
+        secretId,
+        "--output",
+        "json",
+      ],
+      { timeout: 15000, env: { ...process.env } },
+    );
+
+    const result = JSON.parse(stdout);
+    const secretData = JSON.parse(result.SecretString ?? "{}");
+
+    const username = String(secretData[usernameKey] ?? "");
+    const passwordValue = String(secretData[passwordKey] ?? "");
+    const password = Buffer.from(passwordValue, "utf-8");
+    this.stagedBuffers.push(password);
+
+    return { username, password };
+  }
+
+  async getMetadata(ref: string): Promise<CredentialMetadata> {
+    const cli = await this.resolveCli();
+    const { secretId, usernameKey, passwordKey } = this.parseRef(ref);
+
+    const { stdout } = await execFileAsync(
+      cli,
+      [
+        "secretsmanager",
+        "get-secret-value",
+        "--secret-id",
+        secretId,
+        "--output",
+        "json",
+      ],
+      { timeout: 15000, env: { ...process.env } },
+    );
+
+    const result = JSON.parse(stdout);
+    const secretData = JSON.parse(result.SecretString ?? "{}");
+
+    return {
+      username: String(secretData[usernameKey] ?? ""),
+      has_password: !!secretData[passwordKey],
+      backend: this.name,
+    };
+  }
+
+  async cleanup(): Promise<void> {
+    for (const buf of this.stagedBuffers) {
+      buf.fill(0);
+    }
+    this.stagedBuffers = [];
+  }
+
+  /**
+   * Parse ref format: "secret-name#username_key:password_key"
+   * or "arn:aws:...#username_key:password_key"
+   */
+  private parseRef(ref: string): {
+    secretId: string;
+    usernameKey: string;
+    passwordKey: string;
+  } {
+    // For ARN refs, the # separator follows the ARN
+    const hashIdx = ref.lastIndexOf("#");
+    if (hashIdx === -1) {
+      throw new Error(
+        `Invalid AWS Secrets Manager ref format: "${ref}". Expected "secret-name#username_key:password_key"`,
+      );
+    }
+
+    const secretId = ref.substring(0, hashIdx);
+    const fieldPart = ref.substring(hashIdx + 1);
+    const colonIdx = fieldPart.indexOf(":");
+    if (colonIdx === -1) {
+      throw new Error(
+        `Invalid AWS Secrets Manager ref format: "${ref}". Expected "secret-name#username_key:password_key"`,
+      );
+    }
+
+    const usernameKey = fieldPart.substring(0, colonIdx);
+    const passwordKey = fieldPart.substring(colonIdx + 1);
+
+    if (!secretId || !usernameKey || !passwordKey) {
+      throw new Error(
+        `Invalid AWS Secrets Manager ref format: "${ref}". All parts (secret-id, username_key, password_key) are required.`,
+      );
+    }
+
+    return { secretId, usernameKey, passwordKey };
+  }
+
+  private async resolveCli(): Promise<string> {
+    if (!this.cliPath) {
+      this.cliPath = resolveCliPath("aws");
+    }
+    return this.cliPath;
+  }
+}

--- a/src/credentials/hashicorp-vault.ts
+++ b/src/credentials/hashicorp-vault.ts
@@ -1,0 +1,148 @@
+import { execFile } from "child_process";
+import {
+  CredentialBackend,
+  CredentialResult,
+  CredentialMetadata,
+} from "./backend.js";
+import { resolveCliPath } from "../utils/cli-resolver.js";
+
+/** Promisified execFile wrapper */
+function execFileAsync(
+  cmd: string,
+  args: string[],
+  opts: { timeout?: number; env?: NodeJS.ProcessEnv } = {},
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(cmd, args, opts, (error, stdout, stderr) => {
+      if (error) reject(error);
+      else resolve({ stdout: stdout as string, stderr: stderr as string });
+    });
+  });
+}
+
+/**
+ * HashiCorp Vault credential backend.
+ *
+ * ref format: "secret/path#username_field:password_field"
+ * Requires VAULT_ADDR env var and either VAULT_TOKEN or `vault` CLI authenticated.
+ *
+ * Security:
+ * - Passwords returned as Buffer, zero-filled by caller
+ * - Uses vault CLI with KV get
+ */
+export class HashiCorpVaultBackend implements CredentialBackend {
+  readonly name = "hashicorp-vault";
+  private cliPath: string | null = null;
+  private stagedBuffers: Buffer[] = [];
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      if (!process.env.VAULT_ADDR) {
+        return false;
+      }
+      this.cliPath = resolveCliPath("vault");
+      await execFileAsync(this.cliPath, ["token", "lookup"], {
+        timeout: 10000,
+        env: this.buildEnv(),
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getCredential(ref: string): Promise<CredentialResult> {
+    const cli = await this.resolveCli();
+    const { path, usernameField, passwordField } = this.parseRef(ref);
+
+    const { stdout } = await execFileAsync(
+      cli,
+      ["kv", "get", "-format=json", path],
+      { timeout: 15000, env: this.buildEnv() },
+    );
+
+    const result = JSON.parse(stdout);
+    const data = result.data?.data ?? result.data ?? {};
+
+    const username = String(data[usernameField] ?? "");
+    const passwordValue = String(data[passwordField] ?? "");
+    const password = Buffer.from(passwordValue, "utf-8");
+    this.stagedBuffers.push(password);
+
+    return { username, password };
+  }
+
+  async getMetadata(ref: string): Promise<CredentialMetadata> {
+    const cli = await this.resolveCli();
+    const { path, usernameField, passwordField } = this.parseRef(ref);
+
+    const { stdout } = await execFileAsync(
+      cli,
+      ["kv", "get", "-format=json", path],
+      { timeout: 15000, env: this.buildEnv() },
+    );
+
+    const result = JSON.parse(stdout);
+    const data = result.data?.data ?? result.data ?? {};
+
+    return {
+      username: String(data[usernameField] ?? ""),
+      has_password: !!data[passwordField],
+      backend: this.name,
+    };
+  }
+
+  async cleanup(): Promise<void> {
+    for (const buf of this.stagedBuffers) {
+      buf.fill(0);
+    }
+    this.stagedBuffers = [];
+  }
+
+  /**
+   * Parse ref format: "secret/path#username_field:password_field"
+   */
+  private parseRef(ref: string): {
+    path: string;
+    usernameField: string;
+    passwordField: string;
+  } {
+    const hashIdx = ref.indexOf("#");
+    if (hashIdx === -1) {
+      throw new Error(
+        `Invalid Vault ref format: "${ref}". Expected "secret/path#username_field:password_field"`,
+      );
+    }
+
+    const path = ref.substring(0, hashIdx);
+    const fieldPart = ref.substring(hashIdx + 1);
+    const colonIdx = fieldPart.indexOf(":");
+    if (colonIdx === -1) {
+      throw new Error(
+        `Invalid Vault ref format: "${ref}". Expected "secret/path#username_field:password_field"`,
+      );
+    }
+
+    const usernameField = fieldPart.substring(0, colonIdx);
+    const passwordField = fieldPart.substring(colonIdx + 1);
+
+    if (!path || !usernameField || !passwordField) {
+      throw new Error(
+        `Invalid Vault ref format: "${ref}". All parts (path, username_field, password_field) are required.`,
+      );
+    }
+
+    return { path, usernameField, passwordField };
+  }
+
+  private buildEnv(): NodeJS.ProcessEnv {
+    return { ...process.env };
+  }
+
+  private async resolveCli(): Promise<string> {
+    if (!this.cliPath) {
+      this.cliPath = resolveCliPath("vault");
+    }
+    return this.cliPath;
+  }
+}

--- a/src/credentials/macos-keychain.ts
+++ b/src/credentials/macos-keychain.ts
@@ -1,0 +1,124 @@
+import { execFile } from "child_process";
+import {
+  CredentialBackend,
+  CredentialResult,
+  CredentialMetadata,
+} from "./backend.js";
+import { currentPlatform } from "../utils/platform.js";
+import { resolveCliPath } from "../utils/cli-resolver.js";
+
+/** Promisified execFile wrapper */
+function execFileAsync(
+  cmd: string,
+  args: string[],
+  opts: { timeout?: number } = {},
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(cmd, args, opts, (error, stdout, stderr) => {
+      if (error) reject(error);
+      else resolve({ stdout: stdout as string, stderr: stderr as string });
+    });
+  });
+}
+
+/**
+ * macOS Keychain credential backend.
+ *
+ * ref format: "service-name:account-name"
+ * Uses the macOS `security` CLI to retrieve credentials from the login keychain.
+ *
+ * Security:
+ * - macOS only (platform === 'darwin')
+ * - Passwords returned as Buffer, zero-filled by caller
+ */
+export class MacOsKeychainBackend implements CredentialBackend {
+  readonly name = "macos-keychain";
+  private cliPath: string | null = null;
+  private stagedBuffers: Buffer[] = [];
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      if (currentPlatform() !== "darwin") {
+        return false;
+      }
+      this.cliPath = resolveCliPath("security");
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getCredential(ref: string): Promise<CredentialResult> {
+    const cli = await this.resolveCli();
+    const { serviceName, accountName } = this.parseRef(ref);
+
+    // `security find-generic-password -w` outputs password to stdout
+    const { stdout } = await execFileAsync(
+      cli,
+      ["find-generic-password", "-s", serviceName, "-a", accountName, "-w"],
+      { timeout: 10000 },
+    );
+
+    const password = Buffer.from(stdout.trim(), "utf-8");
+    this.stagedBuffers.push(password);
+
+    return { username: accountName, password };
+  }
+
+  async getMetadata(ref: string): Promise<CredentialMetadata> {
+    const cli = await this.resolveCli();
+    const { serviceName, accountName } = this.parseRef(ref);
+
+    let hasPassword = false;
+    try {
+      await execFileAsync(
+        cli,
+        ["find-generic-password", "-s", serviceName, "-a", accountName],
+        { timeout: 10000 },
+      );
+      hasPassword = true;
+    } catch {
+      // Keychain item not found
+    }
+
+    return {
+      username: accountName,
+      has_password: hasPassword,
+      backend: this.name,
+    };
+  }
+
+  async cleanup(): Promise<void> {
+    for (const buf of this.stagedBuffers) {
+      buf.fill(0);
+    }
+    this.stagedBuffers = [];
+  }
+
+  /**
+   * Parse ref format: "service-name:account-name"
+   */
+  private parseRef(ref: string): {
+    serviceName: string;
+    accountName: string;
+  } {
+    const colonIdx = ref.indexOf(":");
+    if (colonIdx === -1 || colonIdx === 0 || colonIdx === ref.length - 1) {
+      throw new Error(
+        `Invalid macOS Keychain ref format: "${ref}". Expected "service-name:account-name"`,
+      );
+    }
+
+    return {
+      serviceName: ref.substring(0, colonIdx),
+      accountName: ref.substring(colonIdx + 1),
+    };
+  }
+
+  private async resolveCli(): Promise<string> {
+    if (!this.cliPath) {
+      this.cliPath = resolveCliPath("security");
+    }
+    return this.cliPath;
+  }
+}

--- a/src/credentials/onepassword.ts
+++ b/src/credentials/onepassword.ts
@@ -1,0 +1,129 @@
+import { execFile } from "child_process";
+import {
+  CredentialBackend,
+  CredentialResult,
+  CredentialMetadata,
+} from "./backend.js";
+import { resolveCliPath } from "../utils/cli-resolver.js";
+
+/** Promisified execFile wrapper */
+function execFileAsync(
+  cmd: string,
+  args: string[],
+  opts: { timeout?: number } = {},
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(cmd, args, opts, (error, stdout, stderr) => {
+      if (error) reject(error);
+      else resolve({ stdout: stdout as string, stderr: stderr as string });
+    });
+  });
+}
+
+/**
+ * 1Password CLI credential backend.
+ *
+ * ref format: "op://vault/item/username-field:password-field"
+ * Requires `op` CLI installed and signed in.
+ *
+ * Security:
+ * - Passwords returned as Buffer, zero-filled by caller
+ * - CLI resolved to absolute path
+ */
+export class OnePasswordBackend implements CredentialBackend {
+  readonly name = "onepassword";
+  private cliPath: string | null = null;
+  private stagedBuffers: Buffer[] = [];
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      this.cliPath = resolveCliPath("op");
+      await execFileAsync(this.cliPath, ["whoami"], { timeout: 10000 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getCredential(ref: string): Promise<CredentialResult> {
+    const cli = await this.resolveCli();
+    const { usernameRef, passwordRef } = this.parseRef(ref);
+
+    const [username, passwordRaw] = await Promise.all([
+      this.readField(cli, usernameRef),
+      this.readField(cli, passwordRef),
+    ]);
+
+    const password = Buffer.from(passwordRaw, "utf-8");
+    this.stagedBuffers.push(password);
+
+    return { username, password };
+  }
+
+  async getMetadata(ref: string): Promise<CredentialMetadata> {
+    const cli = await this.resolveCli();
+    const { usernameRef } = this.parseRef(ref);
+
+    const username = await this.readField(cli, usernameRef).catch(() => "");
+
+    return {
+      username,
+      has_password: true,
+      backend: this.name,
+    };
+  }
+
+  async cleanup(): Promise<void> {
+    for (const buf of this.stagedBuffers) {
+      buf.fill(0);
+    }
+    this.stagedBuffers = [];
+  }
+
+  /**
+   * Parse ref format: "op://vault/item/username-field:password-field"
+   * The colon separates the username field name from the password field name.
+   */
+  private parseRef(ref: string): { usernameRef: string; passwordRef: string } {
+    const colonIdx = ref.lastIndexOf(":");
+    if (colonIdx === -1) {
+      throw new Error(
+        `Invalid 1Password ref format: "${ref}". Expected "op://vault/item/username-field:password-field"`,
+      );
+    }
+
+    const usernameRef = ref.substring(0, colonIdx);
+    const passwordFieldName = ref.substring(colonIdx + 1);
+
+    if (!usernameRef || !passwordFieldName) {
+      throw new Error(
+        `Invalid 1Password ref format: "${ref}". Both username and password field refs are required.`,
+      );
+    }
+
+    // Build the password ref by replacing the last path segment
+    const lastSlash = usernameRef.lastIndexOf("/");
+    if (lastSlash === -1) {
+      throw new Error(
+        `Invalid 1Password ref format: "${ref}". Expected "op://vault/item/field" prefix.`,
+      );
+    }
+    const passwordRef = usernameRef.substring(0, lastSlash + 1) + passwordFieldName;
+
+    return { usernameRef, passwordRef };
+  }
+
+  private async readField(cli: string, fieldRef: string): Promise<string> {
+    const { stdout } = await execFileAsync(cli, ["read", fieldRef], {
+      timeout: 15000,
+    });
+    return stdout.trim();
+  }
+
+  private async resolveCli(): Promise<string> {
+    if (!this.cliPath) {
+      this.cliPath = resolveCliPath("op");
+    }
+    return this.cliPath;
+  }
+}

--- a/src/credentials/windows-credential.ts
+++ b/src/credentials/windows-credential.ts
@@ -79,7 +79,7 @@ export class WindowsCredentialBackend implements CredentialBackend {
   async getMetadata(ref: string): Promise<CredentialMetadata> {
     this.validateRef(ref);
 
-    let username = "";
+    const username = "";
     let hasPassword = false;
 
     try {

--- a/src/credentials/windows-credential.ts
+++ b/src/credentials/windows-credential.ts
@@ -1,0 +1,118 @@
+import { execFile } from "child_process";
+import {
+  CredentialBackend,
+  CredentialResult,
+  CredentialMetadata,
+} from "./backend.js";
+import { currentPlatform } from "../utils/platform.js";
+
+/** Promisified execFile wrapper */
+function execFileAsync(
+  cmd: string,
+  args: string[],
+  opts: { timeout?: number; shell?: boolean } = {},
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(cmd, args, opts, (error, stdout, stderr) => {
+      if (error) reject(error);
+      else resolve({ stdout: stdout as string, stderr: stderr as string });
+    });
+  });
+}
+
+/**
+ * Windows Credential Manager backend.
+ *
+ * ref format: "target-name"
+ * Uses PowerShell's CredentialManager or cmdkey on Windows.
+ *
+ * Security:
+ * - Windows only (platform === 'win32')
+ * - Passwords returned as Buffer, zero-filled by caller
+ */
+export class WindowsCredentialBackend implements CredentialBackend {
+  readonly name = "windows-credential";
+  private stagedBuffers: Buffer[] = [];
+
+  async isAvailable(): Promise<boolean> {
+    if (currentPlatform() !== "win32") {
+      return false;
+    }
+    try {
+      await execFileAsync("cmdkey", ["/list"], { timeout: 10000 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getCredential(ref: string): Promise<CredentialResult> {
+    this.validateRef(ref);
+
+    // Use PowerShell to read credential from Windows Credential Manager
+    const psScript = [
+      `$cred = Get-StoredCredential -Target '${ref.replace(/'/g, "''")}';`,
+      `if ($cred -eq $null) { throw 'Credential not found'; }`,
+      `$bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($cred.Password);`,
+      `$plain = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr);`,
+      `[System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr);`,
+      `Write-Output "$($cred.UserName)|$plain"`,
+    ].join(" ");
+
+    const { stdout } = await execFileAsync(
+      "powershell",
+      ["-NoProfile", "-NonInteractive", "-Command", psScript],
+      { timeout: 15000 },
+    );
+
+    const output = stdout.trim();
+    const separatorIdx = output.indexOf("|");
+    const username = separatorIdx !== -1 ? output.substring(0, separatorIdx) : "";
+    const passwordStr = separatorIdx !== -1 ? output.substring(separatorIdx + 1) : output;
+
+    const password = Buffer.from(passwordStr, "utf-8");
+    this.stagedBuffers.push(password);
+
+    return { username, password };
+  }
+
+  async getMetadata(ref: string): Promise<CredentialMetadata> {
+    this.validateRef(ref);
+
+    let username = "";
+    let hasPassword = false;
+
+    try {
+      const { stdout } = await execFileAsync("cmdkey", ["/list"], {
+        timeout: 10000,
+      });
+      // cmdkey /list output contains target names
+      if (stdout.includes(ref)) {
+        hasPassword = true;
+      }
+    } catch {
+      // cmdkey not available or failed
+    }
+
+    return {
+      username,
+      has_password: hasPassword,
+      backend: this.name,
+    };
+  }
+
+  async cleanup(): Promise<void> {
+    for (const buf of this.stagedBuffers) {
+      buf.fill(0);
+    }
+    this.stagedBuffers = [];
+  }
+
+  private validateRef(ref: string): void {
+    if (!ref || ref.trim().length === 0) {
+      throw new Error(
+        `Invalid Windows Credential ref: "${ref}". Expected a non-empty target name.`,
+      );
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,11 @@ import { AzureKeyVaultBackend } from './credentials/azure-keyvault.js';
 import { EnvCredentialBackend } from './credentials/env.js';
 import { GoogleSecretManagerBackend } from './credentials/google-secret-manager.js';
 import { SshAgentBackend } from './credentials/ssh-agent.js';
+import { OnePasswordBackend } from './credentials/onepassword.js';
+import { HashiCorpVaultBackend } from './credentials/hashicorp-vault.js';
+import { AwsSecretsManagerBackend } from './credentials/aws-secretsmanager.js';
+import { MacOsKeychainBackend } from './credentials/macos-keychain.js';
+import { WindowsCredentialBackend } from './credentials/windows-credential.js';
 import { readFileSync } from 'fs';
 
 function getPackageVersion(): string {
@@ -65,6 +70,11 @@ registry.register(new AzureKeyVaultBackend());
 registry.register(new EnvCredentialBackend());
 registry.register(new GoogleSecretManagerBackend());
 registry.register(new SshAgentBackend());
+registry.register(new OnePasswordBackend());
+registry.register(new HashiCorpVaultBackend());
+registry.register(new AwsSecretsManagerBackend());
+registry.register(new MacOsKeychainBackend());
+registry.register(new WindowsCredentialBackend());
 
 const sessionStore = new SessionStore();
 const credentialMap = new CredentialMap();

--- a/test/unit/aws-secretsmanager-backend.test.ts
+++ b/test/unit/aws-secretsmanager-backend.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { AwsSecretsManagerBackend } from "../../src/credentials/aws-secretsmanager.js";
+
+vi.mock("child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock("../../src/utils/cli-resolver.js", () => ({
+  resolveCliPath: vi.fn(() => "/usr/bin/aws"),
+}));
+
+import { execFile } from "child_process";
+import { resolveCliPath } from "../../src/utils/cli-resolver.js";
+
+function mockExecFile(stdout: string) {
+  const mock = vi.mocked(execFile);
+  mock.mockImplementation(
+    (_cmd: unknown, _args: unknown, _opts: unknown, callback?: (err: Error | null, stdout: string, stderr: string) => void) => {
+      if (typeof _opts === "function") {
+        _opts(null, stdout, "");
+      } else if (callback) {
+        callback(null, stdout, "");
+      }
+      return {} as ReturnType<typeof execFile>;
+    },
+  );
+}
+
+function mockExecFileError(message: string) {
+  const mock = vi.mocked(execFile);
+  mock.mockImplementation(
+    (_cmd: unknown, _args: unknown, _opts: unknown, callback?: (err: Error | null, stdout: string, stderr: string) => void) => {
+      const err = new Error(message);
+      if (typeof _opts === "function") {
+        _opts(err, "", "");
+      } else if (callback) {
+        callback(err, "", "");
+      }
+      return {} as ReturnType<typeof execFile>;
+    },
+  );
+}
+
+function mockExecFileSequence(responses: Array<{ stdout?: string; error?: string }>) {
+  const mock = vi.mocked(execFile);
+  let callIdx = 0;
+  mock.mockImplementation(
+    (_cmd: unknown, _args: unknown, _opts: unknown, callback?: (err: Error | null, stdout: string, stderr: string) => void) => {
+      const resp = responses[callIdx++] ?? responses[responses.length - 1];
+      const cb = typeof _opts === "function" ? _opts : callback;
+      if (resp.error) {
+        cb?.(new Error(resp.error), "", "");
+      } else {
+        cb?.(null, resp.stdout ?? "", "");
+      }
+      return {} as ReturnType<typeof execFile>;
+    },
+  );
+}
+
+describe("AwsSecretsManagerBackend", () => {
+  let backend: AwsSecretsManagerBackend;
+
+  beforeEach(() => {
+    backend = new AwsSecretsManagerBackend();
+    vi.clearAllMocks();
+    vi.mocked(resolveCliPath).mockReturnValue("/usr/bin/aws");
+  });
+
+  afterEach(async () => {
+    await backend.cleanup();
+  });
+
+  describe("name", () => {
+    it("should be 'aws-secretsmanager'", () => {
+      expect(backend.name).toBe("aws-secretsmanager");
+    });
+  });
+
+  describe("isAvailable", () => {
+    it("should return true when AWS credentials are valid", async () => {
+      mockExecFile('{"Account":"123456789012"}');
+      expect(await backend.isAvailable()).toBe(true);
+    });
+
+    it("should return false when aws CLI not found", async () => {
+      vi.mocked(resolveCliPath).mockImplementation(() => {
+        throw new Error("CLI tool not found: aws");
+      });
+      expect(await backend.isAvailable()).toBe(false);
+    });
+
+    it("should return false when AWS credentials invalid", async () => {
+      mockExecFileError("Unable to locate credentials");
+      expect(await backend.isAvailable()).toBe(false);
+    });
+  });
+
+  describe("getCredential", () => {
+    it("should return username and password from AWS secret", async () => {
+      const awsResponse = {
+        SecretString: JSON.stringify({
+          username: "dbadmin",
+          password: "aws-secret-pass",
+        }),
+      };
+      mockExecFileSequence([
+        { stdout: JSON.stringify(awsResponse) },
+      ]);
+
+      const result = await backend.getCredential(
+        "my-db-secret#username:password",
+      );
+      expect(result.username).toBe("dbadmin");
+      expect(Buffer.isBuffer(result.password)).toBe(true);
+      expect(result.password.toString("utf-8")).toBe("aws-secret-pass");
+    });
+
+    it("should support ARN format refs", async () => {
+      const awsResponse = {
+        SecretString: JSON.stringify({
+          user: "root",
+          pass: "arn-secret",
+        }),
+      };
+      mockExecFile(JSON.stringify(awsResponse));
+
+      const result = await backend.getCredential(
+        "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret#user:pass",
+      );
+      expect(result.username).toBe("root");
+      expect(result.password.toString("utf-8")).toBe("arn-secret");
+
+      // Verify the secret-id passed to CLI
+      const mock = vi.mocked(execFile);
+      const args = mock.mock.calls[0][1] as string[];
+      expect(args).toContain(
+        "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret",
+      );
+    });
+
+    it("should throw on invalid ref format (no hash)", async () => {
+      await expect(
+        backend.getCredential("my-secret"),
+      ).rejects.toThrow("Invalid AWS Secrets Manager ref format");
+    });
+
+    it("should throw on invalid ref format (no colon in keys)", async () => {
+      await expect(
+        backend.getCredential("my-secret#fieldonly"),
+      ).rejects.toThrow("Invalid AWS Secrets Manager ref format");
+    });
+
+    it("should call aws CLI with correct args", async () => {
+      const awsResponse = {
+        SecretString: JSON.stringify({ u: "x", p: "y" }),
+      };
+      mockExecFile(JSON.stringify(awsResponse));
+
+      await backend.getCredential("prod/db-creds#u:p");
+
+      const mock = vi.mocked(execFile);
+      const args = mock.mock.calls[0][1] as string[];
+      expect(args).toEqual([
+        "secretsmanager",
+        "get-secret-value",
+        "--secret-id",
+        "prod/db-creds",
+        "--output",
+        "json",
+      ]);
+    });
+  });
+
+  describe("getMetadata", () => {
+    it("should return metadata without password value", async () => {
+      const awsResponse = {
+        SecretString: JSON.stringify({
+          username: "admin",
+          password: "secret",
+        }),
+      };
+      mockExecFile(JSON.stringify(awsResponse));
+
+      const meta = await backend.getMetadata("my-secret#username:password");
+      expect(meta.username).toBe("admin");
+      expect(meta.has_password).toBe(true);
+      expect(meta.backend).toBe("aws-secretsmanager");
+    });
+
+    it("should report has_password false when key missing", async () => {
+      const awsResponse = {
+        SecretString: JSON.stringify({ username: "admin" }),
+      };
+      mockExecFile(JSON.stringify(awsResponse));
+
+      const meta = await backend.getMetadata("my-secret#username:password");
+      expect(meta.has_password).toBe(false);
+    });
+  });
+
+  describe("cleanup", () => {
+    it("should zero-fill all staged password Buffers", async () => {
+      const awsResponse = {
+        SecretString: JSON.stringify({ u: "x", p: "password123" }),
+      };
+      mockExecFile(JSON.stringify(awsResponse));
+
+      const result = await backend.getCredential("secret#u:p");
+      const pwRef = result.password;
+
+      await backend.cleanup();
+      expect(pwRef.every((byte) => byte === 0)).toBe(true);
+    });
+  });
+});

--- a/test/unit/hashicorp-vault-backend.test.ts
+++ b/test/unit/hashicorp-vault-backend.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { HashiCorpVaultBackend } from "../../src/credentials/hashicorp-vault.js";
+
+vi.mock("child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock("../../src/utils/cli-resolver.js", () => ({
+  resolveCliPath: vi.fn(() => "/usr/bin/vault"),
+}));
+
+import { execFile } from "child_process";
+import { resolveCliPath } from "../../src/utils/cli-resolver.js";
+
+function mockExecFile(stdout: string) {
+  const mock = vi.mocked(execFile);
+  mock.mockImplementation(
+    (_cmd: unknown, _args: unknown, _opts: unknown, callback?: (err: Error | null, stdout: string, stderr: string) => void) => {
+      if (typeof _opts === "function") {
+        _opts(null, stdout, "");
+      } else if (callback) {
+        callback(null, stdout, "");
+      }
+      return {} as ReturnType<typeof execFile>;
+    },
+  );
+}
+
+function mockExecFileError(message: string) {
+  const mock = vi.mocked(execFile);
+  mock.mockImplementation(
+    (_cmd: unknown, _args: unknown, _opts: unknown, callback?: (err: Error | null, stdout: string, stderr: string) => void) => {
+      const err = new Error(message);
+      if (typeof _opts === "function") {
+        _opts(err, "", "");
+      } else if (callback) {
+        callback(err, "", "");
+      }
+      return {} as ReturnType<typeof execFile>;
+    },
+  );
+}
+
+function mockExecFileSequence(responses: Array<{ stdout?: string; error?: string }>) {
+  const mock = vi.mocked(execFile);
+  let callIdx = 0;
+  mock.mockImplementation(
+    (_cmd: unknown, _args: unknown, _opts: unknown, callback?: (err: Error | null, stdout: string, stderr: string) => void) => {
+      const resp = responses[callIdx++] ?? responses[responses.length - 1];
+      const cb = typeof _opts === "function" ? _opts : callback;
+      if (resp.error) {
+        cb?.(new Error(resp.error), "", "");
+      } else {
+        cb?.(null, resp.stdout ?? "", "");
+      }
+      return {} as ReturnType<typeof execFile>;
+    },
+  );
+}
+
+describe("HashiCorpVaultBackend", () => {
+  let backend: HashiCorpVaultBackend;
+  const origEnv = { ...process.env };
+
+  beforeEach(() => {
+    backend = new HashiCorpVaultBackend();
+    vi.clearAllMocks();
+    vi.mocked(resolveCliPath).mockReturnValue("/usr/bin/vault");
+    process.env.VAULT_ADDR = "http://127.0.0.1:8200";
+    process.env.VAULT_TOKEN = "test-token";
+  });
+
+  afterEach(async () => {
+    await backend.cleanup();
+    process.env = { ...origEnv };
+  });
+
+  describe("name", () => {
+    it("should be 'hashicorp-vault'", () => {
+      expect(backend.name).toBe("hashicorp-vault");
+    });
+  });
+
+  describe("isAvailable", () => {
+    it("should return true when VAULT_ADDR set and token valid", async () => {
+      mockExecFile('{"data":{"accessor":"token-accessor"}}');
+      expect(await backend.isAvailable()).toBe(true);
+    });
+
+    it("should return false when VAULT_ADDR not set", async () => {
+      delete process.env.VAULT_ADDR;
+      expect(await backend.isAvailable()).toBe(false);
+    });
+
+    it("should return false when vault CLI not found", async () => {
+      vi.mocked(resolveCliPath).mockImplementation(() => {
+        throw new Error("CLI tool not found: vault");
+      });
+      expect(await backend.isAvailable()).toBe(false);
+    });
+
+    it("should return false when token lookup fails", async () => {
+      mockExecFileError("permission denied");
+      expect(await backend.isAvailable()).toBe(false);
+    });
+  });
+
+  describe("getCredential", () => {
+    it("should return username and password from Vault KV", async () => {
+      const vaultResponse = {
+        data: {
+          data: {
+            user: "admin",
+            pass: "vault-secret",
+          },
+        },
+      };
+      mockExecFileSequence([
+        { stdout: JSON.stringify(vaultResponse) },
+      ]);
+
+      const result = await backend.getCredential("secret/myapp#user:pass");
+      expect(result.username).toBe("admin");
+      expect(Buffer.isBuffer(result.password)).toBe(true);
+      expect(result.password.toString("utf-8")).toBe("vault-secret");
+    });
+
+    it("should handle KV v1 format (data without nested data)", async () => {
+      const vaultResponse = {
+        data: {
+          username: "root",
+          password: "kv1-secret",
+        },
+      };
+      mockExecFile(JSON.stringify(vaultResponse));
+
+      const result = await backend.getCredential(
+        "secret/data/myapp#username:password",
+      );
+      expect(result.username).toBe("root");
+      expect(result.password.toString("utf-8")).toBe("kv1-secret");
+    });
+
+    it("should throw on invalid ref format (no hash)", async () => {
+      await expect(
+        backend.getCredential("secret/path"),
+      ).rejects.toThrow("Invalid Vault ref format");
+    });
+
+    it("should throw on invalid ref format (no colon in fields)", async () => {
+      await expect(
+        backend.getCredential("secret/path#fieldonly"),
+      ).rejects.toThrow("Invalid Vault ref format");
+    });
+
+    it("should throw on empty parts", async () => {
+      await expect(
+        backend.getCredential("#user:pass"),
+      ).rejects.toThrow("Invalid Vault ref format");
+    });
+
+    it("should call vault CLI with correct args", async () => {
+      const vaultResponse = {
+        data: { data: { u: "x", p: "y" } },
+      };
+      mockExecFile(JSON.stringify(vaultResponse));
+
+      await backend.getCredential("secret/ssh-creds#u:p");
+
+      const mock = vi.mocked(execFile);
+      const args = mock.mock.calls[0][1] as string[];
+      expect(args).toEqual(["kv", "get", "-format=json", "secret/ssh-creds"]);
+    });
+  });
+
+  describe("getMetadata", () => {
+    it("should return metadata without password value", async () => {
+      const vaultResponse = {
+        data: {
+          data: { user: "admin", pass: "secret" },
+        },
+      };
+      mockExecFile(JSON.stringify(vaultResponse));
+
+      const meta = await backend.getMetadata("secret/app#user:pass");
+      expect(meta.username).toBe("admin");
+      expect(meta.has_password).toBe(true);
+      expect(meta.backend).toBe("hashicorp-vault");
+    });
+
+    it("should report has_password false when field missing", async () => {
+      const vaultResponse = {
+        data: {
+          data: { user: "admin" },
+        },
+      };
+      mockExecFile(JSON.stringify(vaultResponse));
+
+      const meta = await backend.getMetadata("secret/app#user:pass");
+      expect(meta.has_password).toBe(false);
+    });
+  });
+
+  describe("cleanup", () => {
+    it("should zero-fill all staged password Buffers", async () => {
+      const vaultResponse = {
+        data: { data: { u: "admin", p: "password123" } },
+      };
+      mockExecFile(JSON.stringify(vaultResponse));
+
+      const result = await backend.getCredential("secret/app#u:p");
+      const pwRef = result.password;
+
+      await backend.cleanup();
+      expect(pwRef.every((byte) => byte === 0)).toBe(true);
+    });
+  });
+});

--- a/test/unit/macos-keychain-backend.test.ts
+++ b/test/unit/macos-keychain-backend.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { MacOsKeychainBackend } from "../../src/credentials/macos-keychain.js";
+
+vi.mock("child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock("../../src/utils/cli-resolver.js", () => ({
+  resolveCliPath: vi.fn(() => "/usr/bin/security"),
+}));
+
+vi.mock("../../src/utils/platform.js", () => ({
+  currentPlatform: vi.fn(() => "darwin"),
+}));
+
+import { execFile } from "child_process";
+import { resolveCliPath } from "../../src/utils/cli-resolver.js";
+import { currentPlatform } from "../../src/utils/platform.js";
+
+function mockExecFile(stdout: string) {
+  const mock = vi.mocked(execFile);
+  mock.mockImplementation(
+    (_cmd: unknown, _args: unknown, _opts: unknown, callback?: (err: Error | null, stdout: string, stderr: string) => void) => {
+      if (typeof _opts === "function") {
+        _opts(null, stdout, "");
+      } else if (callback) {
+        callback(null, stdout, "");
+      }
+      return {} as ReturnType<typeof execFile>;
+    },
+  );
+}
+
+function mockExecFileError(message: string) {
+  const mock = vi.mocked(execFile);
+  mock.mockImplementation(
+    (_cmd: unknown, _args: unknown, _opts: unknown, callback?: (err: Error | null, stdout: string, stderr: string) => void) => {
+      const err = new Error(message);
+      if (typeof _opts === "function") {
+        _opts(err, "", "");
+      } else if (callback) {
+        callback(err, "", "");
+      }
+      return {} as ReturnType<typeof execFile>;
+    },
+  );
+}
+
+describe("MacOsKeychainBackend", () => {
+  let backend: MacOsKeychainBackend;
+
+  beforeEach(() => {
+    backend = new MacOsKeychainBackend();
+    vi.clearAllMocks();
+    vi.mocked(resolveCliPath).mockReturnValue("/usr/bin/security");
+    vi.mocked(currentPlatform).mockReturnValue("darwin");
+  });
+
+  afterEach(async () => {
+    await backend.cleanup();
+  });
+
+  describe("name", () => {
+    it("should be 'macos-keychain'", () => {
+      expect(backend.name).toBe("macos-keychain");
+    });
+  });
+
+  describe("isAvailable", () => {
+    it("should return true on macOS with security CLI", async () => {
+      expect(await backend.isAvailable()).toBe(true);
+    });
+
+    it("should return false on non-macOS platforms", async () => {
+      vi.mocked(currentPlatform).mockReturnValue("linux");
+      expect(await backend.isAvailable()).toBe(false);
+    });
+
+    it("should return false when security CLI not found", async () => {
+      vi.mocked(resolveCliPath).mockImplementation(() => {
+        throw new Error("CLI tool not found: security");
+      });
+      expect(await backend.isAvailable()).toBe(false);
+    });
+  });
+
+  describe("getCredential", () => {
+    it("should return account name as username and password from keychain", async () => {
+      mockExecFile("keychain-password\n");
+
+      const result = await backend.getCredential("my-service:my-account");
+      expect(result.username).toBe("my-account");
+      expect(Buffer.isBuffer(result.password)).toBe(true);
+      expect(result.password.toString("utf-8")).toBe("keychain-password");
+    });
+
+    it("should call security CLI with correct args", async () => {
+      mockExecFile("pass\n");
+
+      await backend.getCredential("sshservice:admin");
+
+      const mock = vi.mocked(execFile);
+      const args = mock.mock.calls[0][1] as string[];
+      expect(args).toEqual([
+        "find-generic-password",
+        "-s",
+        "sshservice",
+        "-a",
+        "admin",
+        "-w",
+      ]);
+    });
+
+    it("should throw on invalid ref format (no colon)", async () => {
+      await expect(
+        backend.getCredential("no-colon"),
+      ).rejects.toThrow("Invalid macOS Keychain ref format");
+    });
+
+    it("should throw on invalid ref format (empty service)", async () => {
+      await expect(
+        backend.getCredential(":account"),
+      ).rejects.toThrow("Invalid macOS Keychain ref format");
+    });
+
+    it("should throw on invalid ref format (empty account)", async () => {
+      await expect(
+        backend.getCredential("service:"),
+      ).rejects.toThrow("Invalid macOS Keychain ref format");
+    });
+  });
+
+  describe("getMetadata", () => {
+    it("should return metadata with has_password true when item found", async () => {
+      mockExecFile("keychain: ...\n");
+
+      const meta = await backend.getMetadata("my-service:my-account");
+      expect(meta.username).toBe("my-account");
+      expect(meta.has_password).toBe(true);
+      expect(meta.backend).toBe("macos-keychain");
+    });
+
+    it("should return has_password false when item not found", async () => {
+      mockExecFileError("The specified item could not be found");
+
+      const meta = await backend.getMetadata("missing:account");
+      expect(meta.has_password).toBe(false);
+    });
+  });
+
+  describe("cleanup", () => {
+    it("should zero-fill all staged password Buffers", async () => {
+      mockExecFile("password123\n");
+
+      const result = await backend.getCredential("svc:acct");
+      const pwRef = result.password;
+
+      await backend.cleanup();
+      expect(pwRef.every((byte) => byte === 0)).toBe(true);
+    });
+  });
+});

--- a/test/unit/onepassword-backend.test.ts
+++ b/test/unit/onepassword-backend.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { OnePasswordBackend } from "../../src/credentials/onepassword.js";
+
+vi.mock("child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock("../../src/utils/cli-resolver.js", () => ({
+  resolveCliPath: vi.fn(() => "/usr/bin/op"),
+}));
+
+import { execFile } from "child_process";
+import { resolveCliPath } from "../../src/utils/cli-resolver.js";
+
+function mockExecFile(stdout: string) {
+  const mock = vi.mocked(execFile);
+  mock.mockImplementation(
+    (_cmd: unknown, _args: unknown, _opts: unknown, callback?: (err: Error | null, stdout: string, stderr: string) => void) => {
+      if (typeof _opts === "function") {
+        _opts(null, stdout, "");
+      } else if (callback) {
+        callback(null, stdout, "");
+      }
+      return {} as ReturnType<typeof execFile>;
+    },
+  );
+}
+
+function mockExecFileError(message: string) {
+  const mock = vi.mocked(execFile);
+  mock.mockImplementation(
+    (_cmd: unknown, _args: unknown, _opts: unknown, callback?: (err: Error | null, stdout: string, stderr: string) => void) => {
+      const err = new Error(message);
+      if (typeof _opts === "function") {
+        _opts(err, "", "");
+      } else if (callback) {
+        callback(err, "", "");
+      }
+      return {} as ReturnType<typeof execFile>;
+    },
+  );
+}
+
+function mockExecFileSequence(responses: Array<{ stdout?: string; error?: string }>) {
+  const mock = vi.mocked(execFile);
+  let callIdx = 0;
+  mock.mockImplementation(
+    (_cmd: unknown, _args: unknown, _opts: unknown, callback?: (err: Error | null, stdout: string, stderr: string) => void) => {
+      const resp = responses[callIdx++] ?? responses[responses.length - 1];
+      const cb = typeof _opts === "function" ? _opts : callback;
+      if (resp.error) {
+        cb?.(new Error(resp.error), "", "");
+      } else {
+        cb?.(null, resp.stdout ?? "", "");
+      }
+      return {} as ReturnType<typeof execFile>;
+    },
+  );
+}
+
+describe("OnePasswordBackend", () => {
+  let backend: OnePasswordBackend;
+
+  beforeEach(() => {
+    backend = new OnePasswordBackend();
+    vi.clearAllMocks();
+    vi.mocked(resolveCliPath).mockReturnValue("/usr/bin/op");
+  });
+
+  afterEach(async () => {
+    await backend.cleanup();
+  });
+
+  describe("name", () => {
+    it("should be 'onepassword'", () => {
+      expect(backend.name).toBe("onepassword");
+    });
+  });
+
+  describe("isAvailable", () => {
+    it("should return true when op CLI is available and signed in", async () => {
+      mockExecFile('{"email":"user@example.com"}');
+      expect(await backend.isAvailable()).toBe(true);
+    });
+
+    it("should return false when op CLI not found", async () => {
+      vi.mocked(resolveCliPath).mockImplementation(() => {
+        throw new Error("CLI tool not found: op");
+      });
+      expect(await backend.isAvailable()).toBe(false);
+    });
+
+    it("should return false when op whoami fails", async () => {
+      mockExecFileError("not signed in");
+      expect(await backend.isAvailable()).toBe(false);
+    });
+  });
+
+  describe("getCredential", () => {
+    it("should return username and password from 1Password", async () => {
+      mockExecFileSequence([
+        { stdout: "admin\n" },
+        { stdout: "s3cret-pass\n" },
+      ]);
+
+      const result = await backend.getCredential(
+        "op://vault/item/username:password",
+      );
+      expect(result.username).toBe("admin");
+      expect(Buffer.isBuffer(result.password)).toBe(true);
+      expect(result.password.toString("utf-8")).toBe("s3cret-pass");
+    });
+
+    it("should call op read with correct field refs", async () => {
+      mockExecFileSequence([
+        { stdout: "user1\n" },
+        { stdout: "pass1\n" },
+      ]);
+
+      await backend.getCredential("op://myvault/myitem/user:pass");
+
+      const mock = vi.mocked(execFile);
+      const call1Args = mock.mock.calls[0][1] as string[];
+      const call2Args = mock.mock.calls[1][1] as string[];
+      expect(call1Args).toEqual(["read", "op://myvault/myitem/user"]);
+      expect(call2Args).toEqual(["read", "op://myvault/myitem/pass"]);
+    });
+
+    it("should throw on invalid ref format (no colon)", async () => {
+      await expect(
+        backend.getCredential("op://vault/item/field"),
+      ).rejects.toThrow("Invalid 1Password ref format");
+    });
+
+    it("should throw on invalid ref format (empty parts)", async () => {
+      await expect(
+        backend.getCredential("op://vault/item/:"),
+      ).rejects.toThrow("Invalid 1Password ref format");
+    });
+  });
+
+  describe("getMetadata", () => {
+    it("should return metadata without password value", async () => {
+      mockExecFile("admin");
+
+      const meta = await backend.getMetadata(
+        "op://vault/item/username:password",
+      );
+      expect(meta.username).toBe("admin");
+      expect(meta.has_password).toBe(true);
+      expect(meta.backend).toBe("onepassword");
+    });
+  });
+
+  describe("cleanup", () => {
+    it("should zero-fill all staged password Buffers", async () => {
+      mockExecFileSequence([
+        { stdout: "user\n" },
+        { stdout: "password123\n" },
+      ]);
+
+      const result = await backend.getCredential(
+        "op://vault/item/user:pass",
+      );
+      const pwRef = result.password;
+      expect(pwRef.toString("utf-8")).toBe("password123");
+
+      await backend.cleanup();
+      expect(pwRef.every((byte) => byte === 0)).toBe(true);
+    });
+  });
+});

--- a/test/unit/windows-credential-backend.test.ts
+++ b/test/unit/windows-credential-backend.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { WindowsCredentialBackend } from "../../src/credentials/windows-credential.js";
+
+vi.mock("child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock("../../src/utils/platform.js", () => ({
+  currentPlatform: vi.fn(() => "win32"),
+}));
+
+import { execFile } from "child_process";
+import { currentPlatform } from "../../src/utils/platform.js";
+
+function mockExecFile(stdout: string) {
+  const mock = vi.mocked(execFile);
+  mock.mockImplementation(
+    (_cmd: unknown, _args: unknown, _opts: unknown, callback?: (err: Error | null, stdout: string, stderr: string) => void) => {
+      if (typeof _opts === "function") {
+        _opts(null, stdout, "");
+      } else if (callback) {
+        callback(null, stdout, "");
+      }
+      return {} as ReturnType<typeof execFile>;
+    },
+  );
+}
+
+function mockExecFileError(message: string) {
+  const mock = vi.mocked(execFile);
+  mock.mockImplementation(
+    (_cmd: unknown, _args: unknown, _opts: unknown, callback?: (err: Error | null, stdout: string, stderr: string) => void) => {
+      const err = new Error(message);
+      if (typeof _opts === "function") {
+        _opts(err, "", "");
+      } else if (callback) {
+        callback(err, "", "");
+      }
+      return {} as ReturnType<typeof execFile>;
+    },
+  );
+}
+
+describe("WindowsCredentialBackend", () => {
+  let backend: WindowsCredentialBackend;
+
+  beforeEach(() => {
+    backend = new WindowsCredentialBackend();
+    vi.clearAllMocks();
+    vi.mocked(currentPlatform).mockReturnValue("win32");
+  });
+
+  afterEach(async () => {
+    await backend.cleanup();
+  });
+
+  describe("name", () => {
+    it("should be 'windows-credential'", () => {
+      expect(backend.name).toBe("windows-credential");
+    });
+  });
+
+  describe("isAvailable", () => {
+    it("should return true on Windows with cmdkey", async () => {
+      mockExecFile("Currently stored credentials:\n");
+      expect(await backend.isAvailable()).toBe(true);
+    });
+
+    it("should return false on non-Windows platforms", async () => {
+      vi.mocked(currentPlatform).mockReturnValue("linux");
+      expect(await backend.isAvailable()).toBe(false);
+    });
+
+    it("should return false when cmdkey fails", async () => {
+      mockExecFileError("cmdkey not found");
+      expect(await backend.isAvailable()).toBe(false);
+    });
+  });
+
+  describe("getCredential", () => {
+    it("should return username and password from Windows Credential Manager", async () => {
+      mockExecFile("DOMAIN\\admin|win-secret\n");
+
+      const result = await backend.getCredential("my-target");
+      expect(result.username).toBe("DOMAIN\\admin");
+      expect(Buffer.isBuffer(result.password)).toBe(true);
+      expect(result.password.toString("utf-8")).toBe("win-secret");
+    });
+
+    it("should throw on empty ref", async () => {
+      await expect(backend.getCredential("")).rejects.toThrow(
+        "Invalid Windows Credential ref",
+      );
+    });
+
+    it("should throw on whitespace-only ref", async () => {
+      await expect(backend.getCredential("   ")).rejects.toThrow(
+        "Invalid Windows Credential ref",
+      );
+    });
+
+    it("should call powershell with correct arguments", async () => {
+      mockExecFile("user|pass\n");
+
+      await backend.getCredential("my-target");
+
+      const mock = vi.mocked(execFile);
+      const cmd = mock.mock.calls[0][0] as string;
+      const args = mock.mock.calls[0][1] as string[];
+      expect(cmd).toBe("powershell");
+      expect(args[0]).toBe("-NoProfile");
+      expect(args[1]).toBe("-NonInteractive");
+      expect(args[2]).toBe("-Command");
+    });
+  });
+
+  describe("getMetadata", () => {
+    it("should return has_password true when target found in cmdkey list", async () => {
+      mockExecFile("Currently stored credentials:\n  Target: my-target\n");
+
+      const meta = await backend.getMetadata("my-target");
+      expect(meta.has_password).toBe(true);
+      expect(meta.backend).toBe("windows-credential");
+    });
+
+    it("should return has_password false when target not found", async () => {
+      mockExecFile("Currently stored credentials:\n  Target: other-target\n");
+
+      const meta = await backend.getMetadata("my-target");
+      expect(meta.has_password).toBe(false);
+    });
+
+    it("should return has_password false when cmdkey fails", async () => {
+      mockExecFileError("cmdkey error");
+
+      const meta = await backend.getMetadata("my-target");
+      expect(meta.has_password).toBe(false);
+    });
+  });
+
+  describe("cleanup", () => {
+    it("should zero-fill all staged password Buffers", async () => {
+      mockExecFile("user|password123\n");
+
+      const result = await backend.getCredential("test-target");
+      const pwRef = result.password;
+
+      await backend.cleanup();
+      expect(pwRef.every((byte) => byte === 0)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Closes #86

## Summary

5 new credential backends — meet users where their secrets already live.

## New backends

| Backend | Ref format | Prerequisite |
|---------|-----------|--------------|
| `onepassword` | `op://vault/item/user_field:pass_field` | `op` CLI signed in |
| `hashicorp-vault` | `secret/path#user_field:pass_field` | `VAULT_ADDR` + `VAULT_TOKEN` |
| `aws-secretsmanager` | `secret-name#user_key:pass_key` | AWS credentials in env/IMDS |
| `macos-keychain` | `service-name:account-name` | macOS only (`security` CLI) |
| `windows-credential` | `target-name` | Windows only (`cmdkey`) |

All backends implement `checkHealth()` with specific diagnostics (e.g. `op not found in PATH`, `VAULT_ADDR not set`, `not macOS`).

## Changes
- 5 new backend files in `src/credentials/`
- `src/credentials/registry.ts` — all 5 registered alongside existing backends
- 5 new test files in `test/unit/`

## Tests
✅ 266 tests pass (+50 new)