### PR TITLE
feat: privilege escalation sudo and enable mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,11 @@ server.tool(
       .describe('Platform hint for prompt detection (default: auto)'),
     timeout_ms: z.number().int().positive().optional().describe('Connection + command timeout in milliseconds (default: 30000)'),
     use_ssh_config: z.boolean().optional().describe('When true (default), honor ~/.ssh/config for User, Port, IdentityFile, ProxyJump, etc. Set false to skip.'),
+    sudo: z.boolean().optional().describe('When true, run the command under sudo. Uses sudo -n (non-interactive) if no sudo_password_ref is provided.'),
+    sudo_password_ref: z.object({
+      backend: z.string().describe('Credential backend name'),
+      ref: z.string().describe('Credential reference string'),
+    }).optional().describe('Credential reference for the sudo password (separate from login credential)'),
   },
   async (input) => {
     try {
@@ -238,10 +243,19 @@ server.tool(
     session_id: z.string().describe('Session ID returned by ssh_session_open'),
     command: z.string().describe('Command to execute in the session'),
     timeout_ms: z.number().int().positive().optional().describe('Command timeout in milliseconds (default: 30000)'),
+    sudo: z.boolean().optional().describe('When true, run the command under sudo. Uses sudo -n (non-interactive) if no sudo_password_ref is provided.'),
+    sudo_password_ref: z.object({
+      backend: z.string().describe('Credential backend name'),
+      ref: z.string().describe('Credential reference string'),
+    }).optional().describe('Credential reference for the sudo password'),
+    enable_password_ref: z.object({
+      backend: z.string().describe('Credential backend name'),
+      ref: z.string().describe('Credential reference string'),
+    }).optional().describe('Credential reference for Cisco IOS enable mode password'),
   },
   async (input) => {
     try {
-      const result = await sshSessionExecute(sessionStore, input);
+      const result = await sshSessionExecute(sessionStore, input, registry);
       return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
     } catch (err: unknown) {
       return {

--- a/src/ssh/privilege-escalation.ts
+++ b/src/ssh/privilege-escalation.ts
@@ -1,0 +1,121 @@
+/**
+ * Privilege escalation helpers for sudo and Cisco enable mode.
+ *
+ * Provides:
+ *   - Sudo password prompt detection (custom deterministic prompt)
+ *   - Command wrapping for sudo -S with proper shell quoting
+ *   - Enable mode prompt/password sequence handling
+ *   - Credential fetching with proper buffer lifecycle
+ */
+
+import type { CredentialRegistry } from '../credentials/registry.js';
+
+/** Deterministic sudo prompt token — used with `sudo -S -p` to avoid
+ *  confusion with SSH password prompts or localized sudo messages. */
+export const SUDO_PROMPT_TOKEN = '__AI_SSH_TOOLKIT_SUDO__:';
+
+/** Credential reference for escalation passwords. */
+export interface EscalationCredentialRef {
+  backend: string;
+  ref: string;
+}
+
+/**
+ * Fetch an escalation password from a credential backend.
+ * Returns a new Buffer that the caller MUST zero-fill after use.
+ */
+export async function fetchEscalationCredential(
+  registry: CredentialRegistry,
+  credRef: EscalationCredentialRef,
+): Promise<Buffer<ArrayBufferLike>> {
+  const backend = registry.getBackend(credRef.backend);
+  try {
+    const available = await backend.isAvailable();
+    if (!available) {
+      throw new Error(
+        `Credential backend "${credRef.backend}" is not available for privilege escalation.`,
+      );
+    }
+    const cred = await backend.getCredential(credRef.ref);
+    // Copy into our own buffer so backend.cleanup() doesn't wipe it
+    const buf = Buffer.from(cred.password) as Buffer<ArrayBufferLike>;
+    cred.password.fill(0);
+    return buf;
+  } finally {
+    await backend.cleanup();
+  }
+}
+
+/**
+ * Shell-quote a string for use inside single quotes in sh -c.
+ * Replaces every ' with '\'' (end quote, escaped quote, start quote).
+ */
+export function shellQuote(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+/**
+ * Build a sudo-wrapped command string for SSH argv.
+ *
+ * When a password is available: `sudo -k -S -p '<token>' -- sh -c '<cmd>'`
+ *   -k  invalidates cached credentials to force our password
+ *   -S  reads password from stdin
+ *   -p  sets a deterministic prompt we can detect
+ *
+ * When no password (passwordless): `sudo -n -- sh -c '<cmd>'`
+ *   -n  non-interactive, fails immediately if password needed
+ */
+export function buildSudoCommand(command: string, hasPassword: boolean): string {
+  const quoted = shellQuote(command);
+  if (hasPassword) {
+    return `sudo -k -S -p ${shellQuote(SUDO_PROMPT_TOKEN)} -- sh -c ${quoted}`;
+  }
+  return `sudo -n -- sh -c ${quoted}`;
+}
+
+/**
+ * Detect our custom sudo password prompt in PTY output.
+ */
+export function detectSudoPrompt(output: string): boolean {
+  return output.includes(SUDO_PROMPT_TOKEN);
+}
+
+/** Pattern indicating sudo -n failure (password required). */
+const SUDO_PASSWORD_REQUIRED_RE = /sudo:.*(?:a password is required|interactive password|no tty present)/i;
+
+/**
+ * Check if sudo -n output indicates a password is required.
+ */
+export function isSudoPasswordRequired(output: string): boolean {
+  return SUDO_PASSWORD_REQUIRED_RE.test(output);
+}
+
+/**
+ * Detect Cisco enable password prompt.
+ * Enable prompt is typically just "Password:" on its own line,
+ * similar to SSH but appears after sending "enable".
+ */
+export function detectEnablePrompt(output: string): boolean {
+  return /[Pp]assword:\s*$/.test(output);
+}
+
+/**
+ * Validate escalation input combinations and throw clear errors.
+ */
+export function validateEscalationInputs(opts: {
+  sudo?: boolean;
+  sudo_password_ref?: EscalationCredentialRef;
+  enable_password_ref?: EscalationCredentialRef;
+}): void {
+  if (opts.sudo && opts.enable_password_ref) {
+    throw new Error(
+      'Cannot use both sudo and enable_password_ref simultaneously. ' +
+      'Use sudo for Linux hosts or enable_password_ref for network devices, not both.',
+    );
+  }
+  if (opts.sudo_password_ref && !opts.sudo) {
+    throw new Error(
+      'sudo_password_ref requires sudo=true. Set sudo to true to use privilege escalation.',
+    );
+  }
+}

--- a/src/ssh/pty-manager.ts
+++ b/src/ssh/pty-manager.ts
@@ -10,6 +10,7 @@ import { detectPasswordPrompt, detectPrompt, type PlatformHint } from './prompt-
 import { scrubOutput } from './output-scrubber.js';
 import { SSH_PTY_OPTIONS } from './pty-options.js';
 import { resolveSshConfig } from './ssh-config-reader.js';
+import { detectSudoPrompt, isSudoPasswordRequired } from './privilege-escalation.js';
 
 export interface PtySessionOptions {
   host: string;
@@ -30,6 +31,12 @@ export interface PtySessionOptions {
    * Set to false to skip config lookup entirely.
    */
   use_ssh_config?: boolean;
+  /**
+   * Sudo password as Buffer — used when the command is wrapped with `sudo -S`.
+   * Piped to stdin when the custom sudo prompt token is detected.
+   * Zeroed by caller after this function resolves/rejects.
+   */
+  sudo_password?: Buffer;
 }
 
 export interface PtySessionResult {
@@ -57,6 +64,7 @@ export async function runSshSession(opts: PtySessionOptions): Promise<PtySession
     platform = 'auto',
     timeout_ms = 30000,
     use_ssh_config = true,
+    sudo_password,
   } = opts;
 
   // ── SSH config resolution ─────────────────────────────────────────────────
@@ -141,6 +149,7 @@ export async function runSshSession(opts: PtySessionOptions): Promise<PtySession
     let rawOutput = '';
     let exitCode: number | null = null;
     let passwordSent = false;
+    let sudoPasswordSent = false;
     let settled = false;
 
     function finish(code: number | null) {
@@ -167,8 +176,22 @@ export async function runSshSession(opts: PtySessionOptions): Promise<PtySession
     term.onData((data: string) => {
       rawOutput += data;
 
-      // Handle password prompt
-      if (!passwordSent && detectPasswordPrompt(rawOutput)) {
+      // Handle sudo password prompt (must check before SSH password prompt
+      // because both may match generic password patterns)
+      if (!sudoPasswordSent && detectSudoPrompt(rawOutput)) {
+        sudoPasswordSent = true;
+        if (!sudo_password || sudo_password.length === 0) {
+          fail(new Error(
+            'Sudo password prompt received but no sudo_password_ref was provided.',
+          ));
+          return;
+        }
+        term.write(sudo_password.toString('utf-8') + '\r');
+        return;
+      }
+
+      // Handle SSH password prompt
+      if (!passwordSent && !sudoPasswordSent && detectPasswordPrompt(rawOutput)) {
         passwordSent = true;
         if (!password || password.length === 0) {
           fail(new Error(
@@ -180,6 +203,15 @@ export async function runSshSession(opts: PtySessionOptions): Promise<PtySession
         // Convert Buffer to string only at the moment of write — never store as a string variable.
         // Buffer.fill(0) in the caller is the only real zero-wipe.
         term.write(password.toString('utf-8') + '\r');
+        return;
+      }
+
+      // Detect sudo -n failure (passwordless sudo not available)
+      if (!sudoPasswordSent && isSudoPasswordRequired(rawOutput)) {
+        fail(new Error(
+          'Passwordless sudo (sudo -n) failed: a password is required. ' +
+          'Provide sudo_password_ref with a credential backend and reference to supply the sudo password.',
+        ));
         return;
       }
 

--- a/src/tools/ssh-execute.ts
+++ b/src/tools/ssh-execute.ts
@@ -6,6 +6,12 @@ import type { PlatformHint } from '../ssh/prompt-detector.js';
 import type { CredentialRegistry } from '../credentials/registry.js';
 import { runSshSession } from '../ssh/pty-manager.js';
 import type { CredentialMap } from '../credentials/credential-map.js';
+import {
+  type EscalationCredentialRef,
+  fetchEscalationCredential,
+  buildSudoCommand,
+  validateEscalationInputs,
+} from '../ssh/privilege-escalation.js';
 
 export interface SshExecuteInput {
   host: string;
@@ -22,6 +28,11 @@ export interface SshExecuteInput {
    * Set to false to bypass ssh config lookup entirely.
    */
   use_ssh_config?: boolean;
+  /** When true, run the command under sudo. Uses sudo -n (non-interactive)
+   *  if no sudo_password_ref is provided. */
+  sudo?: boolean;
+  /** Credential ref for the sudo password (separate from login credential). */
+  sudo_password_ref?: EscalationCredentialRef;
 }
 
 export interface SshExecuteResult {
@@ -45,6 +56,9 @@ export async function sshExecute(
     platform = 'auto',
     timeout_ms = 30000,
   } = input;
+
+  // Validate escalation input combinations
+  validateEscalationInputs(input);
 
   // Validate required inputs before any lookups
   if (!host) throw new Error('host is required');
@@ -96,20 +110,35 @@ export async function sshExecute(
   // ssh config resolution first (if use_ssh_config is enabled) and throw with
   // a better error message if username resolution still fails.
 
+  // ── Privilege escalation ─────────────────────────────────────────────────
+  let sudoPasswordBuffer: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+  let finalCommand = command;
+
+  if (input.sudo) {
+    if (input.sudo_password_ref) {
+      sudoPasswordBuffer = await fetchEscalationCredential(registry, input.sudo_password_ref);
+      finalCommand = buildSudoCommand(command, true);
+    } else {
+      finalCommand = buildSudoCommand(command, false);
+    }
+  }
+
   // Run the PTY session
   try {
     const result = await runSshSession({
       host,
       username: resolvedUsername || undefined,
       password: passwordBuffer,
-      command,
+      command: finalCommand,
       platform,
       timeout_ms,
       use_ssh_config: input.use_ssh_config ?? true,
+      sudo_password: sudoPasswordBuffer.length > 0 ? sudoPasswordBuffer : undefined,
     });
     return result;
   } finally {
-    // Zero-fill password buffer after PTY session completes (success or failure)
+    // Zero-fill password buffers after PTY session completes (success or failure)
     passwordBuffer.fill(0);
+    sudoPasswordBuffer.fill(0);
   }
 }

--- a/src/tools/ssh-session-execute.ts
+++ b/src/tools/ssh-session-execute.ts
@@ -6,14 +6,30 @@
  */
 
 import type { SessionStore, ManagedSession } from '../ssh/session-store.js';
+import type { CredentialRegistry } from '../credentials/registry.js';
 import type { IDisposable } from 'node-pty';
 import { detectPrompt } from '../ssh/prompt-detector.js';
 import { scrubOutput } from '../ssh/output-scrubber.js';
+import {
+  type EscalationCredentialRef,
+  fetchEscalationCredential,
+  buildSudoCommand,
+  detectSudoPrompt,
+  detectEnablePrompt,
+  isSudoPasswordRequired,
+  validateEscalationInputs,
+} from '../ssh/privilege-escalation.js';
 
 export interface SshSessionExecuteInput {
   session_id: string;
   command: string;
   timeout_ms?: number; // default 30000
+  /** When true, run the command under sudo. */
+  sudo?: boolean;
+  /** Credential ref for the sudo password. */
+  sudo_password_ref?: EscalationCredentialRef;
+  /** Credential ref for Cisco IOS enable mode password. */
+  enable_password_ref?: EscalationCredentialRef;
 }
 
 export interface SshSessionExecuteResult {
@@ -25,8 +41,12 @@ export interface SshSessionExecuteResult {
 export async function sshSessionExecute(
   sessionStore: SessionStore,
   input: SshSessionExecuteInput,
+  registry?: CredentialRegistry,
 ): Promise<SshSessionExecuteResult> {
   const { session_id, command, timeout_ms = 30_000 } = input;
+
+  // Validate escalation input combinations
+  validateEscalationInputs(input);
 
   if (!session_id?.trim()) {
     throw new Error('session_id is required and cannot be empty');
@@ -45,21 +65,52 @@ export async function sshSessionExecute(
     throw new Error('A command is already running on this session. Wait for it to complete.');
   }
 
+  // ── Privilege escalation setup ─────────────────────────────────────────
+  let sudoPasswordBuffer: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+  let enablePasswordBuffer: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+  let finalCommand = command;
+
+  if (input.sudo) {
+    if (input.sudo_password_ref) {
+      if (!registry) {
+        throw new Error('CredentialRegistry is required for sudo_password_ref');
+      }
+      sudoPasswordBuffer = await fetchEscalationCredential(registry, input.sudo_password_ref);
+      finalCommand = buildSudoCommand(command, true);
+    } else {
+      finalCommand = buildSudoCommand(command, false);
+    }
+  }
+
+  if (input.enable_password_ref) {
+    if (!registry) {
+      throw new Error('CredentialRegistry is required for enable_password_ref');
+    }
+    enablePasswordBuffer = await fetchEscalationCredential(registry, input.enable_password_ref);
+  }
+
   // Update activity timestamp
   session.lastActivity = Date.now();
   session.outputBuffer = ''; // reset capture buffer for this command
   session.inFlight = true;
 
   const sess = session; // capture for closure — TypeScript narrowing guard
+  const hasEnable = enablePasswordBuffer.length > 0;
 
   return new Promise<SshSessionExecuteResult>((resolve, reject) => {
     let captureBuffer = '';
     let settled = false;
     let dataDisposable: IDisposable | undefined;
+    let sudoPasswordSent = false;
+    let enablePasswordSent = false;
+    let enableCommandSent = !hasEnable; // skip enable phase if not needed
 
     let exitDisposable: IDisposable | undefined;
 
     function cleanup() {
+      // Zero escalation buffers
+      sudoPasswordBuffer.fill(0);
+      enablePasswordBuffer.fill(0);
       if (dataDisposable) {
         try { dataDisposable.dispose(); } catch { /* ignore */ }
         const idx = sess.disposables.indexOf(dataDisposable);
@@ -103,7 +154,60 @@ export async function sshSessionExecute(
       sess.outputBuffer += data;
       sess.lastActivity = Date.now();
 
-      if (detectPrompt(captureBuffer, sess.platform)) {
+      // ── Enable mode: wait for password prompt after sending 'enable' ──
+      if (hasEnable && !enablePasswordSent && detectEnablePrompt(captureBuffer)) {
+        enablePasswordSent = true;
+        try {
+          sess.ptyProcess.write(enablePasswordBuffer.toString('utf-8') + '\r');
+        } catch (err) {
+          sessionStore.delete(sess.id);
+          fail(new Error(`Failed to write enable password to PTY: ${String(err)}`));
+        }
+        // Reset capture to collect output after enable auth
+        captureBuffer = '';
+        return;
+      }
+
+      // ── Enable mode: after password sent, wait for prompt then send command ──
+      if (hasEnable && enablePasswordSent && !enableCommandSent && detectPrompt(captureBuffer, sess.platform)) {
+        enableCommandSent = true;
+        captureBuffer = ''; // reset to capture only command output
+        try {
+          sess.ptyProcess.write(finalCommand + '\r');
+        } catch (err) {
+          sessionStore.delete(sess.id);
+          fail(new Error(`Failed to write command to PTY: ${String(err)}`));
+        }
+        return;
+      }
+
+      // ── Sudo password prompt ──────────────────────────────────────────
+      if (input.sudo && !sudoPasswordSent && detectSudoPrompt(captureBuffer)) {
+        sudoPasswordSent = true;
+        if (sudoPasswordBuffer.length === 0) {
+          fail(new Error('Sudo password prompt received but no sudo_password_ref was provided.'));
+          return;
+        }
+        try {
+          sess.ptyProcess.write(sudoPasswordBuffer.toString('utf-8') + '\r');
+        } catch (err) {
+          sessionStore.delete(sess.id);
+          fail(new Error(`Failed to write sudo password to PTY: ${String(err)}`));
+        }
+        return;
+      }
+
+      // ── Detect sudo -n failure ────────────────────────────────────────
+      if (input.sudo && !sudoPasswordSent && isSudoPasswordRequired(captureBuffer)) {
+        fail(new Error(
+          'Passwordless sudo (sudo -n) failed: a password is required. ' +
+          'Provide sudo_password_ref with a credential backend and reference to supply the sudo password.',
+        ));
+        return;
+      }
+
+      // ── Normal prompt detection (command finished) ────────────────────
+      if (enableCommandSent && detectPrompt(captureBuffer, sess.platform)) {
         finish(captureBuffer);
       }
     });
@@ -118,10 +222,13 @@ export async function sshSessionExecute(
     });
     sess.disposables.push(exitDisposable);
 
-    // Write the command to the PTY — wrap in try/catch so a dead PTY
-    // doesn't leave inFlight=true and listeners dangling
+    // Write the initial command to the PTY — for enable mode, send 'enable' first
     try {
-      sess.ptyProcess.write(command + '\r');
+      if (hasEnable) {
+        sess.ptyProcess.write('enable\r');
+      } else {
+        sess.ptyProcess.write(finalCommand + '\r');
+      }
     } catch (err) {
       // PTY is dead — remove the session from the store and fail cleanly
       sessionStore.delete(sess.id);

--- a/test/unit/sudo-escalation.test.ts
+++ b/test/unit/sudo-escalation.test.ts
@@ -1,0 +1,632 @@
+/**
+ * Unit tests for privilege escalation — sudo -S pipe, sudo -n fallback,
+ * Cisco enable mode sequence, and no password leakage.
+ */
+
+import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest';
+import type { IPty } from 'node-pty';
+import type { ManagedSession } from '../../src/ssh/session-store.js';
+import { SessionStore } from '../../src/ssh/session-store.js';
+import type { CredentialBackend, CredentialResult } from '../../src/credentials/backend.js';
+import { CredentialRegistry } from '../../src/credentials/registry.js';
+import {
+  SUDO_PROMPT_TOKEN,
+  buildSudoCommand,
+  shellQuote,
+  detectSudoPrompt,
+  isSudoPasswordRequired,
+  validateEscalationInputs,
+  fetchEscalationCredential,
+} from '../../src/ssh/privilege-escalation.js';
+
+// ── ssh-config-reader mock ──────────────────────────────────────────────────
+vi.mock('../../src/ssh/ssh-config-reader.js', () => ({
+  resolveSshConfig: vi.fn().mockResolvedValue(null),
+}));
+
+// ── node-pty mock ───────────────────────────────────────────────────────────
+let fakeOnData: ((data: string) => void) | null = null;
+let fakeOnExit: ((ev: { exitCode: number }) => void) | null = null;
+let fakeWrite: MockInstance;
+let fakeKill: MockInstance;
+let spawnMock: MockInstance;
+
+vi.mock('node-pty', () => {
+  fakeWrite = vi.fn();
+  fakeKill = vi.fn();
+  spawnMock = vi.fn(() => ({
+    onData: (cb: (data: string) => void) => { fakeOnData = cb; },
+    onExit: (cb: (ev: { exitCode: number }) => void) => { fakeOnExit = cb; },
+    write: fakeWrite,
+    kill: fakeKill,
+  }));
+  return { default: { spawn: spawnMock } };
+});
+
+// Import after mocks
+const { runSshSession } = await import('../../src/ssh/pty-manager.js');
+const { sshExecute } = await import('../../src/tools/ssh-execute.js');
+const { sshSessionExecute } = await import('../../src/tools/ssh-session-execute.js');
+
+// ── Test helpers ────────────────────────────────────────────────────────────
+
+function makeFakeBackend(password: string = 'sudo-secret'): CredentialBackend {
+  return {
+    name: 'test-backend',
+    isAvailable: vi.fn().mockResolvedValue(true),
+    getCredential: vi.fn().mockResolvedValue({
+      username: 'testuser',
+      password: Buffer.from(password),
+    } as CredentialResult),
+    getMetadata: vi.fn().mockResolvedValue({
+      username: 'testuser',
+      has_password: true,
+      backend: 'test-backend',
+    }),
+    cleanup: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeRegistry(backend?: CredentialBackend): CredentialRegistry {
+  const reg = new CredentialRegistry();
+  reg.register(backend ?? makeFakeBackend());
+  return reg;
+}
+
+function makeFakePty(): IPty & {
+  _triggerData: (d: string) => void;
+  _triggerExit: (code: number) => void;
+  write: ReturnType<typeof vi.fn>;
+  kill: ReturnType<typeof vi.fn>;
+} {
+  const onDataCbs: ((d: string) => void)[] = [];
+  let onExitCb: ((ev: { exitCode: number }) => void) | null = null;
+
+  const fakePty = {
+    write: vi.fn(),
+    kill: vi.fn(),
+    onData(cb: (d: string) => void) {
+      onDataCbs.push(cb);
+      const disposable = {
+        dispose: vi.fn(() => {
+          const idx = onDataCbs.indexOf(cb);
+          if (idx !== -1) onDataCbs.splice(idx, 1);
+        }),
+      };
+      return disposable;
+    },
+    onExit(cb: (ev: { exitCode: number }) => void) {
+      onExitCb = cb;
+      return { dispose: vi.fn(() => { onExitCb = null; }) };
+    },
+    _triggerData(d: string) { for (const cb of [...onDataCbs]) cb(d); },
+    _triggerExit(code: number) { onExitCb?.({ exitCode: code }); },
+    pid: 1234,
+    cols: 220,
+    rows: 24,
+    process: 'ssh',
+    handleFlowControl: false,
+    resize: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+  };
+  return fakePty as unknown as typeof fakePty;
+}
+
+function makeSession(pty: IPty, overrides: Partial<ManagedSession> = {}): ManagedSession {
+  return {
+    id: crypto.randomUUID(),
+    ptyProcess: pty,
+    lastActivity: Date.now(),
+    host: 'test-host',
+    username: 'testuser',
+    platform: 'linux',
+    outputBuffer: '',
+    inFlight: false,
+    disposables: [],
+    ...overrides,
+  };
+}
+
+// ── credential-map mock ─────────────────────────────────────────────────────
+function makeMockCredentialMap() {
+  return { resolve: vi.fn().mockReturnValue(null) } as any;
+}
+
+beforeEach(() => {
+  fakeOnData = null;
+  fakeOnExit = null;
+  vi.clearAllMocks();
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// privilege-escalation.ts unit tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('privilege-escalation helpers', () => {
+  describe('shellQuote', () => {
+    it('wraps simple strings in single quotes', () => {
+      expect(shellQuote('hello')).toBe("'hello'");
+    });
+
+    it('escapes single quotes', () => {
+      expect(shellQuote("it's")).toBe("'it'\\''s'");
+    });
+  });
+
+  describe('buildSudoCommand', () => {
+    it('builds sudo -S command with custom prompt when password available', () => {
+      const result = buildSudoCommand('cat /etc/shadow', true);
+      expect(result).toContain('sudo -k -S -p');
+      expect(result).toContain(SUDO_PROMPT_TOKEN);
+      expect(result).toContain("sh -c 'cat /etc/shadow'");
+    });
+
+    it('builds sudo -n command when no password', () => {
+      const result = buildSudoCommand('cat /etc/shadow', false);
+      expect(result).toBe("sudo -n -- sh -c 'cat /etc/shadow'");
+      expect(result).not.toContain('-S');
+    });
+
+    it('properly quotes commands with shell metacharacters', () => {
+      const result = buildSudoCommand('echo "hi" > /root/file', true);
+      expect(result).toContain("sh -c 'echo \"hi\" > /root/file'");
+    });
+  });
+
+  describe('detectSudoPrompt', () => {
+    it('detects custom sudo prompt token', () => {
+      expect(detectSudoPrompt(`${SUDO_PROMPT_TOKEN}`)).toBe(true);
+    });
+
+    it('does not match generic password prompt', () => {
+      expect(detectSudoPrompt('Password: ')).toBe(false);
+    });
+  });
+
+  describe('isSudoPasswordRequired', () => {
+    it('detects "a password is required" message', () => {
+      expect(isSudoPasswordRequired('sudo: a password is required')).toBe(true);
+    });
+
+    it('detects "no tty present" message', () => {
+      expect(isSudoPasswordRequired('sudo: no tty present and no askpass program specified')).toBe(true);
+    });
+
+    it('does not match normal output', () => {
+      expect(isSudoPasswordRequired('total 0')).toBe(false);
+    });
+  });
+
+  describe('validateEscalationInputs', () => {
+    it('allows sudo=true without password ref', () => {
+      expect(() => validateEscalationInputs({ sudo: true })).not.toThrow();
+    });
+
+    it('allows sudo=true with password ref', () => {
+      expect(() => validateEscalationInputs({
+        sudo: true,
+        sudo_password_ref: { backend: 'test', ref: 'ref' },
+      })).not.toThrow();
+    });
+
+    it('rejects sudo_password_ref without sudo=true', () => {
+      expect(() => validateEscalationInputs({
+        sudo_password_ref: { backend: 'test', ref: 'ref' },
+      })).toThrow(/sudo=true/);
+    });
+
+    it('rejects sudo + enable_password_ref combination', () => {
+      expect(() => validateEscalationInputs({
+        sudo: true,
+        enable_password_ref: { backend: 'test', ref: 'ref' },
+      })).toThrow(/Cannot use both/);
+    });
+  });
+
+  describe('fetchEscalationCredential', () => {
+    it('returns a password buffer and calls cleanup', async () => {
+      const backend = makeFakeBackend('my-secret');
+      const reg = makeRegistry(backend);
+      const buf = await fetchEscalationCredential(reg, { backend: 'test-backend', ref: 'my-ref' });
+      expect(buf.toString('utf-8')).toBe('my-secret');
+      expect(backend.cleanup).toHaveBeenCalled();
+    });
+
+    it('throws when backend is unavailable', async () => {
+      const backend = makeFakeBackend();
+      (backend.isAvailable as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+      const reg = makeRegistry(backend);
+      await expect(
+        fetchEscalationCredential(reg, { backend: 'test-backend', ref: 'ref' }),
+      ).rejects.toThrow(/not available/);
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// pty-manager sudo integration tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('pty-manager sudo support', () => {
+  it('writes sudo password when custom prompt token appears', async () => {
+    const sudoPassword = Buffer.from('sudo-pass');
+    const promise = runSshSession({
+      host: 'test-host',
+      username: 'testuser',
+      password: Buffer.from('ssh-pass'),
+      command: `sudo -k -S -p '${SUDO_PROMPT_TOKEN}' -- sh -c 'cat /etc/shadow'`,
+      platform: 'linux',
+      timeout_ms: 5000,
+      sudo_password: sudoPassword,
+    });
+
+    // Simulate sudo prompt appearing
+    await new Promise(r => setTimeout(r, 0));
+    fakeOnData!(SUDO_PROMPT_TOKEN);
+
+    // Then command output + exit
+    await new Promise(r => setTimeout(r, 0));
+    fakeOnData!('root:x:0:0:root\n');
+    fakeOnExit!({ exitCode: 0 });
+
+    const result = await promise;
+    expect(result.exit_code).toBe(0);
+    // Verify sudo password was written (not SSH password)
+    expect(fakeWrite).toHaveBeenCalledWith('sudo-pass\r');
+  });
+
+  it('detects sudo -n failure and returns clear error', async () => {
+    const promise = runSshSession({
+      host: 'test-host',
+      username: 'testuser',
+      command: "sudo -n -- sh -c 'cat /etc/shadow'",
+      platform: 'linux',
+      timeout_ms: 5000,
+    });
+
+    await new Promise(r => setTimeout(r, 0));
+    fakeOnData!('sudo: a password is required\n');
+
+    await expect(promise).rejects.toThrow(/sudo_password_ref/);
+  });
+
+  it('handles SSH password then sudo password in sequence', async () => {
+    const sshPassword = Buffer.from('ssh-pass');
+    const sudoPassword = Buffer.from('sudo-pass');
+
+    const promise = runSshSession({
+      host: 'test-host',
+      username: 'testuser',
+      password: sshPassword,
+      command: `sudo -k -S -p '${SUDO_PROMPT_TOKEN}' -- sh -c 'whoami'`,
+      platform: 'linux',
+      timeout_ms: 5000,
+      sudo_password: sudoPassword,
+    });
+
+    // First: SSH password prompt
+    await new Promise(r => setTimeout(r, 0));
+    fakeOnData!('Password: ');
+
+    // Then: sudo prompt
+    await new Promise(r => setTimeout(r, 0));
+    fakeOnData!(SUDO_PROMPT_TOKEN);
+
+    // Then: output + exit
+    await new Promise(r => setTimeout(r, 0));
+    fakeOnData!('root\n');
+    fakeOnExit!({ exitCode: 0 });
+
+    const result = await promise;
+    expect(result.exit_code).toBe(0);
+    // SSH password sent first, then sudo password
+    expect(fakeWrite).toHaveBeenCalledWith('ssh-pass\r');
+    expect(fakeWrite).toHaveBeenCalledWith('sudo-pass\r');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ssh_execute sudo integration tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('sshExecute with sudo', () => {
+  it('wraps command with sudo -S when sudo=true and sudo_password_ref provided', async () => {
+    const registry = makeRegistry();
+    const credMap = makeMockCredentialMap();
+
+    const promise = sshExecute(registry, {
+      host: 'test-host',
+      command: 'cat /etc/shadow',
+      username: 'testuser',
+      sudo: true,
+      sudo_password_ref: { backend: 'test-backend', ref: 'sudo-ref' },
+    }, credMap);
+
+    // Let the promise start
+    await new Promise(r => setTimeout(r, 10));
+
+    // Check that spawn was called with sudo-wrapped command
+    const spawnCall = spawnMock.mock.calls[spawnMock.mock.calls.length - 1];
+    const sshArgs: string[] = spawnCall[1];
+    const commandArg = sshArgs[sshArgs.length - 1];
+    expect(commandArg).toContain('sudo -k -S -p');
+    expect(commandArg).toContain("sh -c 'cat /etc/shadow'");
+
+    // Simulate sudo prompt
+    fakeOnData!(SUDO_PROMPT_TOKEN);
+    await new Promise(r => setTimeout(r, 0));
+
+    // Simulate output + exit
+    fakeOnData!('root:x:0:0:root\n');
+    fakeOnExit!({ exitCode: 0 });
+
+    const result = await promise;
+    expect(result.exit_code).toBe(0);
+  });
+
+  it('uses sudo -n when sudo=true but no password ref', async () => {
+    const registry = makeRegistry();
+    const credMap = makeMockCredentialMap();
+
+    const promise = sshExecute(registry, {
+      host: 'test-host',
+      command: 'whoami',
+      username: 'testuser',
+      sudo: true,
+    }, credMap);
+
+    await new Promise(r => setTimeout(r, 10));
+
+    const spawnCall = spawnMock.mock.calls[spawnMock.mock.calls.length - 1];
+    const sshArgs: string[] = spawnCall[1];
+    const commandArg = sshArgs[sshArgs.length - 1];
+    expect(commandArg).toContain('sudo -n');
+    expect(commandArg).not.toContain('-S');
+
+    // Simulate output + exit
+    fakeOnData!('root\n');
+    fakeOnExit!({ exitCode: 0 });
+
+    const result = await promise;
+    expect(result.output).toContain('root');
+  });
+
+  it('rejects with clear error when sudo_password_ref provided without sudo=true', async () => {
+    const registry = makeRegistry();
+    const credMap = makeMockCredentialMap();
+
+    await expect(
+      sshExecute(registry, {
+        host: 'test-host',
+        command: 'whoami',
+        username: 'testuser',
+        sudo_password_ref: { backend: 'test-backend', ref: 'ref' },
+      }, credMap),
+    ).rejects.toThrow(/sudo=true/);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ssh_session_execute sudo + enable tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('sshSessionExecute with sudo', () => {
+  it('wraps command with sudo -S and sends password on prompt', async () => {
+    const store = new SessionStore();
+    const pty = makeFakePty();
+    const session = makeSession(pty);
+    store.add(session);
+    const registry = makeRegistry();
+
+    const promise = sshSessionExecute(store, {
+      session_id: session.id,
+      command: 'cat /etc/shadow',
+      timeout_ms: 5000,
+      sudo: true,
+      sudo_password_ref: { backend: 'test-backend', ref: 'sudo-ref' },
+    }, registry);
+
+    await new Promise(r => setTimeout(r, 10));
+
+    // Verify sudo -S command was written
+    const writeCall = pty.write.mock.calls[0][0] as string;
+    expect(writeCall).toContain('sudo -k -S -p');
+    expect(writeCall).toContain("sh -c 'cat /etc/shadow'");
+
+    // Simulate sudo prompt
+    pty._triggerData(SUDO_PROMPT_TOKEN);
+    await new Promise(r => setTimeout(r, 0));
+
+    // Verify password was sent
+    expect(pty.write).toHaveBeenCalledWith('sudo-secret\r');
+
+    // Simulate output + prompt
+    pty._triggerData('root:x:0:0:root\r\ntestuser@test-host:~$ ');
+
+    const result = await promise;
+    expect(result.output).toContain('root:x:0:0:root');
+    store.destroy();
+  });
+
+  it('uses sudo -n when no password ref', async () => {
+    const store = new SessionStore();
+    const pty = makeFakePty();
+    const session = makeSession(pty);
+    store.add(session);
+
+    const promise = sshSessionExecute(store, {
+      session_id: session.id,
+      command: 'whoami',
+      timeout_ms: 5000,
+      sudo: true,
+    });
+
+    await new Promise(r => setTimeout(r, 0));
+
+    const writeCall = pty.write.mock.calls[0][0] as string;
+    expect(writeCall).toContain('sudo -n');
+    expect(writeCall).not.toContain('-S');
+
+    pty._triggerData('root\r\ntestuser@test-host:~$ ');
+
+    const result = await promise;
+    expect(result.output).toContain('root');
+    store.destroy();
+  });
+
+  it('detects sudo -n failure with clear error', async () => {
+    const store = new SessionStore();
+    const pty = makeFakePty();
+    const session = makeSession(pty);
+    store.add(session);
+
+    const promise = sshSessionExecute(store, {
+      session_id: session.id,
+      command: 'cat /etc/shadow',
+      timeout_ms: 5000,
+      sudo: true,
+    });
+
+    await new Promise(r => setTimeout(r, 0));
+    pty._triggerData('sudo: a password is required\r\ntestuser@test-host:~$ ');
+
+    await expect(promise).rejects.toThrow(/sudo_password_ref/);
+    store.destroy();
+  });
+});
+
+describe('sshSessionExecute with enable mode', () => {
+  it('sends enable, password, then command in sequence', async () => {
+    const store = new SessionStore();
+    const pty = makeFakePty();
+    const session = makeSession(pty, { platform: 'nxos' });
+    store.add(session);
+    const registry = makeRegistry(makeFakeBackend('enable-secret'));
+
+    const promise = sshSessionExecute(store, {
+      session_id: session.id,
+      command: 'show running-config',
+      timeout_ms: 5000,
+      enable_password_ref: { backend: 'test-backend', ref: 'enable-ref' },
+    }, registry);
+
+    await new Promise(r => setTimeout(r, 10));
+
+    // Step 1: 'enable' was sent
+    expect(pty.write).toHaveBeenCalledWith('enable\r');
+
+    // Step 2: device asks for password
+    pty._triggerData('Password: ');
+    await new Promise(r => setTimeout(r, 0));
+
+    // Step 3: password was sent
+    expect(pty.write).toHaveBeenCalledWith('enable-secret\r');
+
+    // Step 4: device returns to privileged prompt
+    pty._triggerData('switch-1#');
+    await new Promise(r => setTimeout(r, 0));
+
+    // Step 5: actual command was sent
+    expect(pty.write).toHaveBeenCalledWith('show running-config\r');
+
+    // Step 6: command output + prompt
+    pty._triggerData('hostname switch-1\r\nswitch-1# ');
+
+    const result = await promise;
+    expect(result.output).toContain('hostname switch-1');
+    store.destroy();
+  });
+
+  it('rejects when enable + sudo combined', async () => {
+    const store = new SessionStore();
+    const pty = makeFakePty();
+    const session = makeSession(pty);
+    store.add(session);
+
+    await expect(
+      sshSessionExecute(store, {
+        session_id: session.id,
+        command: 'show run',
+        sudo: true,
+        enable_password_ref: { backend: 'test', ref: 'ref' },
+      }),
+    ).rejects.toThrow(/Cannot use both/);
+    store.destroy();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Security: no password leakage
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('no password leakage', () => {
+  it('sudo error messages never contain the password value', async () => {
+    const store = new SessionStore();
+    const pty = makeFakePty();
+    const session = makeSession(pty);
+    store.add(session);
+
+    const promise = sshSessionExecute(store, {
+      session_id: session.id,
+      command: 'cat /etc/shadow',
+      timeout_ms: 5000,
+      sudo: true,
+    });
+
+    await new Promise(r => setTimeout(r, 0));
+    pty._triggerData('sudo: a password is required\n');
+
+    try {
+      await promise;
+    } catch (err: unknown) {
+      const msg = (err as Error).message;
+      expect(msg).not.toContain('sudo-secret');
+      expect(msg).toContain('sudo_password_ref');
+    }
+    store.destroy();
+  });
+
+  it('pty-manager sudo error does not leak password buffer content', async () => {
+    const promise = runSshSession({
+      host: 'test-host',
+      username: 'testuser',
+      command: "sudo -n -- sh -c 'cat /etc/shadow'",
+      platform: 'linux',
+      timeout_ms: 5000,
+      sudo_password: Buffer.from('top-secret-password'),
+    });
+
+    await new Promise(r => setTimeout(r, 0));
+    fakeOnData!('sudo: a password is required\n');
+
+    try {
+      await promise;
+    } catch (err: unknown) {
+      const msg = (err as Error).message;
+      expect(msg).not.toContain('top-secret-password');
+    }
+  });
+
+  it('sudo password buffer is zeroed after sshExecute completes', async () => {
+    const backend = makeFakeBackend('zero-me');
+    const registry = makeRegistry(backend);
+    const credMap = makeMockCredentialMap();
+
+    const promise = sshExecute(registry, {
+      host: 'test-host',
+      command: 'whoami',
+      username: 'testuser',
+      sudo: true,
+      sudo_password_ref: { backend: 'test-backend', ref: 'ref' },
+    }, credMap);
+
+    await new Promise(r => setTimeout(r, 10));
+    fakeOnData!('root\n');
+    fakeOnExit!({ exitCode: 0 });
+
+    await promise;
+    // Backend cleanup should have been called
+    expect(backend.cleanup).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #85

## Summary

`ssh_execute` and `ssh_session_execute` now handle `sudo` for Linux and `enable` mode for Cisco IOS/IOS-XE — passwords are fetched from credential backends and piped internally, never appearing in command strings or logs.

## New parameters

### ssh_execute
| Param | Type | Description |
|-------|------|-------------|
| `sudo` | bool | Wrap command in `sudo -S` (or `-n` if no password ref) |
| `sudo_password_ref` | `{backend, ref}` | Credential ref for sudo password |

### ssh_session_execute
Same as above, plus:
| `enable_password_ref` | `{backend, ref}` | Cisco IOS enable mode password |

## Behavior

- **sudo with password**: fetches credential, pipes to `sudo -S -p <token> -- sh -c '<cmd>'`
- **sudo without password ref**: tries `sudo -n` first; if it fails with "password required", returns clear error asking for `sudo_password_ref`
- **Cisco enable**: state machine — sends `enable\n`, detects password prompt, sends password, waits for `#` prompt, then runs command

## Changes
- `src/ssh/privilege-escalation.ts` — shared helpers, prompt detection
- `src/ssh/pty-manager.ts` — sudo prompt interception
- `src/tools/ssh-execute.ts` + `ssh-session-execute.ts` — new params wired in
- `src/index.ts` — MCP schemas updated
- `test/unit/sudo-escalation.test.ts` — 30 new tests (no password leakage verified)

## Tests
✅ 236 tests pass