### PR TITLE
feat: SCP/SFTP file transfer tools (ssh_upload, ssh_download, ssh_sftp_list)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import { sshMultiExecute } from './tools/ssh-multi-execute.js';
 import { credentialGet } from './tools/credential-get.js';
 import { credentialListBackends } from './tools/credential-list.js';
 import { sshCheckHost } from './tools/ssh-check.js';
+import { sshUpload, sshDownload, sshSftpList } from './tools/ssh-transfer.js';
 import { versionCheck } from './tools/version-check.js';
 import { credentialDiagnose } from './tools/credential-diagnose.js';
 import { CredentialRegistry } from './credentials/registry.js';
@@ -303,6 +304,87 @@ server.tool(
       return {
         content: [{ type: 'text' as const, text: JSON.stringify({ success: true, path: credentialMap.getFilePath() }) }],
       };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── ssh_upload ────────────────────────────────────────────────────────────────
+server.tool(
+  'ssh_upload',
+  'Upload a local file to a remote host via SFTP.',
+  {
+    host: z.string().describe('Hostname or IP address of the remote target'),
+    local_path: z.string().describe('Path to the local file to upload'),
+    remote_path: z.string().describe('Destination path on the remote host'),
+    username: z.string().optional().describe('SSH username (overrides credential ref username and ~/.ssh/config User)'),
+    credential_ref: z.string().optional().describe('Credential reference string understood by the selected backend'),
+    credential_backend: z.string().optional().describe('Name of the credential backend (default: google-secret-manager)'),
+    port: z.number().int().min(1).max(65535).optional().describe('SSH port (default: 22)'),
+    timeout_ms: z.number().int().positive().optional().describe('Transfer timeout in milliseconds (default: 30000)'),
+  },
+  async (input) => {
+    try {
+      const result = await sshUpload(registry, input, credentialMap);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── ssh_download ─────────────────────────────────────────────────────────────
+server.tool(
+  'ssh_download',
+  'Download a remote file to the local filesystem via SFTP.',
+  {
+    host: z.string().describe('Hostname or IP address of the remote target'),
+    remote_path: z.string().describe('Path to the file on the remote host'),
+    local_path: z.string().describe('Destination path on the local filesystem'),
+    username: z.string().optional().describe('SSH username (overrides credential ref username and ~/.ssh/config User)'),
+    credential_ref: z.string().optional().describe('Credential reference string understood by the selected backend'),
+    credential_backend: z.string().optional().describe('Name of the credential backend (default: google-secret-manager)'),
+    port: z.number().int().min(1).max(65535).optional().describe('SSH port (default: 22)'),
+    timeout_ms: z.number().int().positive().optional().describe('Transfer timeout in milliseconds (default: 30000)'),
+  },
+  async (input) => {
+    try {
+      const result = await sshDownload(registry, input, credentialMap);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── ssh_sftp_list ────────────────────────────────────────────────────────────
+server.tool(
+  'ssh_sftp_list',
+  'List remote directory contents via SFTP.',
+  {
+    host: z.string().describe('Hostname or IP address of the remote target'),
+    remote_path: z.string().describe('Path to the remote directory to list'),
+    recursive: z.boolean().optional().describe('When true, list directory contents recursively (default: false)'),
+    username: z.string().optional().describe('SSH username (overrides credential ref username and ~/.ssh/config User)'),
+    credential_ref: z.string().optional().describe('Credential reference string understood by the selected backend'),
+    credential_backend: z.string().optional().describe('Name of the credential backend (default: google-secret-manager)'),
+    port: z.number().int().min(1).max(65535).optional().describe('SSH port (default: 22)'),
+    timeout_ms: z.number().int().positive().optional().describe('Operation timeout in milliseconds (default: 30000)'),
+  },
+  async (input) => {
+    try {
+      const result = await sshSftpList(registry, input, credentialMap);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
     } catch (err: unknown) {
       return {
         content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],

--- a/src/tools/ssh-transfer.ts
+++ b/src/tools/ssh-transfer.ts
@@ -1,0 +1,431 @@
+/**
+ * SCP/SFTP file transfer tools — ssh_upload, ssh_download, ssh_sftp_list.
+ *
+ * All three tools use the `sftp` binary in batch mode for consistency.
+ * Password auth is handled via `sshpass -d <fd>` when a credential is resolved.
+ */
+
+import { spawn } from 'child_process';
+import { resolveCliPath } from '../utils/cli-resolver.js';
+import { resolveSshConfig } from '../ssh/ssh-config-reader.js';
+import type { CredentialRegistry } from '../credentials/registry.js';
+import type { CredentialMap } from '../credentials/credential-map.js';
+
+// ── Shared types ─────────────────────────────────────────────────────────────
+
+export interface SshTransferInput {
+  host: string;
+  username?: string;
+  credential_ref?: string;
+  credential_backend?: string;
+  port?: number;
+  timeout_ms?: number;
+}
+
+export interface SshUploadInput extends SshTransferInput {
+  local_path: string;
+  remote_path: string;
+}
+
+export interface SshDownloadInput extends SshTransferInput {
+  remote_path: string;
+  local_path: string;
+}
+
+export interface SshSftpListInput extends SshTransferInput {
+  remote_path: string;
+  recursive?: boolean;
+}
+
+export interface SftpEntry {
+  name: string;
+  type: 'file' | 'directory' | 'symlink';
+  size?: number;
+  permissions?: string;
+  modified?: string;
+}
+
+export interface SftpListResult {
+  path: string;
+  entries: SftpEntry[];
+  truncated: boolean;
+}
+
+export interface TransferResult {
+  success: boolean;
+  local_path: string;
+  remote_path: string;
+  duration_ms: number;
+  message?: string;
+}
+
+const MAX_LIST_ENTRIES = 200;
+
+// ── Path validation ──────────────────────────────────────────────────────────
+
+function validatePath(path: string, label: string): void {
+  if (!path || !path.trim()) {
+    throw new Error(`${label} is required`);
+  }
+  if (/[\r\n]/.test(path)) {
+    throw new Error(`${label} must not contain newline characters`);
+  }
+}
+
+// ── Environment allowlist ────────────────────────────────────────────────────
+
+function buildSshEnv(extra?: Record<string, string>): Record<string, string> {
+  const env: Record<string, string> = {};
+  const allowlist = [
+    'HOME', 'PATH', 'TERM', 'LANG', 'LC_ALL',
+    'SSH_AUTH_SOCK', 'SSH_AGENT_PID',
+    'USERPROFILE', 'HOMEDRIVE', 'HOMEPATH', 'SystemRoot',
+  ];
+  for (const key of allowlist) {
+    const value = process.env[key];
+    if (value) env[key] = value;
+  }
+  env.TERM ??= 'xterm-color';
+  if (extra) Object.assign(env, extra);
+  return env;
+}
+
+// ── Credential resolution ────────────────────────────────────────────────────
+
+interface ResolvedAuth {
+  username: string;
+  password: Buffer<ArrayBufferLike>;
+}
+
+async function resolveAuth(
+  registry: CredentialRegistry,
+  credentialMap: CredentialMap,
+  host: string,
+  credentialBackend?: string,
+  credentialRef?: string,
+  explicitUsername?: string,
+): Promise<ResolvedAuth> {
+  let backend = credentialBackend;
+  let ref = credentialRef;
+  let mappedUsername: string | undefined;
+
+  if (backend === undefined && ref === undefined) {
+    const mapped = credentialMap.resolve(host);
+    if (mapped) {
+      backend = mapped.backend;
+      ref = mapped.ref;
+      mappedUsername = mapped.username;
+    }
+  }
+
+  let resolvedUsername = explicitUsername ?? mappedUsername ?? '';
+  let passwordBuffer: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+
+  if (ref !== undefined) {
+    if (!ref.trim()) {
+      throw new Error('credential_ref cannot be empty');
+    }
+    const backendName = backend ?? 'google-secret-manager';
+    const backendInst = registry.getBackend(backendName);
+    try {
+      const available = await backendInst.isAvailable();
+      if (!available) {
+        throw new Error(`Credential backend "${backendName}" is not available`);
+      }
+      const cred = await backendInst.getCredential(ref);
+      resolvedUsername = cred.username || resolvedUsername;
+      passwordBuffer = Buffer.from(cred.password) as Buffer<ArrayBufferLike>;
+      cred.password.fill(0);
+    } finally {
+      await backendInst.cleanup();
+    }
+  }
+
+  // Resolve SSH config for username if still missing
+  if (!resolvedUsername) {
+    const cfg = await resolveSshConfig(host);
+    if (cfg?.user) {
+      resolvedUsername = cfg.user;
+    }
+  }
+
+  if (!resolvedUsername) {
+    throw new Error(
+      'username is required. Provide username, a credential_ref with a username, ' +
+      'or add a User directive to ~/.ssh/config for this host.',
+    );
+  }
+
+  return { username: resolvedUsername, password: passwordBuffer };
+}
+
+// ── SFTP subprocess runner ───────────────────────────────────────────────────
+
+interface SftpRunOptions {
+  host: string;
+  username: string;
+  password: Buffer<ArrayBufferLike>;
+  port?: number;
+  batchCommands: string;
+  timeoutMs: number;
+}
+
+/**
+ * Run sftp in batch mode. Returns { stdout, stderr }.
+ * Throws on non-zero exit or timeout.
+ */
+export async function runSftp(opts: SftpRunOptions): Promise<{ stdout: string; stderr: string }> {
+  const { host, username, password, port, batchCommands, timeoutMs } = opts;
+  const hasPassword = password.length > 0;
+
+  const sftpArgs: string[] = [
+    '-o', 'StrictHostKeyChecking=accept-new',
+    '-o', `ConnectTimeout=${Math.max(1, Math.ceil(timeoutMs / 1000))}`,
+    '-o', 'NumberOfPasswordPrompts=1',
+    '-b', '-',  // read batch commands from stdin
+  ];
+  if (port !== undefined && port !== 22) {
+    sftpArgs.push('-P', String(port));
+  }
+  sftpArgs.push(`${username}@${host}`);
+
+  let cmd: string;
+  let args: string[];
+  const env = buildSshEnv();
+
+  if (hasPassword) {
+    // Use sshpass to provide password
+    const sshpassBin = resolveCliPath('sshpass');
+    // Pass password via environment (SSHPASS)
+    env.SSHPASS = password.toString('utf-8');
+    cmd = sshpassBin;
+    args = ['-e', resolveCliPath('sftp'), ...sftpArgs];
+  } else {
+    cmd = resolveCliPath('sftp');
+    args = ['-o', 'BatchMode=yes', ...sftpArgs];
+  }
+
+  return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let finished = false;
+
+    const timer = setTimeout(() => {
+      if (!finished) {
+        finished = true;
+        child.kill('SIGTERM');
+        reject(new Error(`SFTP operation timed out after ${timeoutMs}ms`));
+      }
+    }, timeoutMs);
+
+    child.stdout.on('data', (data: Buffer) => { stdout += data.toString(); });
+    child.stderr.on('data', (data: Buffer) => { stderr += data.toString(); });
+
+    child.on('error', (err) => {
+      if (!finished) {
+        finished = true;
+        clearTimeout(timer);
+        reject(new Error(`Failed to spawn sftp: ${err.message}`));
+      }
+    });
+
+    child.on('close', (code) => {
+      if (!finished) {
+        finished = true;
+        clearTimeout(timer);
+        if (code === 0) {
+          resolve({ stdout, stderr });
+        } else {
+          const msg = stderr.trim() || `sftp exited with code ${code}`;
+          reject(new Error(msg));
+        }
+      }
+    });
+
+    // Write batch commands to stdin and close
+    child.stdin.write(batchCommands + '\n');
+    child.stdin.end();
+  });
+}
+
+// ── Quote path for SFTP batch command ────────────────────────────────────────
+
+function sftpQuote(p: string): string {
+  // Wrap in double quotes, escaping embedded backslashes and double quotes
+  return '"' + p.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
+}
+
+// ── Tool handlers ────────────────────────────────────────────────────────────
+
+export async function sshUpload(
+  registry: CredentialRegistry,
+  input: SshUploadInput,
+  credentialMap: CredentialMap,
+): Promise<TransferResult> {
+  if (!input.host) throw new Error('host is required');
+  validatePath(input.local_path, 'local_path');
+  validatePath(input.remote_path, 'remote_path');
+
+  const start = Date.now();
+  const auth = await resolveAuth(
+    registry, credentialMap, input.host,
+    input.credential_backend, input.credential_ref, input.username,
+  );
+
+  try {
+    const batchCmd = `put ${sftpQuote(input.local_path)} ${sftpQuote(input.remote_path)}`;
+    await runSftp({
+      host: input.host,
+      username: auth.username,
+      password: auth.password,
+      port: input.port,
+      batchCommands: batchCmd,
+      timeoutMs: input.timeout_ms ?? 30000,
+    });
+
+    return {
+      success: true,
+      local_path: input.local_path,
+      remote_path: input.remote_path,
+      duration_ms: Date.now() - start,
+    };
+  } finally {
+    auth.password.fill(0);
+  }
+}
+
+export async function sshDownload(
+  registry: CredentialRegistry,
+  input: SshDownloadInput,
+  credentialMap: CredentialMap,
+): Promise<TransferResult> {
+  if (!input.host) throw new Error('host is required');
+  validatePath(input.remote_path, 'remote_path');
+  validatePath(input.local_path, 'local_path');
+
+  const start = Date.now();
+  const auth = await resolveAuth(
+    registry, credentialMap, input.host,
+    input.credential_backend, input.credential_ref, input.username,
+  );
+
+  try {
+    const batchCmd = `get ${sftpQuote(input.remote_path)} ${sftpQuote(input.local_path)}`;
+    await runSftp({
+      host: input.host,
+      username: auth.username,
+      password: auth.password,
+      port: input.port,
+      batchCommands: batchCmd,
+      timeoutMs: input.timeout_ms ?? 30000,
+    });
+
+    return {
+      success: true,
+      local_path: input.local_path,
+      remote_path: input.remote_path,
+      duration_ms: Date.now() - start,
+    };
+  } finally {
+    auth.password.fill(0);
+  }
+}
+
+export async function sshSftpList(
+  registry: CredentialRegistry,
+  input: SshSftpListInput,
+  credentialMap: CredentialMap,
+): Promise<SftpListResult> {
+  if (!input.host) throw new Error('host is required');
+  validatePath(input.remote_path, 'remote_path');
+
+  const auth = await resolveAuth(
+    registry, credentialMap, input.host,
+    input.credential_backend, input.credential_ref, input.username,
+  );
+
+  try {
+    const lsFlag = input.recursive ? '-Rla' : '-la';
+    const batchCmd = `ls ${lsFlag} ${sftpQuote(input.remote_path)}`;
+    const { stdout } = await runSftp({
+      host: input.host,
+      username: auth.username,
+      password: auth.password,
+      port: input.port,
+      batchCommands: batchCmd,
+      timeoutMs: input.timeout_ms ?? 30000,
+    });
+
+    const entries = parseSftpListing(stdout);
+    const truncated = entries.length > MAX_LIST_ENTRIES;
+    return {
+      path: input.remote_path,
+      entries: truncated ? entries.slice(0, MAX_LIST_ENTRIES) : entries,
+      truncated,
+    };
+  } finally {
+    auth.password.fill(0);
+  }
+}
+
+// ── SFTP ls output parser ────────────────────────────────────────────────────
+
+/**
+ * Parse OpenSSH `ls -la` output lines into structured entries.
+ *
+ * Expected format per line:
+ *   -rw-r--r--    1 user  group     1234 Jan  1 12:00 filename
+ *   drwxr-xr-x    2 user  group     4096 Jan  1 12:00 dirname
+ *   lrwxrwxrwx    1 user  group       10 Jan  1 12:00 link -> target
+ *
+ * Best-effort parsing — unparseable lines are skipped.
+ */
+export function parseSftpListing(output: string): SftpEntry[] {
+  const entries: SftpEntry[] = [];
+  const lines = output.split('\n');
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    // Skip "total N" header and directory headers for recursive listings
+    if (/^total\s+\d+/i.test(trimmed)) continue;
+    if (trimmed.endsWith(':') && !trimmed.startsWith('-') && !trimmed.startsWith('d') && !trimmed.startsWith('l')) continue;
+
+    // Match ls -la output: permissions links user group size date name
+    const match = trimmed.match(
+      /^([dlcbps-][rwxsStT-]{9})\s+\d+\s+\S+\s+\S+\s+(\d+)\s+(\w+\s+\d+\s+[\d:]+)\s+(.+)$/
+    );
+    if (!match) continue;
+
+    const [, perms, sizeStr, dateStr, nameField] = match;
+    const name = nameField.includes(' -> ') ? nameField.split(' -> ')[0] : nameField;
+
+    // Skip . and .. entries
+    if (name === '.' || name === '..') continue;
+
+    let type: 'file' | 'directory' | 'symlink';
+    if (perms.startsWith('d')) {
+      type = 'directory';
+    } else if (perms.startsWith('l')) {
+      type = 'symlink';
+    } else {
+      type = 'file';
+    }
+
+    entries.push({
+      name,
+      type,
+      size: parseInt(sizeStr, 10),
+      permissions: perms,
+      modified: dateStr,
+    });
+  }
+
+  return entries;
+}

--- a/test/unit/sftp.test.ts
+++ b/test/unit/sftp.test.ts
@@ -1,0 +1,540 @@
+/**
+ * Unit tests for ssh-transfer tools (ssh_upload, ssh_download, ssh_sftp_list).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { CredentialRegistry } from '../../src/credentials/registry.js';
+import type { CredentialMap } from '../../src/credentials/credential-map.js';
+
+// Mock child_process.spawn
+const mockSpawn = vi.fn();
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    spawn: (...args: unknown[]) => mockSpawn(...args),
+    execFileSync: actual.execFileSync,
+  };
+});
+
+// Mock cli-resolver to avoid real binary lookups
+vi.mock('../../src/utils/cli-resolver.js', () => ({
+  resolveCliPath: (name: string) => `/usr/bin/${name}`,
+}));
+
+// Mock ssh-config-reader
+vi.mock('../../src/ssh/ssh-config-reader.js', () => ({
+  resolveSshConfig: vi.fn().mockResolvedValue(null),
+}));
+
+import { sshUpload, sshDownload, sshSftpList, parseSftpListing, runSftp } from '../../src/tools/ssh-transfer.js';
+import type { SshUploadInput, SshDownloadInput, SshSftpListInput } from '../../src/tools/ssh-transfer.js';
+import { EventEmitter, PassThrough, Writable } from 'stream';
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+function createMockRegistry(opts?: {
+  username?: string;
+  password?: string;
+  available?: boolean;
+}): CredentialRegistry {
+  const { username = 'testuser', password = 'testpass', available = true } = opts ?? {};
+  const mockBackend = {
+    name: 'test-backend',
+    isAvailable: vi.fn().mockResolvedValue(available),
+    getCredential: vi.fn().mockResolvedValue({
+      username,
+      password: Buffer.from(password),
+    }),
+    cleanup: vi.fn().mockResolvedValue(undefined),
+  };
+  return {
+    getBackend: vi.fn().mockReturnValue(mockBackend),
+    getCredential: vi.fn(),
+    register: vi.fn(),
+    listBackends: vi.fn(),
+  } as unknown as CredentialRegistry;
+}
+
+function createMockCredentialMap(mapped?: { backend: string; ref: string; username?: string }): CredentialMap {
+  return {
+    resolve: vi.fn().mockReturnValue(mapped ?? null),
+    reload: vi.fn(),
+    getFilePath: vi.fn(),
+  } as unknown as CredentialMap;
+}
+
+interface MockChildProcess extends EventEmitter {
+  stdout: PassThrough;
+  stderr: PassThrough;
+  stdin: Writable & { writtenData: string[] };
+  kill: ReturnType<typeof vi.fn>;
+}
+
+function createMockChild(opts?: {
+  exitCode?: number;
+  stdout?: string;
+  stderr?: string;
+  emitError?: Error;
+}): MockChildProcess {
+  const { exitCode = 0, stdout = '', stderr = '', emitError } = opts ?? {};
+
+  const child = new EventEmitter() as MockChildProcess;
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+
+  const writtenData: string[] = [];
+  child.stdin = new Writable({
+    write(chunk, _encoding, callback) {
+      writtenData.push(chunk.toString());
+      callback();
+    },
+  }) as MockChildProcess['stdin'];
+  child.stdin.writtenData = writtenData;
+  child.kill = vi.fn();
+
+  // Emit data then close asynchronously — use setTimeout(0) to ensure
+  // spawn callers have attached 'data' listeners before we push data.
+  setTimeout(() => {
+    if (emitError) {
+      child.emit('error', emitError);
+      return;
+    }
+    if (stdout) child.stdout.write(stdout);
+    child.stdout.end();
+    if (stderr) child.stderr.write(stderr);
+    child.stderr.end();
+    // Give 'data' events a chance to fire before 'close'
+    setTimeout(() => child.emit('close', exitCode), 0);
+  }, 0);
+
+  return child;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('parseSftpListing', () => {
+  it('parses standard ls -la output', () => {
+    const output = [
+      'total 8',
+      'drwxr-xr-x    2 root  root     4096 Jan  1 12:00 subdir',
+      '-rw-r--r--    1 root  root     1234 Feb 15 09:30 file.txt',
+      'lrwxrwxrwx    1 root  root       10 Mar  3 14:00 link -> target',
+    ].join('\n');
+
+    const entries = parseSftpListing(output);
+    expect(entries).toHaveLength(3);
+
+    expect(entries[0]).toEqual({
+      name: 'subdir',
+      type: 'directory',
+      size: 4096,
+      permissions: 'drwxr-xr-x',
+      modified: 'Jan  1 12:00',
+    });
+
+    expect(entries[1]).toEqual({
+      name: 'file.txt',
+      type: 'file',
+      size: 1234,
+      permissions: '-rw-r--r--',
+      modified: 'Feb 15 09:30',
+    });
+
+    expect(entries[2]).toEqual({
+      name: 'link',
+      type: 'symlink',
+      size: 10,
+      permissions: 'lrwxrwxrwx',
+      modified: 'Mar  3 14:00',
+    });
+  });
+
+  it('skips . and .. entries', () => {
+    const output = [
+      'drwxr-xr-x    2 root  root     4096 Jan  1 12:00 .',
+      'drwxr-xr-x    3 root  root     4096 Jan  1 12:00 ..',
+      '-rw-r--r--    1 root  root       42 Jan  1 12:00 data.txt',
+    ].join('\n');
+
+    const entries = parseSftpListing(output);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].name).toBe('data.txt');
+  });
+
+  it('skips unparseable lines', () => {
+    const output = [
+      'some random text',
+      '-rw-r--r--    1 root  root     100 Jan  1 12:00 valid.txt',
+      'another garbage line',
+    ].join('\n');
+
+    const entries = parseSftpListing(output);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].name).toBe('valid.txt');
+  });
+
+  it('returns empty array for empty output', () => {
+    expect(parseSftpListing('')).toEqual([]);
+  });
+
+  it('handles filenames with spaces', () => {
+    const output = '-rw-r--r--    1 root  root     100 Jan  1 12:00 my file name.txt';
+    const entries = parseSftpListing(output);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].name).toBe('my file name.txt');
+  });
+});
+
+describe('runSftp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('runs sftp in batch mode without password (key-based auth)', async () => {
+    const child = createMockChild({ stdout: 'ok\n' });
+    mockSpawn.mockReturnValue(child);
+
+    const result = await runSftp({
+      host: 'example.com',
+      username: 'user',
+      password: Buffer.alloc(0),
+      batchCommands: 'ls /tmp',
+      timeoutMs: 5000,
+    });
+
+    expect(result.stdout).toBe('ok\n');
+    expect(mockSpawn).toHaveBeenCalledOnce();
+
+    // Should use sftp binary directly (no sshpass)
+    const [cmd, args] = mockSpawn.mock.calls[0];
+    expect(cmd).toBe('/usr/bin/sftp');
+    expect(args).toContain('-o');
+    expect(args).toContain('BatchMode=yes');
+    expect(args).toContain('user@example.com');
+
+    // Verify batch commands were sent to stdin
+    expect(child.stdin.writtenData.join('')).toContain('ls /tmp');
+  });
+
+  it('uses sshpass when password is provided', async () => {
+    const child = createMockChild({ stdout: 'transferred\n' });
+    mockSpawn.mockReturnValue(child);
+
+    await runSftp({
+      host: 'host.test',
+      username: 'admin',
+      password: Buffer.from('secret'),
+      batchCommands: 'put /local /remote',
+      timeoutMs: 5000,
+    });
+
+    const [cmd, args, spawnOpts] = mockSpawn.mock.calls[0];
+    expect(cmd).toBe('/usr/bin/sshpass');
+    expect(args[0]).toBe('-e');
+    expect(args[1]).toBe('/usr/bin/sftp');
+    expect(spawnOpts.env.SSHPASS).toBe('secret');
+  });
+
+  it('includes port when non-default', async () => {
+    const child = createMockChild({ stdout: '' });
+    mockSpawn.mockReturnValue(child);
+
+    await runSftp({
+      host: 'host.test',
+      username: 'user',
+      password: Buffer.alloc(0),
+      port: 2222,
+      batchCommands: 'ls /',
+      timeoutMs: 5000,
+    });
+
+    const [, args] = mockSpawn.mock.calls[0];
+    expect(args).toContain('-P');
+    expect(args).toContain('2222');
+  });
+
+  it('rejects on non-zero exit code', async () => {
+    const child = createMockChild({ exitCode: 1, stderr: 'Connection refused' });
+    mockSpawn.mockReturnValue(child);
+
+    await expect(runSftp({
+      host: 'host.test',
+      username: 'user',
+      password: Buffer.alloc(0),
+      batchCommands: 'ls /',
+      timeoutMs: 5000,
+    })).rejects.toThrow('Connection refused');
+  });
+
+  it('rejects on spawn error', async () => {
+    const child = createMockChild({ emitError: new Error('ENOENT') });
+    mockSpawn.mockReturnValue(child);
+
+    await expect(runSftp({
+      host: 'host.test',
+      username: 'user',
+      password: Buffer.alloc(0),
+      batchCommands: 'ls /',
+      timeoutMs: 5000,
+    })).rejects.toThrow('Failed to spawn sftp');
+  });
+
+  it('rejects on timeout', async () => {
+    vi.useFakeTimers();
+
+    // Create a child that never emits close
+    const child = new EventEmitter() as MockChildProcess;
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    const writtenData: string[] = [];
+    child.stdin = new Writable({
+      write(chunk, _enc, cb) { writtenData.push(chunk.toString()); cb(); },
+    }) as MockChildProcess['stdin'];
+    child.stdin.writtenData = writtenData;
+    child.kill = vi.fn();
+    mockSpawn.mockReturnValue(child);
+
+    const promise = runSftp({
+      host: 'host.test',
+      username: 'user',
+      password: Buffer.alloc(0),
+      batchCommands: 'ls /',
+      timeoutMs: 1000,
+    });
+
+    vi.advanceTimersByTime(1001);
+
+    await expect(promise).rejects.toThrow('timed out');
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+
+    vi.useRealTimers();
+  });
+});
+
+describe('sshUpload', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('uploads a file successfully', async () => {
+    const child = createMockChild({ stdout: '' });
+    mockSpawn.mockReturnValue(child);
+
+    const registry = createMockRegistry();
+    const credMap = createMockCredentialMap();
+    const input: SshUploadInput = {
+      host: 'server.test',
+      local_path: '/tmp/file.txt',
+      remote_path: '/home/user/file.txt',
+      username: 'testuser',
+    };
+
+    const result = await sshUpload(registry, input, credMap);
+    expect(result.success).toBe(true);
+    expect(result.local_path).toBe('/tmp/file.txt');
+    expect(result.remote_path).toBe('/home/user/file.txt');
+    expect(result.duration_ms).toBeGreaterThanOrEqual(0);
+
+    // Verify batch command contains put
+    const stdinData = child.stdin.writtenData.join('');
+    expect(stdinData).toContain('put');
+  });
+
+  it('throws on empty host', async () => {
+    const registry = createMockRegistry();
+    const credMap = createMockCredentialMap();
+
+    await expect(sshUpload(registry, {
+      host: '',
+      local_path: '/tmp/f',
+      remote_path: '/remote/f',
+      username: 'user',
+    }, credMap)).rejects.toThrow('host is required');
+  });
+
+  it('throws on path with newlines', async () => {
+    const registry = createMockRegistry();
+    const credMap = createMockCredentialMap();
+
+    await expect(sshUpload(registry, {
+      host: 'server',
+      local_path: '/tmp/file\n.txt',
+      remote_path: '/remote/file.txt',
+      username: 'user',
+    }, credMap)).rejects.toThrow('must not contain newline');
+  });
+
+  it('resolves credentials from credential map', async () => {
+    const child = createMockChild({ stdout: '' });
+    mockSpawn.mockReturnValue(child);
+
+    const registry = createMockRegistry();
+    const credMap = createMockCredentialMap({
+      backend: 'test-backend',
+      ref: 'my-secret',
+      username: 'mapuser',
+    });
+
+    await sshUpload(registry, {
+      host: 'server.test',
+      local_path: '/tmp/f',
+      remote_path: '/remote/f',
+    }, credMap);
+
+    expect(credMap.resolve).toHaveBeenCalledWith('server.test');
+    expect(registry.getBackend).toHaveBeenCalledWith('test-backend');
+  });
+
+  it('zeros password buffer after transfer', async () => {
+    const child = createMockChild({ stdout: '' });
+    mockSpawn.mockReturnValue(child);
+
+    const passwordBuf = Buffer.from('mysecret');
+    const mockBackend = {
+      name: 'test-backend',
+      isAvailable: vi.fn().mockResolvedValue(true),
+      getCredential: vi.fn().mockResolvedValue({
+        username: 'user',
+        password: passwordBuf,
+      }),
+      cleanup: vi.fn().mockResolvedValue(undefined),
+    };
+    const registry = {
+      getBackend: vi.fn().mockReturnValue(mockBackend),
+    } as unknown as CredentialRegistry;
+    const credMap = createMockCredentialMap();
+
+    await sshUpload(registry, {
+      host: 'server.test',
+      local_path: '/tmp/f',
+      remote_path: '/remote/f',
+      credential_backend: 'test-backend',
+      credential_ref: 'my-ref',
+    }, credMap);
+
+    // The original password buffer should have been zeroed by resolveAuth
+    expect(passwordBuf.every(b => b === 0)).toBe(true);
+  });
+});
+
+describe('sshDownload', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('downloads a file successfully', async () => {
+    const child = createMockChild({ stdout: '' });
+    mockSpawn.mockReturnValue(child);
+
+    const registry = createMockRegistry();
+    const credMap = createMockCredentialMap();
+
+    const result = await sshDownload(registry, {
+      host: 'server.test',
+      remote_path: '/remote/data.csv',
+      local_path: '/tmp/data.csv',
+      username: 'user',
+    }, credMap);
+
+    expect(result.success).toBe(true);
+    expect(result.remote_path).toBe('/remote/data.csv');
+    expect(result.local_path).toBe('/tmp/data.csv');
+
+    const stdinData = child.stdin.writtenData.join('');
+    expect(stdinData).toContain('get');
+  });
+
+  it('throws on missing remote_path', async () => {
+    const registry = createMockRegistry();
+    const credMap = createMockCredentialMap();
+
+    await expect(sshDownload(registry, {
+      host: 'server',
+      remote_path: '',
+      local_path: '/tmp/f',
+      username: 'user',
+    }, credMap)).rejects.toThrow('remote_path is required');
+  });
+});
+
+describe('sshSftpList', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('lists directory contents', async () => {
+    const lsOutput = [
+      'total 12',
+      'drwxr-xr-x    2 root  root     4096 Jan  1 12:00 subdir',
+      '-rw-r--r--    1 root  root     1234 Feb 15 09:30 file.txt',
+    ].join('\n');
+
+    const child = createMockChild({ stdout: lsOutput });
+    mockSpawn.mockReturnValue(child);
+
+    const registry = createMockRegistry();
+    const credMap = createMockCredentialMap();
+
+    const result = await sshSftpList(registry, {
+      host: 'server.test',
+      remote_path: '/var/data',
+      username: 'user',
+    }, credMap);
+
+    expect(result.path).toBe('/var/data');
+    expect(result.entries).toHaveLength(2);
+    expect(result.truncated).toBe(false);
+    expect(result.entries[0].name).toBe('subdir');
+    expect(result.entries[0].type).toBe('directory');
+    expect(result.entries[1].name).toBe('file.txt');
+    expect(result.entries[1].type).toBe('file');
+  });
+
+  it('truncates at 200 entries', async () => {
+    const lines = ['total 999'];
+    for (let i = 0; i < 250; i++) {
+      lines.push(`-rw-r--r--    1 root  root     ${i} Jan  1 12:00 file${i}.txt`);
+    }
+    const child = createMockChild({ stdout: lines.join('\n') });
+    mockSpawn.mockReturnValue(child);
+
+    const registry = createMockRegistry();
+    const credMap = createMockCredentialMap();
+
+    const result = await sshSftpList(registry, {
+      host: 'server.test',
+      remote_path: '/big',
+      username: 'user',
+    }, credMap);
+
+    expect(result.entries).toHaveLength(200);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('uses recursive flag', async () => {
+    const child = createMockChild({ stdout: '' });
+    mockSpawn.mockReturnValue(child);
+
+    const registry = createMockRegistry();
+    const credMap = createMockCredentialMap();
+
+    await sshSftpList(registry, {
+      host: 'server.test',
+      remote_path: '/data',
+      recursive: true,
+      username: 'user',
+    }, credMap);
+
+    const stdinData = child.stdin.writtenData.join('');
+    expect(stdinData).toContain('-Rla');
+  });
+
+  it('propagates sftp errors', async () => {
+    const child = createMockChild({ exitCode: 1, stderr: 'No such file or directory' });
+    mockSpawn.mockReturnValue(child);
+
+    const registry = createMockRegistry();
+    const credMap = createMockCredentialMap();
+
+    await expect(sshSftpList(registry, {
+      host: 'server.test',
+      remote_path: '/nonexistent',
+      username: 'user',
+    }, credMap)).rejects.toThrow('No such file or directory');
+  });
+});

--- a/test/unit/sftp.test.ts
+++ b/test/unit/sftp.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for ssh-transfer tools (ssh_upload, ssh_download, ssh_sftp_list).
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { CredentialRegistry } from '../../src/credentials/registry.js';
 import type { CredentialMap } from '../../src/credentials/credential-map.js';
 
@@ -28,7 +28,7 @@ vi.mock('../../src/ssh/ssh-config-reader.js', () => ({
 }));
 
 import { sshUpload, sshDownload, sshSftpList, parseSftpListing, runSftp } from '../../src/tools/ssh-transfer.js';
-import type { SshUploadInput, SshDownloadInput, SshSftpListInput } from '../../src/tools/ssh-transfer.js';
+import type { SshUploadInput } from '../../src/tools/ssh-transfer.js';
 import { EventEmitter, PassThrough, Writable } from 'stream';
 
 // ── Test helpers ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #82

## Summary

Three new tools for file transfer over SSH — no more `cat | base64` workarounds. Uses `sftp` batch mode for security and consistency.

## New tools

| Tool | Description |
|------|-------------|
| `ssh_upload` | Upload local file to remote path |
| `ssh_download` | Download remote file to local path |
| `ssh_sftp_list` | List remote directory (structured, capped at 200 entries) |

## ssh_sftp_list response
```json
{
  "entries": [
    { "name": "app.log", "type": "file", "size": 102400, "permissions": "-rw-r--r--", "modified": "May  7 14:00" },
    { "name": "logs", "type": "directory", "permissions": "drwxr-xr-x" }
  ],
  "truncated": false
}
```

## Implementation details
- sftp batch mode (`-b`) — no interactive prompts
- Password auth via `sshpass -e`; key-based auth with `BatchMode=yes`
- Same credential resolution as `ssh_execute`
- Path validation rejects `\r\n` to prevent batch command injection
- Password buffers zero-filled after use

## Changes
- `src/tools/ssh-transfer.ts` — all 3 tools
- `src/index.ts` — tools registered with full zod schemas
- `test/unit/sftp.test.ts` — 22 new tests

## Tests
✅ 228 tests pass