### PR TITLE
feat: SSH port forwarding (-L, -R, -D)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,12 @@ import { credentialListBackends } from './tools/credential-list.js';
 import { sshCheckHost } from './tools/ssh-check.js';
 import { versionCheck } from './tools/version-check.js';
 import { credentialDiagnose } from './tools/credential-diagnose.js';
+import { sshForwardLocal } from './tools/ssh-forward-local.js';
+import { sshForwardRemote } from './tools/ssh-forward-remote.js';
+import { sshForwardDynamic } from './tools/ssh-forward-dynamic.js';
+import { sshForwardClose } from './tools/ssh-forward-close.js';
+import { sshForwardList } from './tools/ssh-forward-list.js';
+import { destroyAllForwards } from './ssh/forward-manager.js';
 import { CredentialRegistry } from './credentials/registry.js';
 import { CredentialMap } from './credentials/credential-map.js';
 import { BitwardenBackend } from './credentials/bitwarden.js';
@@ -69,11 +75,11 @@ registry.register(new SshAgentBackend());
 const sessionStore = new SessionStore();
 const credentialMap = new CredentialMap();
 
-// Graceful shutdown: destroy all sessions before exiting
-const shutdown = () => { sessionStore.destroy(); process.exit(0); };
+// Graceful shutdown: destroy all sessions and forwards before exiting
+const shutdown = () => { destroyAllForwards(); sessionStore.destroy(); process.exit(0); };
 process.once('SIGINT', shutdown);
 process.once('SIGTERM', shutdown);
-process.on('exit', () => sessionStore.destroy());
+process.on('exit', () => { destroyAllForwards(); sessionStore.destroy(); });
 
 // ── ssh_execute ──────────────────────────────────────────────────────────────
 server.tool(
@@ -303,6 +309,126 @@ server.tool(
       return {
         content: [{ type: 'text' as const, text: JSON.stringify({ success: true, path: credentialMap.getFilePath() }) }],
       };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── ssh_forward_local ─────────────────────────────────────────────────────────
+server.tool(
+  'ssh_forward_local',
+  'Start a local SSH port forward (-L). Binds a local port and tunnels traffic to a remote host:port through the SSH server. Uses key/agent auth (BatchMode).',
+  {
+    host: z.string().describe('SSH server hostname or IP address'),
+    local_port: z.number().int().min(1).max(65535).describe('Local port to bind'),
+    remote_host: z.string().describe('Remote host to forward traffic to (as seen from SSH server)'),
+    remote_port: z.number().int().min(1).max(65535).describe('Remote port to forward traffic to'),
+    username: z.string().optional().describe('SSH username'),
+    credential_backend: z.string().optional().describe('Credential backend name'),
+    credential_ref: z.string().optional().describe('Credential reference string'),
+    idle_timeout_seconds: z.number().int().positive().optional().describe('Max lifetime in seconds before auto-close (default: 3600)'),
+    use_ssh_config: z.boolean().optional().describe('Honor ~/.ssh/config (default: true)'),
+  },
+  async (input) => {
+    try {
+      const result = await sshForwardLocal(registry, input, credentialMap);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── ssh_forward_remote ───────────────────────────────────────────────────────
+server.tool(
+  'ssh_forward_remote',
+  'Start a remote SSH port forward (-R). Binds a port on the SSH server and tunnels traffic back to a local host:port. Uses key/agent auth (BatchMode).',
+  {
+    host: z.string().describe('SSH server hostname or IP address'),
+    remote_port: z.number().int().min(1).max(65535).describe('Remote port to bind on SSH server'),
+    local_host: z.string().describe('Local host to forward traffic to'),
+    local_port: z.number().int().min(1).max(65535).describe('Local port to forward traffic to'),
+    username: z.string().optional().describe('SSH username'),
+    credential_backend: z.string().optional().describe('Credential backend name'),
+    credential_ref: z.string().optional().describe('Credential reference string'),
+    idle_timeout_seconds: z.number().int().positive().optional().describe('Max lifetime in seconds before auto-close (default: 3600)'),
+    use_ssh_config: z.boolean().optional().describe('Honor ~/.ssh/config (default: true)'),
+  },
+  async (input) => {
+    try {
+      const result = await sshForwardRemote(registry, input, credentialMap);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── ssh_forward_dynamic ──────────────────────────────────────────────────────
+server.tool(
+  'ssh_forward_dynamic',
+  'Start a dynamic SOCKS proxy SSH forward (-D). Binds a local port as a SOCKS proxy through the SSH server. Uses key/agent auth (BatchMode).',
+  {
+    host: z.string().describe('SSH server hostname or IP address'),
+    local_port: z.number().int().min(1).max(65535).describe('Local port to bind as SOCKS proxy'),
+    username: z.string().optional().describe('SSH username'),
+    credential_backend: z.string().optional().describe('Credential backend name'),
+    credential_ref: z.string().optional().describe('Credential reference string'),
+    idle_timeout_seconds: z.number().int().positive().optional().describe('Max lifetime in seconds before auto-close (default: 3600)'),
+    use_ssh_config: z.boolean().optional().describe('Honor ~/.ssh/config (default: true)'),
+  },
+  async (input) => {
+    try {
+      const result = await sshForwardDynamic(registry, input, credentialMap);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── ssh_forward_close ────────────────────────────────────────────────────────
+server.tool(
+  'ssh_forward_close',
+  'Close an active SSH port forward.',
+  {
+    forward_id: z.string().describe('Forward ID returned by ssh_forward_local/remote/dynamic'),
+  },
+  async (input) => {
+    try {
+      const result = sshForwardClose(input);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── ssh_forward_list ─────────────────────────────────────────────────────────
+server.tool(
+  'ssh_forward_list',
+  'List all active SSH port forwards with their status and configuration.',
+  {},
+  async () => {
+    try {
+      const result = sshForwardList();
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
     } catch (err: unknown) {
       return {
         content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],

--- a/src/ssh/forward-manager.ts
+++ b/src/ssh/forward-manager.ts
@@ -1,0 +1,388 @@
+/**
+ * SSH port forward manager — spawns and tracks background ssh -N processes
+ * for local (-L), remote (-R), and dynamic (-D) port forwarding.
+ *
+ * Uses BatchMode=yes + ExitOnForwardFailure=yes so that forwarding is
+ * limited to key/agent-based authentication (no interactive password prompts).
+ */
+
+import { spawn, type ChildProcess } from 'child_process';
+import { randomUUID } from 'crypto';
+import { resolveSshBin } from '../utils/cli-resolver.js';
+import { resolveSshConfig } from './ssh-config-reader.js';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type ForwardType = 'local' | 'remote' | 'dynamic';
+
+export interface ForwardEntry {
+  forward_id: string;
+  type: ForwardType;
+  host: string;
+  status: 'active' | 'closed';
+  local_port: number;
+  remote_host?: string;
+  remote_port?: number;
+  created_at: string;
+}
+
+interface InternalForwardEntry extends ForwardEntry {
+  process: ChildProcess;
+  timeout_timer: ReturnType<typeof setTimeout> | null;
+  stderr_buffer: string;
+}
+
+export interface ForwardLocalInput {
+  host: string;
+  local_port: number;
+  remote_host: string;
+  remote_port: number;
+  username?: string;
+  credential_backend?: string;
+  credential_ref?: string;
+  idle_timeout_seconds?: number;
+  use_ssh_config?: boolean;
+}
+
+export interface ForwardRemoteInput {
+  host: string;
+  remote_port: number;
+  local_host: string;
+  local_port: number;
+  username?: string;
+  credential_backend?: string;
+  credential_ref?: string;
+  idle_timeout_seconds?: number;
+  use_ssh_config?: boolean;
+}
+
+export interface ForwardDynamicInput {
+  host: string;
+  local_port: number;
+  username?: string;
+  credential_backend?: string;
+  credential_ref?: string;
+  idle_timeout_seconds?: number;
+  use_ssh_config?: boolean;
+}
+
+export interface ForwardResult {
+  forward_id: string;
+  status: 'active' | 'closed';
+  local_port: number;
+  remote_host?: string;
+  remote_port?: number;
+}
+
+// ── Forward store ────────────────────────────────────────────────────────────
+
+const forwards = new Map<string, InternalForwardEntry>();
+
+// Exposed for testing: allow injecting a custom spawn function
+export type SpawnFn = typeof spawn;
+let _spawnFn: SpawnFn = spawn;
+
+export function _setSpawnFn(fn: SpawnFn): void {
+  _spawnFn = fn;
+}
+export function _resetSpawnFn(): void {
+  _spawnFn = spawn;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function buildFilteredEnv(): Record<string, string> {
+  return {
+    HOME: process.env.HOME ?? process.env.USERPROFILE ?? '',
+    PATH: process.env.PATH ?? '',
+    USERPROFILE: process.env.USERPROFILE ?? '',
+    HOMEDRIVE: process.env.HOMEDRIVE ?? '',
+    HOMEPATH: process.env.HOMEPATH ?? '',
+    SystemRoot: process.env.SystemRoot ?? '',
+    SSH_AUTH_SOCK: process.env.SSH_AUTH_SOCK ?? '',
+  };
+}
+
+function finalizeForward(id: string): void {
+  const entry = forwards.get(id);
+  if (!entry) return;
+
+  if (entry.timeout_timer) {
+    clearTimeout(entry.timeout_timer);
+    entry.timeout_timer = null;
+  }
+
+  entry.status = 'closed';
+
+  try {
+    if (entry.process.pid && !entry.process.killed) {
+      entry.process.kill('SIGTERM');
+    }
+  } catch {
+    // Process may already be dead
+  }
+
+  forwards.delete(id);
+}
+
+/**
+ * Resolve username from credential inputs and SSH config.
+ * Returns the resolved username (may be empty if none found).
+ */
+async function resolveUsername(
+  input: { host: string; username?: string; credential_ref?: string; credential_backend?: string; use_ssh_config?: boolean },
+  registry?: { getBackend(name: string): { isAvailable(): Promise<boolean>; getCredential(ref: string): Promise<{ username: string; password: Buffer }>; cleanup(): Promise<void> } },
+  credentialMap?: { resolve(host: string): { backend: string; ref?: string; username?: string } | null },
+): Promise<string> {
+  let { credential_ref, credential_backend } = input;
+  let mappedUsername: string | undefined;
+
+  // Credential map fallback
+  if (credential_backend === undefined && credential_ref === undefined && credentialMap) {
+    const mapped = credentialMap.resolve(input.host);
+    if (mapped) {
+      credential_backend = mapped.backend;
+      credential_ref = mapped.ref;
+      mappedUsername = mapped.username;
+    }
+  }
+
+  // Resolve username from credential backend (username only, no password for forwarding)
+  let credentialUsername: string | undefined;
+  if (credential_ref !== undefined && registry) {
+    const backendName = credential_backend ?? 'google-secret-manager';
+    const backend = registry.getBackend(backendName);
+    try {
+      const available = await backend.isAvailable();
+      if (available) {
+        const cred = await backend.getCredential(credential_ref);
+        credentialUsername = cred.username || undefined;
+        // Zero password immediately — we don't use passwords for forwarding
+        cred.password.fill(0);
+      }
+    } finally {
+      await backend.cleanup();
+    }
+  }
+
+  // Priority: explicit username > credential username > mapped username > ssh config
+  let resolvedUsername = input.username ?? credentialUsername ?? mappedUsername ?? '';
+
+  if (!resolvedUsername && (input.use_ssh_config ?? true)) {
+    const config = await resolveSshConfig(input.host);
+    if (config?.user) {
+      resolvedUsername = config.user;
+    }
+  }
+
+  return resolvedUsername;
+}
+
+// ── Core operations ──────────────────────────────────────────────────────────
+
+/**
+ * Start a local port forward (-L local_port:remote_host:remote_port).
+ */
+export async function startLocalForward(
+  input: ForwardLocalInput,
+  registry?: Parameters<typeof resolveUsername>[1],
+  credentialMap?: Parameters<typeof resolveUsername>[2],
+): Promise<ForwardResult> {
+  const username = await resolveUsername(input, registry, credentialMap);
+  const forwardSpec = `${input.local_port}:${input.remote_host}:${input.remote_port}`;
+  return startForwardProcess('local', input.host, username, ['-L', forwardSpec], {
+    local_port: input.local_port,
+    remote_host: input.remote_host,
+    remote_port: input.remote_port,
+    idle_timeout_seconds: input.idle_timeout_seconds,
+    use_ssh_config: input.use_ssh_config,
+  });
+}
+
+/**
+ * Start a remote port forward (-R remote_port:local_host:local_port).
+ */
+export async function startRemoteForward(
+  input: ForwardRemoteInput,
+  registry?: Parameters<typeof resolveUsername>[1],
+  credentialMap?: Parameters<typeof resolveUsername>[2],
+): Promise<ForwardResult> {
+  const username = await resolveUsername(input, registry, credentialMap);
+  const forwardSpec = `${input.remote_port}:${input.local_host}:${input.local_port}`;
+  return startForwardProcess('remote', input.host, username, ['-R', forwardSpec], {
+    local_port: input.local_port,
+    remote_host: input.local_host,
+    remote_port: input.remote_port,
+    idle_timeout_seconds: input.idle_timeout_seconds,
+    use_ssh_config: input.use_ssh_config,
+  });
+}
+
+/**
+ * Start a dynamic SOCKS forward (-D local_port).
+ */
+export async function startDynamicForward(
+  input: ForwardDynamicInput,
+  registry?: Parameters<typeof resolveUsername>[1],
+  credentialMap?: Parameters<typeof resolveUsername>[2],
+): Promise<ForwardResult> {
+  const username = await resolveUsername(input, registry, credentialMap);
+  return startForwardProcess('dynamic', input.host, username, ['-D', String(input.local_port)], {
+    local_port: input.local_port,
+    idle_timeout_seconds: input.idle_timeout_seconds,
+    use_ssh_config: input.use_ssh_config,
+  });
+}
+
+async function startForwardProcess(
+  type: ForwardType,
+  host: string,
+  username: string,
+  forwardArgs: string[],
+  opts: {
+    local_port: number;
+    remote_host?: string;
+    remote_port?: number;
+    idle_timeout_seconds?: number;
+    use_ssh_config?: boolean;
+  },
+): Promise<ForwardResult> {
+  const sshBin = await resolveSshBin();
+  const timeoutSeconds = opts.idle_timeout_seconds ?? 3600;
+
+  const args: string[] = [
+    '-N',                           // No remote command
+    '-o', 'BatchMode=yes',          // No interactive prompts
+    '-o', 'ExitOnForwardFailure=yes', // Fail if forward can't be established
+    '-o', 'StrictHostKeyChecking=accept-new',
+    ...forwardArgs,
+  ];
+
+  if (username) {
+    args.push('-l', username);
+  }
+
+  if (opts.use_ssh_config === false) {
+    args.push('-F', '/dev/null');
+  }
+
+  args.push('--', host);
+
+  const forward_id = randomUUID();
+
+  const child = _spawnFn(sshBin, args, {
+    stdio: ['ignore', 'ignore', 'pipe'],
+    env: buildFilteredEnv(),
+    detached: false,
+  });
+
+  // Accumulate stderr (bounded)
+  let stderrBuf = '';
+  if (child.stderr) {
+    child.stderr.on('data', (chunk: Buffer) => {
+      if (stderrBuf.length < 4096) {
+        stderrBuf += chunk.toString('utf-8').slice(0, 4096 - stderrBuf.length);
+      }
+    });
+  }
+
+  const entry: InternalForwardEntry = {
+    forward_id,
+    type,
+    host,
+    status: 'active',
+    local_port: opts.local_port,
+    remote_host: opts.remote_host,
+    remote_port: opts.remote_port,
+    created_at: new Date().toISOString(),
+    process: child,
+    timeout_timer: null,
+    stderr_buffer: '',
+  };
+
+  forwards.set(forward_id, entry);
+
+  // Auto-close on process exit
+  child.on('close', () => {
+    entry.stderr_buffer = stderrBuf;
+    finalizeForward(forward_id);
+  });
+
+  // Wait briefly for the process to stabilize (catch immediate failures)
+  const startupError = await new Promise<string | null>((resolve) => {
+    const stabilize = setTimeout(() => {
+      resolve(null);
+    }, 500);
+
+    child.on('close', (code) => {
+      clearTimeout(stabilize);
+      resolve(stderrBuf || `ssh exited with code ${code}`);
+    });
+
+    child.on('error', (err) => {
+      clearTimeout(stabilize);
+      resolve(err.message);
+    });
+  });
+
+  if (startupError) {
+    finalizeForward(forward_id);
+    throw new Error(`Forward failed: ${startupError}`);
+  }
+
+  // Set max lifetime timer
+  if (timeoutSeconds > 0) {
+    entry.timeout_timer = setTimeout(() => {
+      finalizeForward(forward_id);
+    }, timeoutSeconds * 1000);
+    // Don't prevent Node from exiting
+    if (entry.timeout_timer && typeof entry.timeout_timer === 'object' && 'unref' in entry.timeout_timer) {
+      entry.timeout_timer.unref();
+    }
+  }
+
+  return {
+    forward_id,
+    status: 'active',
+    local_port: opts.local_port,
+    remote_host: opts.remote_host,
+    remote_port: opts.remote_port,
+  };
+}
+
+/**
+ * Close an active forward by ID.
+ */
+export function closeForward(forward_id: string): { forward_id: string; status: 'closed' } {
+  const entry = forwards.get(forward_id);
+  if (!entry) {
+    throw new Error(`No active forward with id: ${forward_id}`);
+  }
+  finalizeForward(forward_id);
+  return { forward_id, status: 'closed' };
+}
+
+/**
+ * List all active forwards.
+ */
+export function listForwards(): ForwardEntry[] {
+  return Array.from(forwards.values()).map((e) => ({
+    forward_id: e.forward_id,
+    type: e.type,
+    host: e.host,
+    status: e.status,
+    local_port: e.local_port,
+    remote_host: e.remote_host,
+    remote_port: e.remote_port,
+    created_at: e.created_at,
+  }));
+}
+
+/**
+ * Destroy all active forwards — used during shutdown.
+ */
+export function destroyAllForwards(): void {
+  for (const id of Array.from(forwards.keys())) {
+    finalizeForward(id);
+  }
+}

--- a/src/tools/ssh-forward-close.ts
+++ b/src/tools/ssh-forward-close.ts
@@ -1,0 +1,14 @@
+/**
+ * ssh_forward_close tool handler — closes an active SSH port forward.
+ */
+
+import { closeForward } from '../ssh/forward-manager.js';
+
+export interface SshForwardCloseInput {
+  forward_id: string;
+}
+
+export function sshForwardClose(input: SshForwardCloseInput): { forward_id: string; status: 'closed' } {
+  if (!input.forward_id) throw new Error('forward_id is required');
+  return closeForward(input.forward_id);
+}

--- a/src/tools/ssh-forward-dynamic.ts
+++ b/src/tools/ssh-forward-dynamic.ts
@@ -1,0 +1,26 @@
+/**
+ * ssh_forward_dynamic tool handler — starts a dynamic (-D) SOCKS proxy SSH forward.
+ */
+
+import type { CredentialRegistry } from '../credentials/registry.js';
+import type { CredentialMap } from '../credentials/credential-map.js';
+import { startDynamicForward, type ForwardResult } from '../ssh/forward-manager.js';
+
+export interface SshForwardDynamicInput {
+  host: string;
+  local_port: number;
+  username?: string;
+  credential_backend?: string;
+  credential_ref?: string;
+  idle_timeout_seconds?: number;
+  use_ssh_config?: boolean;
+}
+
+export async function sshForwardDynamic(
+  registry: CredentialRegistry,
+  input: SshForwardDynamicInput,
+  credentialMap: CredentialMap,
+): Promise<ForwardResult> {
+  if (!input.host) throw new Error('host is required');
+  return startDynamicForward(input, registry, credentialMap);
+}

--- a/src/tools/ssh-forward-list.ts
+++ b/src/tools/ssh-forward-list.ts
@@ -1,0 +1,9 @@
+/**
+ * ssh_forward_list tool handler — lists all active SSH port forwards.
+ */
+
+import { listForwards, type ForwardEntry } from '../ssh/forward-manager.js';
+
+export function sshForwardList(): ForwardEntry[] {
+  return listForwards();
+}

--- a/src/tools/ssh-forward-local.ts
+++ b/src/tools/ssh-forward-local.ts
@@ -1,0 +1,28 @@
+/**
+ * ssh_forward_local tool handler — starts a local (-L) SSH port forward.
+ */
+
+import type { CredentialRegistry } from '../credentials/registry.js';
+import type { CredentialMap } from '../credentials/credential-map.js';
+import { startLocalForward, type ForwardResult } from '../ssh/forward-manager.js';
+
+export interface SshForwardLocalInput {
+  host: string;
+  local_port: number;
+  remote_host: string;
+  remote_port: number;
+  username?: string;
+  credential_backend?: string;
+  credential_ref?: string;
+  idle_timeout_seconds?: number;
+  use_ssh_config?: boolean;
+}
+
+export async function sshForwardLocal(
+  registry: CredentialRegistry,
+  input: SshForwardLocalInput,
+  credentialMap: CredentialMap,
+): Promise<ForwardResult> {
+  if (!input.host) throw new Error('host is required');
+  return startLocalForward(input, registry, credentialMap);
+}

--- a/src/tools/ssh-forward-remote.ts
+++ b/src/tools/ssh-forward-remote.ts
@@ -1,0 +1,28 @@
+/**
+ * ssh_forward_remote tool handler — starts a remote (-R) SSH port forward.
+ */
+
+import type { CredentialRegistry } from '../credentials/registry.js';
+import type { CredentialMap } from '../credentials/credential-map.js';
+import { startRemoteForward, type ForwardResult } from '../ssh/forward-manager.js';
+
+export interface SshForwardRemoteInput {
+  host: string;
+  remote_port: number;
+  local_host: string;
+  local_port: number;
+  username?: string;
+  credential_backend?: string;
+  credential_ref?: string;
+  idle_timeout_seconds?: number;
+  use_ssh_config?: boolean;
+}
+
+export async function sshForwardRemote(
+  registry: CredentialRegistry,
+  input: SshForwardRemoteInput,
+  credentialMap: CredentialMap,
+): Promise<ForwardResult> {
+  if (!input.host) throw new Error('host is required');
+  return startRemoteForward(input, registry, credentialMap);
+}

--- a/test/unit/port-forward.test.ts
+++ b/test/unit/port-forward.test.ts
@@ -1,0 +1,385 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+import type { ChildProcess } from 'child_process';
+
+// ---------------------------------------------------------------------------
+// Mock child_process.spawn
+// ---------------------------------------------------------------------------
+const spawnMock = vi.fn();
+vi.mock('child_process', () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+  execFile: vi.fn(),
+}));
+
+// Mock resolveSshBin
+vi.mock('../../src/utils/cli-resolver.js', () => ({
+  resolveSshBin: vi.fn().mockResolvedValue('/usr/bin/ssh'),
+  resolveCliPath: vi.fn().mockReturnValue('/usr/bin/ssh'),
+}));
+
+// Mock resolveSshConfig
+vi.mock('../../src/ssh/ssh-config-reader.js', () => ({
+  resolveSshConfig: vi.fn().mockResolvedValue(null),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Creates a fake ChildProcess that stays alive (doesn't auto-close). */
+function makeFakeChild(): ChildProcess & EventEmitter {
+  const child = new EventEmitter() as ChildProcess & EventEmitter;
+  const stderr = new EventEmitter();
+  Object.assign(child, {
+    pid: 12345,
+    killed: false,
+    stdin: null,
+    stdout: null,
+    stderr,
+    stdio: [null, null, stderr],
+    exitCode: null,
+    signalCode: null,
+    connected: false,
+    channel: undefined,
+    send: vi.fn(),
+    disconnect: vi.fn(),
+    unref: vi.fn(),
+    ref: vi.fn(),
+    [Symbol.dispose]: vi.fn(),
+    kill: vi.fn(function (this: { killed: boolean }) {
+      this.killed = true;
+      return true;
+    }),
+  });
+  return child;
+}
+
+/** Creates a fake child that exits immediately with given code. */
+function makeFakeChildExiting(code: number, stderrMsg?: string): ChildProcess & EventEmitter {
+  const child = makeFakeChild();
+  // Schedule exit on next tick so spawn can return first
+  setImmediate(() => {
+    if (stderrMsg && child.stderr) {
+      child.stderr.emit('data', Buffer.from(stderrMsg));
+    }
+    child.emit('close', code);
+  });
+  return child;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SSH port forwarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(async () => {
+    // Clean up any active forwards
+    const { destroyAllForwards } = await import('../../src/ssh/forward-manager.js');
+    destroyAllForwards();
+    vi.useRealTimers();
+  });
+
+  // ── Local forward (-L) ─────────────────────────────────────────────────
+
+  describe('ssh_forward_local', () => {
+    it('spawns ssh with correct -L args', async () => {
+      const child = makeFakeChild();
+      spawnMock.mockReturnValue(child);
+
+      const { startLocalForward } = await import('../../src/ssh/forward-manager.js');
+      const resultP = startLocalForward({
+        host: 'bastion.example.com',
+        local_port: 8080,
+        remote_host: 'db.internal',
+        remote_port: 5432,
+        username: 'admin',
+      });
+
+      // Let the 500ms stabilization timer pass
+      await vi.advanceTimersByTimeAsync(600);
+      const result = await resultP;
+
+      expect(result.status).toBe('active');
+      expect(result.local_port).toBe(8080);
+      expect(result.remote_host).toBe('db.internal');
+      expect(result.remote_port).toBe(5432);
+      expect(result.forward_id).toBeTruthy();
+
+      // Verify spawn args
+      const [bin, args] = spawnMock.mock.calls[0];
+      expect(bin).toBe('/usr/bin/ssh');
+      expect(args).toContain('-N');
+      expect(args).toContain('-L');
+      expect(args).toContain('8080:db.internal:5432');
+      expect(args).toContain('-l');
+      expect(args).toContain('admin');
+      expect(args).toContain('--');
+      expect(args).toContain('bastion.example.com');
+      expect(args).toContain('BatchMode=yes');
+      expect(args).toContain('ExitOnForwardFailure=yes');
+    });
+
+    it('fails when ssh exits immediately', async () => {
+      const child = makeFakeChildExiting(255, 'Connection refused');
+      spawnMock.mockReturnValue(child);
+
+      const { startLocalForward } = await import('../../src/ssh/forward-manager.js');
+
+      await expect(
+        startLocalForward({
+          host: 'bad.example.com',
+          local_port: 8080,
+          remote_host: 'db.internal',
+          remote_port: 5432,
+        })
+      ).rejects.toThrow(/Forward failed/);
+    });
+  });
+
+  // ── Remote forward (-R) ────────────────────────────────────────────────
+
+  describe('ssh_forward_remote', () => {
+    it('spawns ssh with correct -R args', async () => {
+      const child = makeFakeChild();
+      spawnMock.mockReturnValue(child);
+
+      const { startRemoteForward } = await import('../../src/ssh/forward-manager.js');
+      const resultP = startRemoteForward({
+        host: 'gateway.example.com',
+        remote_port: 9090,
+        local_host: 'localhost',
+        local_port: 3000,
+        username: 'deploy',
+      });
+
+      await vi.advanceTimersByTimeAsync(600);
+      const result = await resultP;
+
+      expect(result.status).toBe('active');
+      expect(result.local_port).toBe(3000);
+      expect(result.remote_port).toBe(9090);
+
+      const [, args] = spawnMock.mock.calls[0];
+      expect(args).toContain('-R');
+      expect(args).toContain('9090:localhost:3000');
+      expect(args).toContain('-l');
+      expect(args).toContain('deploy');
+      expect(args).toContain('gateway.example.com');
+    });
+  });
+
+  // ── Dynamic forward (-D) ──────────────────────────────────────────────
+
+  describe('ssh_forward_dynamic', () => {
+    it('spawns ssh with correct -D args', async () => {
+      const child = makeFakeChild();
+      spawnMock.mockReturnValue(child);
+
+      const { startDynamicForward } = await import('../../src/ssh/forward-manager.js');
+      const resultP = startDynamicForward({
+        host: 'proxy.example.com',
+        local_port: 1080,
+        username: 'socksuser',
+      });
+
+      await vi.advanceTimersByTimeAsync(600);
+      const result = await resultP;
+
+      expect(result.status).toBe('active');
+      expect(result.local_port).toBe(1080);
+      expect(result.remote_host).toBeUndefined();
+      expect(result.remote_port).toBeUndefined();
+
+      const [, args] = spawnMock.mock.calls[0];
+      expect(args).toContain('-D');
+      expect(args).toContain('1080');
+      expect(args).toContain('proxy.example.com');
+    });
+  });
+
+  // ── List ───────────────────────────────────────────────────────────────
+
+  describe('ssh_forward_list', () => {
+    it('returns all active forwards', async () => {
+      const child1 = makeFakeChild();
+      const child2 = makeFakeChild();
+      spawnMock.mockReturnValueOnce(child1).mockReturnValueOnce(child2);
+
+      const { startLocalForward, startDynamicForward, listForwards } = await import(
+        '../../src/ssh/forward-manager.js'
+      );
+
+      const p1 = startLocalForward({
+        host: 'host1.example.com',
+        local_port: 8080,
+        remote_host: 'db.internal',
+        remote_port: 5432,
+      });
+      await vi.advanceTimersByTimeAsync(600);
+      await p1;
+
+      const p2 = startDynamicForward({
+        host: 'host2.example.com',
+        local_port: 1080,
+      });
+      await vi.advanceTimersByTimeAsync(600);
+      await p2;
+
+      const list = listForwards();
+      expect(list).toHaveLength(2);
+      expect(list[0].type).toBe('local');
+      expect(list[1].type).toBe('dynamic');
+      expect(list.every((e) => e.status === 'active')).toBe(true);
+    });
+
+    it('returns empty array when no forwards', async () => {
+      const { listForwards } = await import('../../src/ssh/forward-manager.js');
+      expect(listForwards()).toEqual([]);
+    });
+  });
+
+  // ── Close ──────────────────────────────────────────────────────────────
+
+  describe('ssh_forward_close', () => {
+    it('kills process and removes entry', async () => {
+      const child = makeFakeChild();
+      spawnMock.mockReturnValue(child);
+
+      const { startLocalForward, closeForward, listForwards } = await import(
+        '../../src/ssh/forward-manager.js'
+      );
+
+      const resultP = startLocalForward({
+        host: 'host.example.com',
+        local_port: 8080,
+        remote_host: 'db.internal',
+        remote_port: 5432,
+      });
+      await vi.advanceTimersByTimeAsync(600);
+      const result = await resultP;
+
+      expect(listForwards()).toHaveLength(1);
+
+      const closeResult = closeForward(result.forward_id);
+      expect(closeResult.status).toBe('closed');
+      expect(child.kill).toHaveBeenCalled();
+      expect(listForwards()).toHaveLength(0);
+    });
+
+    it('throws for unknown forward_id', async () => {
+      const { closeForward } = await import('../../src/ssh/forward-manager.js');
+      expect(() => closeForward('nonexistent-id')).toThrow(/No active forward/);
+    });
+
+    it('is idempotent via destroyAllForwards', async () => {
+      const child = makeFakeChild();
+      spawnMock.mockReturnValue(child);
+
+      const { startLocalForward, destroyAllForwards, listForwards } = await import(
+        '../../src/ssh/forward-manager.js'
+      );
+
+      const resultP = startLocalForward({
+        host: 'host.example.com',
+        local_port: 8080,
+        remote_host: 'db.internal',
+        remote_port: 5432,
+      });
+      await vi.advanceTimersByTimeAsync(600);
+      await resultP;
+
+      destroyAllForwards();
+      expect(listForwards()).toHaveLength(0);
+
+      // Second call should not throw
+      destroyAllForwards();
+      expect(listForwards()).toHaveLength(0);
+    });
+  });
+
+  // ── Timeout ────────────────────────────────────────────────────────────
+
+  describe('idle timeout', () => {
+    it('auto-closes forward after timeout', async () => {
+      const child = makeFakeChild();
+      spawnMock.mockReturnValue(child);
+
+      const { startLocalForward, listForwards } = await import('../../src/ssh/forward-manager.js');
+
+      const resultP = startLocalForward({
+        host: 'host.example.com',
+        local_port: 8080,
+        remote_host: 'db.internal',
+        remote_port: 5432,
+        idle_timeout_seconds: 10,
+      });
+      await vi.advanceTimersByTimeAsync(600);
+      await resultP;
+
+      expect(listForwards()).toHaveLength(1);
+
+      // Advance past the timeout
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(listForwards()).toHaveLength(0);
+      expect(child.kill).toHaveBeenCalled();
+    });
+  });
+
+  // ── Process exit auto-cleanup ──────────────────────────────────────────
+
+  describe('process exit cleanup', () => {
+    it('removes entry when ssh process exits', async () => {
+      const child = makeFakeChild();
+      spawnMock.mockReturnValue(child);
+
+      const { startLocalForward, listForwards } = await import('../../src/ssh/forward-manager.js');
+
+      const resultP = startLocalForward({
+        host: 'host.example.com',
+        local_port: 8080,
+        remote_host: 'db.internal',
+        remote_port: 5432,
+      });
+      await vi.advanceTimersByTimeAsync(600);
+      await resultP;
+
+      expect(listForwards()).toHaveLength(1);
+
+      // Simulate process exit
+      child.emit('close', 0);
+
+      expect(listForwards()).toHaveLength(0);
+    });
+  });
+
+  // ── use_ssh_config=false ───────────────────────────────────────────────
+
+  describe('ssh config', () => {
+    it('passes -F /dev/null when use_ssh_config=false', async () => {
+      const child = makeFakeChild();
+      spawnMock.mockReturnValue(child);
+
+      const { startLocalForward } = await import('../../src/ssh/forward-manager.js');
+
+      const resultP = startLocalForward({
+        host: 'host.example.com',
+        local_port: 8080,
+        remote_host: 'db.internal',
+        remote_port: 5432,
+        use_ssh_config: false,
+      });
+      await vi.advanceTimersByTimeAsync(600);
+      await resultP;
+
+      const [, args] = spawnMock.mock.calls[0];
+      expect(args).toContain('-F');
+      expect(args).toContain('/dev/null');
+    });
+  });
+});


### PR DESCRIPTION
Closes #83

## Summary

5 new tools for persistent SSH port forwards — local, remote, and dynamic (SOCKS). Forwards run in the background and are tracked by ID.

## New tools

| Tool | SSH flag | Description |
|------|----------|-------------|
| `ssh_forward_local` | `-L` | Forward local port to remote host:port |
| `ssh_forward_remote` | `-R` | Expose local port on remote side |
| `ssh_forward_dynamic` | `-D` | SOCKS proxy on local port |
| `ssh_forward_close` | — | Kill a forward by ID |
| `ssh_forward_list` | — | List active forwards + status |

## Example
```json
{ "tool": "ssh_forward_local", "host": "bastion", "local_port": 5432, "remote_host": "db.internal", "remote_port": 5432 }
// → { "forward_id": "abc-123", "status": "active", "local_port": 5432 }
```

## Implementation details
- Spawns `ssh -N -o BatchMode=yes -o ExitOnForwardFailure=yes` in background
- 500ms startup stabilization to catch immediate bind failures
- Max lifetime timeout (default 3600s), auto-cleanup on process exit
- Same credential resolution as `ssh_execute`
- `unref()` on timeout so Node exit isn't blocked

## Changes
- `src/ssh/forward-manager.ts` — lifecycle manager
- `src/tools/ssh-forward-{local,remote,dynamic,close,list}.ts` — 5 tool handlers
- `src/index.ts` — all 5 tools registered + `destroyAllForwards()` on shutdown
- `test/unit/port-forward.test.ts` — 12 new tests

## Tests
✅ 218 tests pass