### PR TITLE
feat: ssh_list_hosts inventory tool (closes #123)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,7 @@ import { sshForwardRemote } from './tools/ssh-forward-remote.js';
 import { sshForwardDynamic } from './tools/ssh-forward-dynamic.js';
 import { sshForwardClose } from './tools/ssh-forward-close.js';
 import { sshForwardList } from './tools/ssh-forward-list.js';
+import { sshListHosts } from './tools/ssh-list-hosts.js';
 import { destroyAllForwards } from './ssh/forward-manager.js';
 import { CredentialRegistry } from './credentials/registry.js';
 import { CredentialMap } from './credentials/credential-map.js';
@@ -521,6 +522,26 @@ server.tool(
   async () => {
     try {
       const result = sshForwardList();
+      return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
+    } catch (err: unknown) {
+      return {
+        content: [{ type: 'text' as const, text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }
+);
+
+// ── ssh_list_hosts ───────────────────────────────────────────────────────────
+server.tool(
+  'ssh_list_hosts',
+  'List SSH host aliases from ~/.ssh/config (including Include directives). Returns a sanitized inventory with alias, hostname, user, port, and source file.',
+  {
+    pattern: z.string().optional().describe('Glob pattern to filter host aliases (e.g. "prod-*")'),
+  },
+  async (input) => {
+    try {
+      const result = await sshListHosts(input);
       return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
     } catch (err: unknown) {
       return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,9 +112,11 @@ server.tool(
         username: input.username ?? '',
         credential_backend: input.credential_backend,
         command: input.command,
-        exit_code: result.exit_code,
+        ...(!('dry_run' in result && result.dry_run) && {
+          exit_code: (result as { exit_code: number }).exit_code,
+          stdout_bytes: Buffer.byteLength((result as { output: string }).output, 'utf-8'),
+        }),
         duration_ms: Date.now() - start,
-        stdout_bytes: Buffer.byteLength(result.output, 'utf-8'),
         success: true,
       });
       return { content: [{ type: 'text' as const, text: JSON.stringify(result) }] };
@@ -271,7 +273,7 @@ server.tool(
       auditLogger.log({
         tool: 'ssh_session_open',
         host: input.host,
-        username: result.username,
+        username: !('dry_run' in result && result.dry_run) ? (result as { username: string }).username : '',
         credential_backend: input.credential_backend,
         duration_ms: Date.now() - start,
         success: true,

--- a/src/tools/ssh-list-hosts.ts
+++ b/src/tools/ssh-list-hosts.ts
@@ -1,0 +1,319 @@
+/**
+ * ssh_list_hosts tool handler — enumerates Host entries from ~/.ssh/config
+ * (including Include directives) and returns a sanitized inventory.
+ *
+ * Only exposes: alias, hostname, user, port, source file.
+ * Excludes: IdentityFile, ProxyJump, ProxyCommand, and all other sensitive directives.
+ */
+
+import { readFile, readdir, realpath } from 'fs/promises';
+import { join, dirname, isAbsolute } from 'path';
+import { homedir } from 'os';
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface SshHostEntry {
+  alias: string;
+  hostname?: string;
+  user?: string;
+  port?: number;
+  source: string;
+}
+
+export interface SshListHostsInput {
+  pattern?: string;
+}
+
+export interface SshListHostsResult {
+  hosts: SshHostEntry[];
+}
+
+/** Abstraction over filesystem operations for testability. */
+export interface FsLike {
+  readFile(path: string, encoding: 'utf-8'): Promise<string>;
+  readdir(path: string): Promise<string[]>;
+  realpath(path: string): Promise<string>;
+}
+
+const defaultFs: FsLike = {
+  readFile: (p, enc) => readFile(p, enc),
+  readdir: (p) => readdir(p),
+  realpath: (p) => realpath(p),
+};
+
+// ── Glob pattern matching ───────────────────────────────────────────────────
+
+/** Returns true if `alias` contains SSH glob metacharacters (* ? [ ]). */
+function isWildcardPattern(alias: string): boolean {
+  return /[*?[\]]/.test(alias);
+}
+
+/**
+ * Convert a simple glob pattern to a RegExp.
+ * Escapes regex metacharacters, then maps `*` → `.*` and `?` → `.`.
+ */
+function globToRegex(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+^${}()|\\]/g, '\\$&');
+  const regexStr = escaped.replace(/\*/g, '.*').replace(/\?/g, '.');
+  return new RegExp(`^${regexStr}$`);
+}
+
+// ── SSH config parsing ──────────────────────────────────────────────────────
+
+/**
+ * Strip inline comments: everything after an unquoted `#`.
+ * A `#` preceded by whitespace (or at start) is a comment.
+ */
+function stripComment(line: string): string {
+  // Leading comment
+  if (line.trimStart().startsWith('#')) return '';
+
+  // Inline comment: # preceded by whitespace and not inside quotes
+  let inQuote = false;
+  for (let i = 0; i < line.length; i++) {
+    if (line[i] === '"') {
+      inQuote = !inQuote;
+    } else if (line[i] === '#' && !inQuote && i > 0 && /\s/.test(line[i - 1])) {
+      return line.slice(0, i);
+    }
+  }
+  return line;
+}
+
+/**
+ * Parse a keyword and value from an SSH config line.
+ * Handles both `Keyword value` and `Keyword=value` syntax.
+ * Returns null for empty/comment lines.
+ */
+function parseConfigLine(raw: string): { keyword: string; value: string } | null {
+  const line = stripComment(raw).trim();
+  if (!line) return null;
+
+  // Split on first whitespace or '='
+  const match = line.match(/^(\S+?)(?:\s*=\s*|\s+)(.+)$/);
+  if (!match) return null;
+
+  return { keyword: match[1].toLowerCase(), value: match[2].trim() };
+}
+
+/**
+ * Expand ~ to the user's home directory.
+ */
+function expandTilde(p: string, home: string): string {
+  if (p.startsWith('~/')) return join(home, p.slice(2));
+  if (p === '~') return home;
+  return p;
+}
+
+/**
+ * Expand a glob pattern in a directory, returning matching file paths (sorted).
+ * Handles simple `*` wildcards in the last path segment.
+ */
+async function expandIncludeGlob(
+  pattern: string,
+  sshDir: string,
+  home: string,
+  fs: FsLike,
+): Promise<string[]> {
+  const expanded = expandTilde(pattern, home);
+  const full = isAbsolute(expanded) ? expanded : join(sshDir, expanded);
+
+  const dir = dirname(full);
+  const base = full.slice(dir.length + 1);
+
+  // If no glob chars, return as-is
+  if (!isWildcardPattern(base)) {
+    return [full];
+  }
+
+  const regex = globToRegex(base);
+  try {
+    const entries = await fs.readdir(dir);
+    return entries
+      .filter((e) => regex.test(e))
+      .sort()
+      .map((e) => join(dir, e));
+  } catch {
+    // Directory not found — no matches
+    return [];
+  }
+}
+
+interface ParseContext {
+  fs: FsLike;
+  home: string;
+  sshDir: string;
+  visited: Set<string>;
+  maxDepth: number;
+}
+
+/**
+ * Parse a single SSH config file and return host entries.
+ * Follows Include directives recursively with cycle detection.
+ */
+async function parseSshConfigFile(
+  filePath: string,
+  ctx: ParseContext,
+  depth: number,
+): Promise<SshHostEntry[]> {
+  if (depth > ctx.maxDepth) return [];
+
+  let resolvedPath: string;
+  try {
+    resolvedPath = await ctx.fs.realpath(filePath);
+  } catch {
+    // File doesn't exist
+    return [];
+  }
+
+  if (ctx.visited.has(resolvedPath)) return [];
+  ctx.visited.add(resolvedPath);
+
+  let content: string;
+  try {
+    content = await ctx.fs.readFile(filePath, 'utf-8');
+  } catch {
+    return [];
+  }
+
+  const hosts: SshHostEntry[] = [];
+  let currentBlock: {
+    aliases: string[];
+    hostname?: string;
+    user?: string;
+    port?: number;
+    source: string;
+  } | null = null;
+
+  // Relative path for source display — normalize to tilde form cross-platform.
+  // On Windows, ctx.home uses backslashes; we normalize both to forward slashes
+  // before comparing so the result is always in POSIX tilde form (~/.ssh/...).
+  const normFilePath = filePath.replace(/\\/g, '/');
+  const normHome = ctx.home.replace(/\\/g, '/');
+  const sourceDisplay = normFilePath.startsWith(normHome + '/')
+    ? '~/' + normFilePath.slice(normHome.length + 1)
+    : normFilePath;
+
+  const flushBlock = () => {
+    if (!currentBlock) return;
+    for (const alias of currentBlock.aliases) {
+      hosts.push({
+        alias,
+        hostname: currentBlock.hostname,
+        user: currentBlock.user,
+        port: currentBlock.port,
+        source: currentBlock.source,
+      });
+    }
+    currentBlock = null;
+  };
+
+  const lines = content.split('\n');
+  for (const rawLine of lines) {
+    const parsed = parseConfigLine(rawLine);
+    if (!parsed) continue;
+
+    const { keyword, value } = parsed;
+
+    if (keyword === 'host') {
+      flushBlock();
+
+      // Split Host value into individual patterns, filtering wildcards and negations
+      const aliases = value
+        .split(/\s+/)
+        .filter((a) => a && !isWildcardPattern(a) && !a.startsWith('!'));
+
+      if (aliases.length > 0) {
+        currentBlock = { aliases, source: sourceDisplay };
+      }
+    } else if (keyword === 'match') {
+      // Match block — stop accumulating into current Host block
+      flushBlock();
+    } else if (keyword === 'include') {
+      flushBlock();
+      // Include may specify multiple patterns separated by whitespace
+      const patterns = value.split(/\s+/).filter(Boolean);
+      for (const pattern of patterns) {
+        const files = await expandIncludeGlob(pattern, ctx.sshDir, ctx.home, ctx.fs);
+        for (const file of files) {
+          const included = await parseSshConfigFile(file, ctx, depth + 1);
+          hosts.push(...included);
+        }
+      }
+    } else if (currentBlock) {
+      // Only capture safe fields
+      switch (keyword) {
+        case 'hostname':
+          currentBlock.hostname ??= value;
+          break;
+        case 'user':
+          currentBlock.user ??= value;
+          break;
+        case 'port': {
+          if (currentBlock.port === undefined) {
+            const p = /^\d+$/.test(value) ? parseInt(value, 10) : NaN;
+            if (Number.isFinite(p) && p >= 1 && p <= 65535) {
+              currentBlock.port = p;
+            }
+          }
+          break;
+        }
+        // All other directives (IdentityFile, ProxyJump, etc.) are intentionally ignored
+      }
+    }
+  }
+
+  flushBlock();
+  return hosts;
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/**
+ * List SSH host entries from ~/.ssh/config.
+ *
+ * @param input - Optional pattern to filter aliases (glob syntax: `*`, `?`).
+ * @param fs - Filesystem abstraction for testing.
+ * @param homeDir - Override home directory for testing.
+ */
+export async function sshListHosts(
+  input: SshListHostsInput,
+  fs: FsLike = defaultFs,
+  homeDir?: string,
+): Promise<SshListHostsResult> {
+  const home = homeDir ?? homedir();
+  const sshDir = join(home, '.ssh');
+  const configPath = join(sshDir, 'config');
+
+  const ctx: ParseContext = {
+    fs,
+    home,
+    sshDir,
+    visited: new Set(),
+    maxDepth: 10,
+  };
+
+  const hosts = await parseSshConfigFile(configPath, ctx, 0);
+
+  // Deduplicate by alias (first occurrence wins, matching SSH semantics)
+  const seen = new Set<string>();
+  const deduped: SshHostEntry[] = [];
+  for (const h of hosts) {
+    if (!seen.has(h.alias)) {
+      seen.add(h.alias);
+      deduped.push(h);
+    }
+  }
+
+  // Apply glob filter if pattern provided
+  let result = deduped;
+  if (input.pattern) {
+    const regex = globToRegex(input.pattern);
+    result = deduped.filter((h) => regex.test(h.alias));
+  }
+
+  // Sort by alias for deterministic output
+  result.sort((a, b) => a.alias.localeCompare(b.alias));
+
+  return { hosts: result };
+}

--- a/test/unit/ssh-list-hosts.test.ts
+++ b/test/unit/ssh-list-hosts.test.ts
@@ -1,0 +1,508 @@
+/**
+ * Unit tests for ssh-list-hosts.ts
+ * Mocks filesystem reads to test SSH config parsing, Include expansion,
+ * glob filtering, and sensitive field exclusion.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { join } from 'path';
+import { sshListHosts, type FsLike, type SshHostEntry } from '../../src/tools/ssh-list-hosts.js';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+// Use path.join so paths match what the tool produces on the current OS
+const HOME = process.platform === 'win32' ? 'C:\\Users\\testuser' : '/home/testuser';
+const SSH_DIR = join(HOME, '.ssh');
+const CONFIG = join(SSH_DIR, 'config');
+
+/** Build a mock filesystem from a map of path → content. */
+function mockFs(files: Record<string, string>, dirs: Record<string, string[]> = {}): FsLike {
+  return {
+    readFile: vi.fn(async (path: string) => {
+      if (path in files) return files[path];
+      const err = new Error(`ENOENT: no such file: ${path}`) as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    }),
+    readdir: vi.fn(async (path: string) => {
+      if (path in dirs) return dirs[path];
+      const err = new Error(`ENOENT: no such directory: ${path}`) as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    }),
+    realpath: vi.fn(async (path: string) => {
+      // If the file exists in our map, return the path as-is (simulating realpath)
+      if (path in files) return path;
+      const err = new Error(`ENOENT: no such file: ${path}`) as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    }),
+  };
+}
+
+function findHost(hosts: SshHostEntry[], alias: string): SshHostEntry | undefined {
+  return hosts.find((h) => h.alias === alias);
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('sshListHosts', () => {
+  it('parses basic Host entries with HostName, User, Port', async () => {
+    const fs = mockFs({
+      [CONFIG]: `
+Host web-prod
+  HostName 10.0.1.1
+  User deploy
+  Port 2222
+
+Host db-prod
+  HostName 10.0.2.1
+  User admin
+`,
+    });
+
+    const result = await sshListHosts({}, fs, HOME);
+
+    expect(result.hosts).toHaveLength(2);
+    const web = findHost(result.hosts, 'web-prod')!;
+    expect(web.hostname).toBe('10.0.1.1');
+    expect(web.user).toBe('deploy');
+    expect(web.port).toBe(2222);
+    expect(web.source).toBe('~/.ssh/config');
+
+    const db = findHost(result.hosts, 'db-prod')!;
+    expect(db.hostname).toBe('10.0.2.1');
+    expect(db.user).toBe('admin');
+    expect(db.port).toBeUndefined();
+  });
+
+  it('excludes IdentityFile, ProxyJump, ProxyCommand, and other sensitive fields', async () => {
+    const fs = mockFs({
+      [CONFIG]: `
+Host secure-box
+  HostName secure.example.com
+  User root
+  IdentityFile ~/.ssh/secret_key
+  ProxyJump bastion.example.com
+  ProxyCommand ssh -W %h:%p bastion
+  ForwardAgent yes
+  LocalForward 8080 localhost:80
+`,
+    });
+
+    const result = await sshListHosts({}, fs, HOME);
+
+    expect(result.hosts).toHaveLength(1);
+    const host = result.hosts[0];
+    expect(host.alias).toBe('secure-box');
+    expect(host.hostname).toBe('secure.example.com');
+    expect(host.user).toBe('root');
+    // Sensitive fields should NOT appear in the output
+    expect(host).not.toHaveProperty('identityFile');
+    expect(host).not.toHaveProperty('proxyJump');
+    expect(host).not.toHaveProperty('proxyCommand');
+    expect(host).not.toHaveProperty('forwardAgent');
+    // Only known safe fields (port is also safe but undefined here)
+    const keys = Object.keys(host).sort();
+    for (const k of keys) {
+      expect(['alias', 'hostname', 'user', 'port', 'source']).toContain(k);
+    }
+  });
+
+  it('skips wildcard-only Host entries like Host *', async () => {
+    const fs = mockFs({
+      [CONFIG]: `
+Host *
+  User default-user
+  ServerAliveInterval 60
+
+Host app-server
+  HostName app.example.com
+`,
+    });
+
+    const result = await sshListHosts({}, fs, HOME);
+
+    expect(result.hosts).toHaveLength(1);
+    expect(result.hosts[0].alias).toBe('app-server');
+  });
+
+  it('skips hosts with glob metacharacters (* ? [ ])', async () => {
+    const fs = mockFs({
+      [CONFIG]: `
+Host prod-*
+  User deploy
+
+Host dev-?
+  User developer
+
+Host staging[1-3]
+  User staging
+
+Host concrete-host
+  HostName concrete.example.com
+`,
+    });
+
+    const result = await sshListHosts({}, fs, HOME);
+
+    expect(result.hosts).toHaveLength(1);
+    expect(result.hosts[0].alias).toBe('concrete-host');
+  });
+
+  it('skips negated patterns (Host !bad-host)', async () => {
+    const fs = mockFs({
+      [CONFIG]: `
+Host good-host !bad-host
+  HostName good.example.com
+`,
+    });
+
+    const result = await sshListHosts({}, fs, HOME);
+
+    expect(result.hosts).toHaveLength(1);
+    expect(result.hosts[0].alias).toBe('good-host');
+  });
+
+  it('handles multiple aliases in a single Host line', async () => {
+    const fs = mockFs({
+      [CONFIG]: `
+Host alpha bravo charlie
+  HostName shared.example.com
+  User ops
+  Port 22
+`,
+    });
+
+    const result = await sshListHosts({}, fs, HOME);
+
+    expect(result.hosts).toHaveLength(3);
+    for (const alias of ['alpha', 'bravo', 'charlie']) {
+      const h = findHost(result.hosts, alias)!;
+      expect(h.hostname).toBe('shared.example.com');
+      expect(h.user).toBe('ops');
+    }
+  });
+
+  it('filters by glob pattern', async () => {
+    const fs = mockFs({
+      [CONFIG]: `
+Host prod-web
+  HostName 10.0.1.1
+
+Host prod-db
+  HostName 10.0.2.1
+
+Host staging-web
+  HostName 10.1.1.1
+`,
+    });
+
+    const result = await sshListHosts({ pattern: 'prod-*' }, fs, HOME);
+
+    expect(result.hosts).toHaveLength(2);
+    expect(result.hosts.map((h) => h.alias)).toEqual(['prod-db', 'prod-web']);
+  });
+
+  it('returns empty array when pattern matches nothing', async () => {
+    const fs = mockFs({
+      [CONFIG]: `
+Host app-server
+  HostName app.example.com
+`,
+    });
+
+    const result = await sshListHosts({ pattern: 'nope-*' }, fs, HOME);
+    expect(result.hosts).toHaveLength(0);
+  });
+
+  it('follows Include directives', async () => {
+    const fs = mockFs({
+      [CONFIG]: `Include conf.d/prod.conf\n\nHost local\n  HostName localhost\n`,
+      [join(SSH_DIR, 'conf.d', 'prod.conf')]: `
+Host prod-app
+  HostName prod.example.com
+  User deploy
+`,
+    });
+
+    const result = await sshListHosts({}, fs, HOME);
+
+    expect(result.hosts).toHaveLength(2);
+    const prodApp = findHost(result.hosts, 'prod-app')!;
+    expect(prodApp.hostname).toBe('prod.example.com');
+    expect(prodApp.source).toBe('~/.ssh/conf.d/prod.conf');
+
+    const local = findHost(result.hosts, 'local')!;
+    expect(local.hostname).toBe('localhost');
+    expect(local.source).toBe('~/.ssh/config');
+  });
+
+  it('follows Include with glob patterns', async () => {
+    const fs = mockFs(
+      {
+        [CONFIG]: `Include conf.d/*\n`,
+        [join(SSH_DIR, 'conf.d', 'a.conf')]: `Host alpha\n  HostName alpha.example.com\n`,
+        [join(SSH_DIR, 'conf.d', 'b.conf')]: `Host bravo\n  HostName bravo.example.com\n`,
+      },
+      {
+        [join(SSH_DIR, 'conf.d')]: ['a.conf', 'b.conf'],
+      },
+    );
+
+    const result = await sshListHosts({}, fs, HOME);
+
+    expect(result.hosts).toHaveLength(2);
+    expect(findHost(result.hosts, 'alpha')!.hostname).toBe('alpha.example.com');
+    expect(findHost(result.hosts, 'bravo')!.hostname).toBe('bravo.example.com');
+  });
+
+  it('follows Include with absolute path', async () => {
+    const absPath = process.platform === 'win32' ? 'C:\\etc\\ssh\\extra.conf' : '/etc/ssh/extra.conf';
+    const fs = mockFs({
+      [CONFIG]: `Include ${absPath}\n`,
+      [absPath]: `Host external\n  HostName ext.example.com\n`,
+    });
+
+    const result = await sshListHosts({}, fs, HOME);
+
+    expect(result.hosts).toHaveLength(1);
+    expect(result.hosts[0].alias).toBe('external');
+  });
+
+  it('follows Include with tilde path', async () => {
+    const fs = mockFs({
+      [CONFIG]: `Include ~/.ssh/extra.conf\n`,
+      [join(SSH_DIR, 'extra.conf')]: `Host tilde-host\n  HostName tilde.example.com\n`,
+    });
+
+    const result = await sshListHosts({}, fs, HOME);
+
+    expect(result.hosts).toHaveLength(1);
+    expect(result.hosts[0].alias).toBe('tilde-host');
+  });
+
+  it('handles Include cycle detection', async () => {
+    const fs = mockFs({
+      [CONFIG]: `Include other.conf\nHost main\n  HostName main.example.com\n`,
+      [join(SSH_DIR, 'other.conf')]: `Include ${CONFIG}\nHost other\n  HostName other.example.com\n`,
+    });
+
+    // Should not hang or throw — cycles are detected
+    const result = await sshListHosts({}, fs, HOME);
+
+    expect(result.hosts.length).toBeGreaterThanOrEqual(2);
+    expect(findHost(result.hosts, 'main')).toBeDefined();
+    expect(findHost(result.hosts, 'other')).toBeDefined();
+  });
+
+  it('returns empty hosts when config file does not exist', async () => {
+    const fs = mockFs({});
+
+    const result = await sshListHosts({}, fs, HOME);
+    expect(result.hosts).toHaveLength(0);
+  });
+
+  it('handles case-insensitive keywords', async () => {
+    const fs = mockFs({
+      [CONFIG]: `
+HOST myserver
+  HOSTNAME myserver.example.com
+  user admin
+  PORT 3022
+`,
+    });
+
+    const result = await sshListHosts({}, fs, HOME);
+
+    expect(result.hosts).toHaveLength(1);
+    const h = result.hosts[0];
+    expect(h.alias).toBe('myserver');
+    expect(h.hostname).toBe('myserver.example.com');
+    expect(h.user).toBe('admin');
+    expect(h.port).toBe(3022);
+  });
+
+  it('handles Keyword=value syntax', async () => {
+    const fs = mockFs({
+      [CONFIG]: `
+Host eq-host
+  HostName=eq.example.com
+  User=equser
+  Port=4422
+`,
+    });
+
+    const result = await sshListHosts({}, fs, HOME);
+
+    expect(result.hosts).toHaveLength(1);
+    const h = result.hosts[0];
+    expect(h.hostname).toBe('eq.example.com');
+    expect(h.user).toBe('equser');
+    expect(h.port).toBe(4422);
+  });
+
+  it('strips inline comments', async () => {
+    const fs = mockFs({
+      [CONFIG]: `
+Host comment-host # this is a comment
+  HostName comment.example.com # also a comment
+  User admin
+`,
+    });
+
+    const result = await sshListHosts({}, fs, HOME);
+
+    expect(result.hosts).toHaveLength(1);
+    const h = result.hosts[0];
+    expect(h.alias).toBe('comment-host');
+    expect(h.hostname).toBe('comment.example.com');
+  });
+
+  it('does not attach Match block directives to prior Host block', async () => {
+    const fs = mockFs({
+      [CONFIG]: `
+Host app
+  HostName app.example.com
+
+Match user deploy
+  Port 2222
+`,
+    });
+
+    const result = await sshListHosts({}, fs, HOME);
+
+    expect(result.hosts).toHaveLength(1);
+    const h = result.hosts[0];
+    expect(h.alias).toBe('app');
+    expect(h.port).toBeUndefined();
+  });
+
+  it('deduplicates aliases keeping first occurrence', async () => {
+    const fs = mockFs({
+      [CONFIG]: `
+Host dupe
+  HostName first.example.com
+
+Host dupe
+  HostName second.example.com
+`,
+    });
+
+    const result = await sshListHosts({}, fs, HOME);
+
+    expect(result.hosts).toHaveLength(1);
+    expect(result.hosts[0].hostname).toBe('first.example.com');
+  });
+
+  it('validates port range (ignores invalid ports)', async () => {
+    const fs = mockFs({
+      [CONFIG]: `
+Host bad-port
+  HostName bad.example.com
+  Port 99999
+
+Host bad-port2
+  HostName bad2.example.com
+  Port abc
+
+Host good-port
+  HostName good.example.com
+  Port 443
+`,
+    });
+
+    const result = await sshListHosts({}, fs, HOME);
+
+    expect(findHost(result.hosts, 'bad-port')!.port).toBeUndefined();
+    expect(findHost(result.hosts, 'bad-port2')!.port).toBeUndefined();
+    expect(findHost(result.hosts, 'good-port')!.port).toBe(443);
+  });
+
+  it('uses first-value-wins for HostName/User/Port within a block', async () => {
+    const fs = mockFs({
+      [CONFIG]: `
+Host multi-val
+  HostName first.example.com
+  HostName second.example.com
+  User firstuser
+  User seconduser
+  Port 22
+  Port 2222
+`,
+    });
+
+    const result = await sshListHosts({}, fs, HOME);
+
+    const h = result.hosts[0];
+    expect(h.hostname).toBe('first.example.com');
+    expect(h.user).toBe('firstuser');
+    expect(h.port).toBe(22);
+  });
+
+  it('sorts results by alias', async () => {
+    const fs = mockFs({
+      [CONFIG]: `
+Host zebra
+  HostName z.example.com
+Host apple
+  HostName a.example.com
+Host mango
+  HostName m.example.com
+`,
+    });
+
+    const result = await sshListHosts({}, fs, HOME);
+
+    expect(result.hosts.map((h) => h.alias)).toEqual(['apple', 'mango', 'zebra']);
+  });
+
+  it('pattern with ? matches single character', async () => {
+    const fs = mockFs({
+      [CONFIG]: `
+Host app1
+  HostName app1.example.com
+Host app2
+  HostName app2.example.com
+Host app10
+  HostName app10.example.com
+`,
+    });
+
+    const result = await sshListHosts({ pattern: 'app?' }, fs, HOME);
+
+    expect(result.hosts).toHaveLength(2);
+    expect(result.hosts.map((h) => h.alias)).toEqual(['app1', 'app2']);
+  });
+
+  it('pattern escapes regex special characters (dots)', async () => {
+    const fs = mockFs({
+      [CONFIG]: `
+Host prod.web
+  HostName prod-web.example.com
+Host prodXweb
+  HostName prodX-web.example.com
+`,
+    });
+
+    const result = await sshListHosts({ pattern: 'prod.web' }, fs, HOME);
+
+    expect(result.hosts).toHaveLength(1);
+    expect(result.hosts[0].alias).toBe('prod.web');
+  });
+
+  it('handles host with no extra directives', async () => {
+    const fs = mockFs({
+      [CONFIG]: `Host bare-host\n`,
+    });
+
+    const result = await sshListHosts({}, fs, HOME);
+
+    expect(result.hosts).toHaveLength(1);
+    const h = result.hosts[0];
+    expect(h.alias).toBe('bare-host');
+    expect(h.hostname).toBeUndefined();
+    expect(h.user).toBeUndefined();
+    expect(h.port).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Replaces #123 with a clean implementation rebased on current main.

## Changes
- Adds `ssh_list_hosts` tool: enumerates Host entries from `~/.ssh/config` including Include directives
- Returns sanitized inventory (alias, hostname, user, port, source_file)
- Excludes sensitive fields (IdentityFile, ProxyJump, ProxyCommand)
- Glob pattern filtering, cycle detection, first-value-wins semantics

## Bug fix (vs #123)
Fixes Windows/Node 22 test failures: `source_file` is now always returned in POSIX tilde form (`~/.ssh/config`) regardless of OS path separator. Root cause: `os.homedir()` returns backslash paths on Windows; normalize both paths to forward slashes before comparing.

Closes #89