### PR TITLE
feat: streaming output for long-running commands

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,12 +23,16 @@ import { sshSessionOpen } from './tools/ssh-session-open.js';
 import { sshSessionExecute } from './tools/ssh-session-execute.js';
 import { sshSessionClose } from './tools/ssh-session-close.js';
 import { SessionStore } from './ssh/session-store.js';
+import { StreamStore } from './ssh/stream-store.js';
 import { sshMultiExecute } from './tools/ssh-multi-execute.js';
 import { credentialGet } from './tools/credential-get.js';
 import { credentialListBackends } from './tools/credential-list.js';
 import { sshCheckHost } from './tools/ssh-check.js';
 import { versionCheck } from './tools/version-check.js';
 import { credentialDiagnose } from './tools/credential-diagnose.js';
+import { sshStreamRead } from './tools/ssh-stream-read.js';
+import { sshStreamCancel } from './tools/ssh-stream-cancel.js';
+import { sshStreamList } from './tools/ssh-stream-list.js';
 import { CredentialRegistry } from './credentials/registry.js';
 import { CredentialMap } from './credentials/credential-map.js';
 import { BitwardenBackend } from './credentials/bitwarden.js';
@@ -67,13 +71,14 @@ registry.register(new GoogleSecretManagerBackend());
 registry.register(new SshAgentBackend());
 
 const sessionStore = new SessionStore();
+const streamStore = new StreamStore();
 const credentialMap = new CredentialMap();
 
-// Graceful shutdown: destroy all sessions before exiting
-const shutdown = () => { sessionStore.destroy(); process.exit(0); };
+// Graceful shutdown: destroy all sessions and streams before exiting
+const shutdown = () => { streamStore.destroy(); sessionStore.destroy(); process.exit(0); };
 process.once('SIGINT', shutdown);
 process.once('SIGTERM', shutdown);
-process.on('exit', () => sessionStore.destroy());
+process.on('exit', () => { streamStore.destroy(); sessionStore.destroy(); });
 
 // ── ssh_execute ──────────────────────────────────────────────────────────────
 server.tool(
@@ -91,10 +96,11 @@ server.tool(
       .describe('Platform hint for prompt detection (default: auto)'),
     timeout_ms: z.number().int().positive().optional().describe('Connection + command timeout in milliseconds (default: 30000)'),
     use_ssh_config: z.boolean().optional().describe('When true (default), honor ~/.ssh/config for User, Port, IdentityFile, ProxyJump, etc. Set false to skip.'),
+    stream: z.boolean().optional().describe('When true, run asynchronously and return a stream_id for polling output via ssh_stream_read.'),
   },
   async (input) => {
     try {
-      const result = await sshExecute(registry, input, credentialMap);
+      const result = await sshExecute(registry, input, credentialMap, streamStore);
       return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
     } catch (err: unknown) {
       return {
@@ -238,10 +244,11 @@ server.tool(
     session_id: z.string().describe('Session ID returned by ssh_session_open'),
     command: z.string().describe('Command to execute in the session'),
     timeout_ms: z.number().int().positive().optional().describe('Command timeout in milliseconds (default: 30000)'),
+    stream: z.boolean().optional().describe('When true, run asynchronously and return a stream_id for polling output via ssh_stream_read.'),
   },
   async (input) => {
     try {
-      const result = await sshSessionExecute(sessionStore, input);
+      const result = await sshSessionExecute(sessionStore, input, streamStore);
       return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
     } catch (err: unknown) {
       return {
@@ -303,6 +310,65 @@ server.tool(
       return {
         content: [{ type: 'text' as const, text: JSON.stringify({ success: true, path: credentialMap.getFilePath() }) }],
       };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── ssh_stream_read ──────────────────────────────────────────────────────────
+server.tool(
+  'ssh_stream_read',
+  'Read output chunks from a streaming SSH command started with stream=true.',
+  {
+    stream_id: z.string().describe('Stream ID returned by ssh_execute or ssh_session_execute with stream=true'),
+    offset: z.number().int().min(0).optional().describe('Chunk offset to read from (default: 0). Use the offset returned by previous reads to get only new chunks.'),
+  },
+  async (input) => {
+    try {
+      const result = sshStreamRead(streamStore, input);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── ssh_stream_cancel ────────────────────────────────────────────────────────
+server.tool(
+  'ssh_stream_cancel',
+  'Cancel a running streaming SSH command.',
+  {
+    stream_id: z.string().describe('Stream ID of the stream to cancel'),
+  },
+  async (input) => {
+    try {
+      const result = sshStreamCancel(streamStore, input);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── ssh_stream_list ──────────────────────────────────────────────────────────
+server.tool(
+  'ssh_stream_list',
+  'List all active and recent streaming SSH commands.',
+  {},
+  async () => {
+    try {
+      const result = sshStreamList(streamStore);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
     } catch (err: unknown) {
       return {
         content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],

--- a/src/ssh/pty-manager.ts
+++ b/src/ssh/pty-manager.ts
@@ -30,6 +30,10 @@ export interface PtySessionOptions {
    * Set to false to skip config lookup entirely.
    */
   use_ssh_config?: boolean;
+  /** Optional callback invoked on each PTY data event (for streaming). */
+  onData?: (data: string) => void;
+  /** Optional AbortSignal to cancel the session externally. */
+  abortSignal?: AbortSignal;
 }
 
 export interface PtySessionResult {
@@ -164,8 +168,22 @@ export async function runSshSession(opts: PtySessionOptions): Promise<PtySession
       fail(new Error(`SSH session timed out after ${timeout_ms}ms`));
     }, timeout_ms);
 
+    // Abort signal support for external cancellation (streaming)
+    if (opts.abortSignal) {
+      const onAbort = () => {
+        fail(new Error('SSH session aborted'));
+      };
+      if (opts.abortSignal.aborted) {
+        return fail(new Error('SSH session aborted'));
+      }
+      opts.abortSignal.addEventListener('abort', onAbort, { once: true });
+    }
+
     term.onData((data: string) => {
       rawOutput += data;
+
+      // Invoke streaming callback (exception-safe)
+      try { opts.onData?.(data); } catch { /* ignore */ }
 
       // Handle password prompt
       if (!passwordSent && detectPasswordPrompt(rawOutput)) {

--- a/src/ssh/stream-store.ts
+++ b/src/ssh/stream-store.ts
@@ -1,0 +1,183 @@
+/**
+ * StreamStore — manages poll-based streaming output for long-running SSH commands.
+ *
+ * Each stream accumulates output chunks in memory, keyed by a unique stream_id.
+ * Completed/failed/cancelled streams are auto-cleaned after 5 minutes.
+ */
+
+import { scrubOutput } from './output-scrubber.js';
+
+export type StreamStatus = 'running' | 'completed' | 'failed' | 'cancelled';
+
+export interface StreamChunk {
+  timestamp: string; // ISO 8601
+  text: string;
+  channel: 'stdout' | 'stderr';
+}
+
+export interface StreamEntry {
+  id: string;
+  host: string;
+  command: string;
+  status: StreamStatus;
+  chunks: StreamChunk[];
+  totalBytes: number;
+  exit_code?: number | null;
+  error?: string;
+  startedAt: string;
+  completedAt?: string;
+  /** Callback to cancel the underlying process */
+  onCancel?: () => void;
+}
+
+export interface StreamReadResult {
+  chunks: StreamChunk[];
+  offset: number;
+  status: StreamStatus;
+  exit_code?: number | null;
+  error?: string;
+}
+
+export interface StreamListEntry {
+  id: string;
+  host: string;
+  command: string;
+  status: StreamStatus;
+  chunkCount: number;
+  totalBytes: number;
+  startedAt: string;
+  completedAt?: string;
+  exit_code?: number | null;
+  error?: string;
+}
+
+/** Max bytes per stream before truncation (10 MB) */
+const MAX_STREAM_BYTES = 10 * 1024 * 1024;
+/** Auto-cleanup delay after terminal state (5 minutes) */
+const CLEANUP_DELAY_MS = 5 * 60 * 1000;
+
+export class StreamStore {
+  private streams = new Map<string, StreamEntry>();
+  private cleanupTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  create(id: string, host: string, command: string, onCancel?: () => void): void {
+    this.streams.set(id, {
+      id,
+      host,
+      command,
+      status: 'running',
+      chunks: [],
+      totalBytes: 0,
+      startedAt: new Date().toISOString(),
+      onCancel,
+    });
+  }
+
+  appendChunk(id: string, text: string, channel: 'stdout' | 'stderr'): void {
+    const entry = this.streams.get(id);
+    if (!entry || entry.status !== 'running') return;
+
+    if (entry.totalBytes >= MAX_STREAM_BYTES) return; // drop data beyond limit
+
+    // Truncate chunk if it would exceed the cap
+    const remaining = MAX_STREAM_BYTES - entry.totalBytes;
+    const truncated = text.length > remaining ? text.slice(0, remaining) : text;
+
+    entry.chunks.push({
+      timestamp: new Date().toISOString(),
+      text: scrubOutput(truncated),
+      channel,
+    });
+    entry.totalBytes += truncated.length;
+  }
+
+  read(id: string, offset?: number): StreamReadResult {
+    const entry = this.streams.get(id);
+    if (!entry) throw new Error(`Stream "${id}" not found`);
+
+    const start = offset ?? 0;
+    if (start < 0) throw new Error('offset must be non-negative');
+
+    const chunks = entry.chunks.slice(start);
+    return {
+      chunks,
+      offset: entry.chunks.length,
+      status: entry.status,
+      exit_code: entry.exit_code,
+      error: entry.error,
+    };
+  }
+
+  complete(id: string, exitCode: number | null): void {
+    const entry = this.streams.get(id);
+    if (!entry || entry.status !== 'running') return; // ignore if already terminal
+    entry.status = 'completed';
+    entry.exit_code = exitCode;
+    entry.completedAt = new Date().toISOString();
+    this.scheduleCleanup(id);
+  }
+
+  fail(id: string, error?: string): void {
+    const entry = this.streams.get(id);
+    if (!entry || entry.status !== 'running') return;
+    entry.status = 'failed';
+    entry.error = error;
+    entry.completedAt = new Date().toISOString();
+    this.scheduleCleanup(id);
+  }
+
+  cancel(id: string): { success: boolean; message: string } {
+    const entry = this.streams.get(id);
+    if (!entry) return { success: false, message: `Stream "${id}" not found` };
+    if (entry.status !== 'running') {
+      return { success: false, message: `Stream already ${entry.status}` };
+    }
+    entry.status = 'cancelled';
+    entry.completedAt = new Date().toISOString();
+    try {
+      entry.onCancel?.();
+    } catch { /* best effort */ }
+    this.scheduleCleanup(id);
+    return { success: true, message: 'Stream cancelled' };
+  }
+
+  list(): StreamListEntry[] {
+    return [...this.streams.values()].map((e) => ({
+      id: e.id,
+      host: e.host,
+      command: e.command,
+      status: e.status,
+      chunkCount: e.chunks.length,
+      totalBytes: e.totalBytes,
+      startedAt: e.startedAt,
+      completedAt: e.completedAt,
+      exit_code: e.exit_code,
+      error: e.error,
+    }));
+  }
+
+  get(id: string): StreamEntry | undefined {
+    return this.streams.get(id);
+  }
+
+  destroy(): void {
+    for (const timer of this.cleanupTimers.values()) clearTimeout(timer);
+    this.cleanupTimers.clear();
+    // Cancel all running streams
+    for (const entry of this.streams.values()) {
+      if (entry.status === 'running') {
+        try { entry.onCancel?.(); } catch { /* ignore */ }
+      }
+    }
+    this.streams.clear();
+  }
+
+  private scheduleCleanup(id: string): void {
+    const timer = setTimeout(() => {
+      this.streams.delete(id);
+      this.cleanupTimers.delete(id);
+    }, CLEANUP_DELAY_MS);
+    timer.unref();
+    this.cleanupTimers.set(id, timer);
+  }
+}

--- a/src/tools/ssh-execute.ts
+++ b/src/tools/ssh-execute.ts
@@ -6,6 +6,7 @@ import type { PlatformHint } from '../ssh/prompt-detector.js';
 import type { CredentialRegistry } from '../credentials/registry.js';
 import { runSshSession } from '../ssh/pty-manager.js';
 import type { CredentialMap } from '../credentials/credential-map.js';
+import type { StreamStore } from '../ssh/stream-store.js';
 
 export interface SshExecuteInput {
   host: string;
@@ -22,6 +23,8 @@ export interface SshExecuteInput {
    * Set to false to bypass ssh config lookup entirely.
    */
   use_ssh_config?: boolean;
+  /** When true, run the command asynchronously and return a stream_id for polling. */
+  stream?: boolean;
 }
 
 export interface SshExecuteResult {
@@ -29,11 +32,17 @@ export interface SshExecuteResult {
   exit_code: number | null;
 }
 
+export interface SshExecuteStreamResult {
+  stream_id: string;
+  status: 'running';
+}
+
 export async function sshExecute(
   registry: CredentialRegistry,
   input: SshExecuteInput,
   credentialMap: CredentialMap,
-): Promise<SshExecuteResult> {
+  streamStore?: StreamStore,
+): Promise<SshExecuteResult | SshExecuteStreamResult> {
   let {
     credential_ref,
     credential_backend,
@@ -44,6 +53,7 @@ export async function sshExecute(
     username,
     platform = 'auto',
     timeout_ms = 30000,
+    stream = false,
   } = input;
 
   // Validate required inputs before any lookups
@@ -97,6 +107,36 @@ export async function sshExecute(
   // a better error message if username resolution still fails.
 
   // Run the PTY session
+  if (stream && streamStore) {
+    const streamId = crypto.randomUUID();
+    const abortController = new AbortController();
+    streamStore.create(streamId, host, command, () => abortController.abort());
+
+    // Use a longer default timeout for streaming (5 minutes)
+    const effectiveTimeout = input.timeout_ms ?? 300_000;
+
+    const promise = runSshSession({
+      host,
+      username: resolvedUsername || undefined,
+      password: passwordBuffer,
+      command,
+      platform,
+      timeout_ms: effectiveTimeout,
+      use_ssh_config: input.use_ssh_config ?? true,
+      onData: (data) => streamStore.appendChunk(streamId, data, 'stdout'),
+      abortSignal: abortController.signal,
+    });
+
+    // Handle completion/failure in the background; clean up password
+    promise
+      .then((result) => streamStore.complete(streamId, result.exit_code))
+      .catch((err) => streamStore.fail(streamId, err instanceof Error ? err.message : String(err)))
+      .finally(() => passwordBuffer.fill(0));
+
+    return { stream_id: streamId, status: 'running' as const };
+  }
+
+  // Non-streaming path (unchanged)
   try {
     const result = await runSshSession({
       host,

--- a/src/tools/ssh-session-execute.ts
+++ b/src/tools/ssh-session-execute.ts
@@ -9,11 +9,14 @@ import type { SessionStore, ManagedSession } from '../ssh/session-store.js';
 import type { IDisposable } from 'node-pty';
 import { detectPrompt } from '../ssh/prompt-detector.js';
 import { scrubOutput } from '../ssh/output-scrubber.js';
+import type { StreamStore } from '../ssh/stream-store.js';
 
 export interface SshSessionExecuteInput {
   session_id: string;
   command: string;
   timeout_ms?: number; // default 30000
+  /** When true, run asynchronously and return a stream_id for polling. */
+  stream?: boolean;
 }
 
 export interface SshSessionExecuteResult {
@@ -22,11 +25,18 @@ export interface SshSessionExecuteResult {
   session_id: string;
 }
 
+export interface SshSessionExecuteStreamResult {
+  stream_id: string;
+  session_id: string;
+  status: 'running';
+}
+
 export async function sshSessionExecute(
   sessionStore: SessionStore,
   input: SshSessionExecuteInput,
-): Promise<SshSessionExecuteResult> {
-  const { session_id, command, timeout_ms = 30_000 } = input;
+  streamStore?: StreamStore,
+): Promise<SshSessionExecuteResult | SshSessionExecuteStreamResult> {
+  const { session_id, command, timeout_ms = 30_000, stream = false } = input;
 
   if (!session_id?.trim()) {
     throw new Error('session_id is required and cannot be empty');
@@ -52,6 +62,94 @@ export async function sshSessionExecute(
 
   const sess = session; // capture for closure — TypeScript narrowing guard
 
+  // Streaming path: return immediately, feed chunks to StreamStore
+  if (stream && streamStore) {
+    const streamId = crypto.randomUUID();
+    // For session streaming, cancel sends Ctrl-C then fails the stream
+    streamStore.create(streamId, sess.host, command, () => {
+      try { sess.ptyProcess.write('\x03'); } catch { /* ignore */ }
+    });
+
+    const effectiveTimeout = input.timeout_ms ?? 300_000;
+
+    const promise = new Promise<SshSessionExecuteResult>((resolve, reject) => {
+      let captureBuffer = '';
+      let settled = false;
+      let dataDisposable: IDisposable | undefined;
+      let exitDisposable: IDisposable | undefined;
+
+      function cleanup() {
+        if (dataDisposable) {
+          try { dataDisposable.dispose(); } catch { /* ignore */ }
+          const idx = sess.disposables.indexOf(dataDisposable);
+          if (idx !== -1) sess.disposables.splice(idx, 1);
+          dataDisposable = undefined;
+        }
+        if (exitDisposable) {
+          try { exitDisposable.dispose(); } catch { /* ignore */ }
+          const eidx = sess.disposables.indexOf(exitDisposable);
+          if (eidx !== -1) sess.disposables.splice(eidx, 1);
+          exitDisposable = undefined;
+        }
+        sess.inFlight = false;
+      }
+
+      function finish(output: string) {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        cleanup();
+        const cleaned = scrubOutput(output);
+        resolve({ output: cleaned, exit_code: null, session_id });
+      }
+
+      function fail(err: Error) {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        cleanup();
+        reject(err);
+      }
+
+      const timer = setTimeout(() => {
+        fail(new Error(`ssh_session_execute timed out after ${effectiveTimeout}ms`));
+      }, effectiveTimeout);
+
+      dataDisposable = sess.ptyProcess.onData((data: string) => {
+        if (settled) return;
+        captureBuffer += data;
+        sess.outputBuffer += data;
+        sess.lastActivity = Date.now();
+        try { streamStore.appendChunk(streamId, data, 'stdout'); } catch { /* ignore */ }
+        if (detectPrompt(captureBuffer, sess.platform)) {
+          finish(captureBuffer);
+        }
+      });
+      sess.disposables.push(dataDisposable);
+
+      exitDisposable = sess.ptyProcess.onExit(({ exitCode }) => {
+        sessionStore.delete(sess.id);
+        fail(new Error(`SSH PTY exited unexpectedly with code ${exitCode} during command execution`));
+      });
+      sess.disposables.push(exitDisposable);
+
+      try {
+        sess.ptyProcess.write(command + '\r');
+      } catch (err) {
+        sessionStore.delete(sess.id);
+        fail(new Error(`Failed to write to PTY: ${String(err)}`));
+      }
+    });
+
+    // Handle completion/failure in the background
+    promise
+      .then(() => streamStore.complete(streamId, null))
+      .catch((err) => streamStore.fail(streamId, err instanceof Error ? err.message : String(err)));
+
+    return { stream_id: streamId, session_id, status: 'running' as const };
+  }
+
+  // Non-streaming path (unchanged)
   return new Promise<SshSessionExecuteResult>((resolve, reject) => {
     let captureBuffer = '';
     let settled = false;

--- a/src/tools/ssh-stream-cancel.ts
+++ b/src/tools/ssh-stream-cancel.ts
@@ -1,0 +1,18 @@
+/**
+ * ssh_stream_cancel tool handler — cancels a running streaming SSH command.
+ */
+
+import type { StreamStore } from '../ssh/stream-store.js';
+
+export interface SshStreamCancelInput {
+  stream_id: string;
+}
+
+export function sshStreamCancel(
+  streamStore: StreamStore,
+  input: SshStreamCancelInput,
+): { success: boolean; message: string } {
+  const { stream_id } = input;
+  if (!stream_id?.trim()) throw new Error('stream_id is required');
+  return streamStore.cancel(stream_id);
+}

--- a/src/tools/ssh-stream-list.ts
+++ b/src/tools/ssh-stream-list.ts
@@ -1,0 +1,11 @@
+/**
+ * ssh_stream_list tool handler — lists active and recent streams.
+ */
+
+import type { StreamStore, StreamListEntry } from '../ssh/stream-store.js';
+
+export function sshStreamList(
+  streamStore: StreamStore,
+): StreamListEntry[] {
+  return streamStore.list();
+}

--- a/src/tools/ssh-stream-read.ts
+++ b/src/tools/ssh-stream-read.ts
@@ -1,0 +1,19 @@
+/**
+ * ssh_stream_read tool handler — reads output chunks from a streaming SSH command.
+ */
+
+import type { StreamStore, StreamReadResult } from '../ssh/stream-store.js';
+
+export interface SshStreamReadInput {
+  stream_id: string;
+  offset?: number;
+}
+
+export function sshStreamRead(
+  streamStore: StreamStore,
+  input: SshStreamReadInput,
+): StreamReadResult {
+  const { stream_id, offset } = input;
+  if (!stream_id?.trim()) throw new Error('stream_id is required');
+  return streamStore.read(stream_id, offset);
+}

--- a/test/unit/streaming.test.ts
+++ b/test/unit/streaming.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Unit tests for poll-based streaming output (StreamStore + tool handlers).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { StreamStore } from '../../src/ssh/stream-store.js';
+import { sshStreamRead } from '../../src/tools/ssh-stream-read.js';
+import { sshStreamCancel } from '../../src/tools/ssh-stream-cancel.js';
+import { sshStreamList } from '../../src/tools/ssh-stream-list.js';
+
+describe('StreamStore', () => {
+  let store: StreamStore;
+
+  beforeEach(() => {
+    store = new StreamStore();
+  });
+
+  afterEach(() => {
+    store.destroy();
+  });
+
+  it('creates a stream and returns it via get()', () => {
+    store.create('s1', 'host1', 'ls -la');
+    const entry = store.get('s1');
+    expect(entry).toBeDefined();
+    expect(entry!.status).toBe('running');
+    expect(entry!.host).toBe('host1');
+    expect(entry!.command).toBe('ls -la');
+    expect(entry!.chunks).toHaveLength(0);
+  });
+
+  it('appends chunks with timestamps', () => {
+    store.create('s1', 'host1', 'cmd');
+    store.appendChunk('s1', 'hello ', 'stdout');
+    store.appendChunk('s1', 'world', 'stderr');
+
+    const entry = store.get('s1')!;
+    expect(entry.chunks).toHaveLength(2);
+    expect(entry.chunks[0].text).toBe('hello ');
+    expect(entry.chunks[0].channel).toBe('stdout');
+    expect(entry.chunks[1].text).toBe('world');
+    expect(entry.chunks[1].channel).toBe('stderr');
+    // Timestamps should be valid ISO 8601
+    expect(() => new Date(entry.chunks[0].timestamp)).not.toThrow();
+    expect(entry.totalBytes).toBe(11);
+  });
+
+  it('ignores chunks after completion', () => {
+    store.create('s1', 'host1', 'cmd');
+    store.appendChunk('s1', 'before', 'stdout');
+    store.complete('s1', 0);
+    store.appendChunk('s1', 'after', 'stdout');
+
+    const entry = store.get('s1')!;
+    expect(entry.chunks).toHaveLength(1);
+    expect(entry.chunks[0].text).toBe('before');
+  });
+
+  it('read returns chunks from offset', () => {
+    store.create('s1', 'host1', 'cmd');
+    store.appendChunk('s1', 'chunk0', 'stdout');
+    store.appendChunk('s1', 'chunk1', 'stdout');
+    store.appendChunk('s1', 'chunk2', 'stdout');
+
+    const r1 = store.read('s1', 0);
+    expect(r1.chunks).toHaveLength(3);
+    expect(r1.offset).toBe(3);
+    expect(r1.status).toBe('running');
+
+    const r2 = store.read('s1', 2);
+    expect(r2.chunks).toHaveLength(1);
+    expect(r2.chunks[0].text).toBe('chunk2');
+    expect(r2.offset).toBe(3);
+  });
+
+  it('read with offset beyond chunks returns empty', () => {
+    store.create('s1', 'host1', 'cmd');
+    store.appendChunk('s1', 'data', 'stdout');
+
+    const r = store.read('s1', 10);
+    expect(r.chunks).toHaveLength(0);
+    expect(r.offset).toBe(1);
+  });
+
+  it('read defaults to offset 0', () => {
+    store.create('s1', 'host1', 'cmd');
+    store.appendChunk('s1', 'data', 'stdout');
+
+    const r = store.read('s1');
+    expect(r.chunks).toHaveLength(1);
+  });
+
+  it('read throws for unknown stream', () => {
+    expect(() => store.read('nonexistent')).toThrow('Stream "nonexistent" not found');
+  });
+
+  it('read throws for negative offset', () => {
+    store.create('s1', 'host1', 'cmd');
+    expect(() => store.read('s1', -1)).toThrow('offset must be non-negative');
+  });
+
+  it('complete sets status and exit_code', () => {
+    store.create('s1', 'host1', 'cmd');
+    store.complete('s1', 42);
+
+    const entry = store.get('s1')!;
+    expect(entry.status).toBe('completed');
+    expect(entry.exit_code).toBe(42);
+    expect(entry.completedAt).toBeDefined();
+  });
+
+  it('fail sets status and error', () => {
+    store.create('s1', 'host1', 'cmd');
+    store.fail('s1', 'timeout');
+
+    const entry = store.get('s1')!;
+    expect(entry.status).toBe('failed');
+    expect(entry.error).toBe('timeout');
+  });
+
+  it('terminal state guards prevent double transitions', () => {
+    store.create('s1', 'host1', 'cmd');
+    store.complete('s1', 0);
+    store.fail('s1', 'should be ignored');
+
+    expect(store.get('s1')!.status).toBe('completed');
+    expect(store.get('s1')!.error).toBeUndefined();
+  });
+
+  it('cancel sets status to cancelled and invokes onCancel', () => {
+    const onCancel = vi.fn();
+    store.create('s1', 'host1', 'cmd', onCancel);
+    const result = store.cancel('s1');
+
+    expect(result.success).toBe(true);
+    expect(store.get('s1')!.status).toBe('cancelled');
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('cancel after completion returns failure', () => {
+    store.create('s1', 'host1', 'cmd');
+    store.complete('s1', 0);
+    const result = store.cancel('s1');
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('already completed');
+  });
+
+  it('cancel for unknown stream returns failure', () => {
+    const result = store.cancel('nonexistent');
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('not found');
+  });
+
+  it('complete after cancel is ignored', () => {
+    store.create('s1', 'host1', 'cmd');
+    store.cancel('s1');
+    store.complete('s1', 0);
+
+    expect(store.get('s1')!.status).toBe('cancelled');
+  });
+
+  it('list returns all streams without chunks', () => {
+    store.create('s1', 'host1', 'cmd1');
+    store.create('s2', 'host2', 'cmd2');
+    store.appendChunk('s1', 'data', 'stdout');
+
+    const list = store.list();
+    expect(list).toHaveLength(2);
+    expect(list[0].id).toBe('s1');
+    expect(list[0].chunkCount).toBe(1);
+    expect(list[0].totalBytes).toBe(4);
+    // list entries should not contain chunks array
+    expect((list[0] as Record<string, unknown>).chunks).toBeUndefined();
+  });
+
+  it('destroy clears all streams and cancels running ones', () => {
+    const onCancel = vi.fn();
+    store.create('s1', 'host1', 'cmd', onCancel);
+    store.create('s2', 'host2', 'cmd2');
+    store.complete('s2', 0);
+
+    store.destroy();
+    expect(onCancel).toHaveBeenCalledOnce();
+    expect(store.list()).toHaveLength(0);
+  });
+
+  it('auto-cleanup removes completed streams after delay', async () => {
+    vi.useFakeTimers();
+    try {
+      store.create('s1', 'host1', 'cmd');
+      store.complete('s1', 0);
+      expect(store.get('s1')).toBeDefined();
+
+      // Advance past cleanup delay (5 minutes)
+      vi.advanceTimersByTime(5 * 60 * 1000 + 100);
+
+      expect(store.get('s1')).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('sshStreamRead', () => {
+  it('returns chunks and status from StreamStore', () => {
+    const store = new StreamStore();
+    store.create('s1', 'host1', 'cmd');
+    store.appendChunk('s1', 'hello', 'stdout');
+
+    const result = sshStreamRead(store, { stream_id: 's1' });
+    expect(result.chunks).toHaveLength(1);
+    expect(result.status).toBe('running');
+    expect(result.offset).toBe(1);
+
+    store.destroy();
+  });
+
+  it('supports offset-based polling', () => {
+    const store = new StreamStore();
+    store.create('s1', 'host1', 'cmd');
+    store.appendChunk('s1', 'line1', 'stdout');
+    store.appendChunk('s1', 'line2', 'stdout');
+
+    const r1 = sshStreamRead(store, { stream_id: 's1', offset: 0 });
+    expect(r1.chunks).toHaveLength(2);
+
+    store.appendChunk('s1', 'line3', 'stdout');
+    const r2 = sshStreamRead(store, { stream_id: 's1', offset: r1.offset });
+    expect(r2.chunks).toHaveLength(1);
+    expect(r2.chunks[0].text).toBe('line3');
+
+    store.destroy();
+  });
+
+  it('includes exit_code when completed', () => {
+    const store = new StreamStore();
+    store.create('s1', 'host1', 'cmd');
+    store.complete('s1', 0);
+
+    const result = sshStreamRead(store, { stream_id: 's1' });
+    expect(result.status).toBe('completed');
+    expect(result.exit_code).toBe(0);
+
+    store.destroy();
+  });
+
+  it('throws for empty stream_id', () => {
+    const store = new StreamStore();
+    expect(() => sshStreamRead(store, { stream_id: '' })).toThrow('stream_id is required');
+    store.destroy();
+  });
+});
+
+describe('sshStreamCancel', () => {
+  it('cancels a running stream', () => {
+    const store = new StreamStore();
+    const onCancel = vi.fn();
+    store.create('s1', 'host1', 'cmd', onCancel);
+
+    const result = sshStreamCancel(store, { stream_id: 's1' });
+    expect(result.success).toBe(true);
+    expect(onCancel).toHaveBeenCalled();
+
+    store.destroy();
+  });
+
+  it('throws for empty stream_id', () => {
+    const store = new StreamStore();
+    expect(() => sshStreamCancel(store, { stream_id: '  ' })).toThrow('stream_id is required');
+    store.destroy();
+  });
+});
+
+describe('sshStreamList', () => {
+  it('returns summary of all streams', () => {
+    const store = new StreamStore();
+    store.create('s1', 'host1', 'cmd1');
+    store.create('s2', 'host2', 'cmd2');
+
+    const list = sshStreamList(store);
+    expect(list).toHaveLength(2);
+    expect(list.map(e => e.id)).toContain('s1');
+    expect(list.map(e => e.id)).toContain('s2');
+
+    store.destroy();
+  });
+
+  it('returns empty list when no streams', () => {
+    const store = new StreamStore();
+    expect(sshStreamList(store)).toHaveLength(0);
+    store.destroy();
+  });
+});


### PR DESCRIPTION
Closes #92

## Summary

Poll-based streaming for `ssh_execute` and `ssh_session_execute`. Start a long-running command, get a stream ID back immediately, then poll for chunks as they arrive — no more waiting for completion or losing partial output on timeout.

## Usage

```json
// 1. Start streaming
{ "tool": "ssh_execute", "host": "prod", "command": "tail -f /var/log/app.log", "stream": true }
// → { "stream_id": "abc-123", "status": "running" }

// 2. Poll for chunks
{ "tool": "ssh_stream_read", "stream_id": "abc-123", "offset": 0 }
// → { "chunks": [{"timestamp": "...", "text": "...", "channel": "stdout"}], "offset": 5, "status": "running" }

// 3. Cancel
{ "tool": "ssh_stream_cancel", "stream_id": "abc-123" }
```

## 3 new tools

| Tool | Description |
|------|-------------|
| `ssh_stream_read` | Offset-based poll — returns new chunks since last read |
| `ssh_stream_cancel` | Kill a running stream |
| `ssh_stream_list` | List active/recent streams |

## Implementation details
- `StreamStore`: chunk accumulation with 10MB memory cap, 5-min auto-cleanup after completion
- AbortSignal cancel for `ssh_execute`, Ctrl-C for session-based streams
- `pty-manager` extended with `onData` callback + `AbortSignal` support
- Non-streaming path completely unchanged

## Changes
- `src/ssh/stream-store.ts` — new
- `src/tools/ssh-stream-{read,cancel,list}.ts` — 3 new tools
- `src/ssh/pty-manager.ts` + `src/tools/ssh-execute.ts` + `ssh-session-execute.ts` — stream param wired in
- `src/index.ts` — 3 tools registered
- `test/unit/streaming.test.ts` — 26 new tests

## Tests
✅ 232 tests pass